### PR TITLE
fix: make table extraction tools portable

### DIFF
--- a/tools/extract_named_spectra.py
+++ b/tools/extract_named_spectra.py
@@ -8,18 +8,18 @@ from `pbrt-v4/src/pbrt/util/spectrum.cpp` and emit a Rust source file
 
 The Rust side feeds these into `PiecewiseLinearSpectrum::from_interleaved`.
 
-Run from anywhere; both source and destination paths are hard-coded
-relative to the devkit layout (matching tools/extract_pmj02_tables.py).
+Run from anywhere in the devkit checkout. The source and destination default
+to paths derived from this script's location and can be overridden with
+`--source` and `--output`.
 """
+import argparse
 import re
 from pathlib import Path
 
-V4_SPECTRUM_CPP = Path(
-    "/mnt/hdd1/src/other/pbrt-r4-devkit/pbrt-v4/src/pbrt/util/spectrum.cpp"
-)
-OUT_RS = Path(
-    "/mnt/hdd1/src/other/pbrt-r4-devkit/pbrt-r4/src/util/spectrum/named_arrays.rs"
-)
+DEVKIT_ROOT = Path(__file__).resolve().parents[2]
+R4_ROOT = DEVKIT_ROOT / "pbrt-r4"
+DEFAULT_V4_SPECTRUM_CPP = DEVKIT_ROOT / "pbrt-v4/src/pbrt/util/spectrum.cpp"
+DEFAULT_OUT_RS = R4_ROOT / "src/util/spectrum/named_arrays.rs"
 
 # Arrays we do NOT want to port: CIE base curves are handled by the
 # regular `CIE_*` constants in r4's spectrum module, and the bare lambda
@@ -135,7 +135,27 @@ def to_rust_array(name: str, values: list[float]) -> str:
 
 
 def main() -> int:
-    text = V4_SPECTRUM_CPP.read_text()
+    parser = argparse.ArgumentParser(
+        description="Extract named spectra from a pbrt-v4 spectrum.cpp file."
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=DEFAULT_V4_SPECTRUM_CPP,
+        help=f"pbrt-v4 spectrum.cpp (default: {DEFAULT_V4_SPECTRUM_CPP})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUT_RS,
+        help=f"generated Rust file (default: {DEFAULT_OUT_RS})",
+    )
+    args = parser.parse_args()
+
+    if not args.source.is_file():
+        parser.error(f"source file does not exist: {args.source}")
+
+    text = args.source.read_text()
     text = re.sub(r"//[^\n]*", "", text)
     text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
 
@@ -201,9 +221,10 @@ def main() -> int:
     lines.append("}")
     lines.append("")
 
-    OUT_RS.write_text("\n".join(lines))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(lines))
 
-    print(f"wrote {OUT_RS}")
+    print(f"wrote {args.output}")
     print(f"  {len(array_items)} arrays, {len(public_to_array)} lookup entries")
     if missing:
         print(f"  skipped (no matching variable in cpp): {missing}")

--- a/tools/extract_pmj02_tables.py
+++ b/tools/extract_pmj02_tables.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """Extract pmj02bnSamples and BlueNoiseTextures from pbrt-v4 C++ source
 to raw little-endian binary files."""
+import argparse
 import re
 import struct
 import sys
 from pathlib import Path
 
-V4_ROOT = Path("/mnt/hdd1/src/other/pbrt-r4-devkit/pbrt-v4/src/pbrt/util")
-OUT_ROOT = Path("/mnt/hdd1/src/other/pbrt-r4-devkit/pbrt-r4/src/samplers/data")
-OUT_ROOT.mkdir(parents=True, exist_ok=True)
+DEVKIT_ROOT = Path(__file__).resolve().parents[2]
+R4_ROOT = DEVKIT_ROOT / "pbrt-r4"
+DEFAULT_V4_ROOT = DEVKIT_ROOT / "pbrt-v4/src/pbrt/util"
+DEFAULT_OUT_ROOT = R4_ROOT / "src/samplers/data"
 
 
 def extract_ints(path: Path) -> list[int]:
@@ -28,8 +30,29 @@ def extract_ints(path: Path) -> list[int]:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Extract PMJ02 and blue-noise tables from pbrt-v4 sources."
+    )
+    parser.add_argument(
+        "--v4-util",
+        type=Path,
+        default=DEFAULT_V4_ROOT,
+        help=f"pbrt-v4 util source directory (default: {DEFAULT_V4_ROOT})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUT_ROOT,
+        help=f"output directory for binary tables (default: {DEFAULT_OUT_ROOT})",
+    )
+    args = parser.parse_args()
+
+    for filename in ("pmj02tables.cpp", "bluenoise.cpp"):
+        if not (args.v4_util / filename).is_file():
+            parser.error(f"source file does not exist: {args.v4_util / filename}")
+
     # --- pmj02bnSamples: 5 * 65536 * 2 = 655360 u32 ---
-    p = V4_ROOT / "pmj02tables.cpp"
+    p = args.v4_util / "pmj02tables.cpp"
     ints = extract_ints(p)
     expect = 5 * 65536 * 2
     # The header also has integers (nPMJ02bnSets=5 etc.) but that's in the
@@ -38,21 +61,22 @@ def main() -> int:
     if len(ints) != expect:
         print(f"  WARN: count mismatch — trailing {len(ints) - expect} ignored")
         ints = ints[:expect]
-    out = OUT_ROOT / "pmj02bn_samples.bin"
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    out = args.output_dir / "pmj02bn_samples.bin"
     with out.open("wb") as f:
         for v in ints:
             f.write(struct.pack("<I", v))
     print(f"  wrote {out} ({out.stat().st_size} bytes)")
 
     # --- BlueNoiseTextures: 48 * 128 * 128 = 786432 u16 ---
-    p = V4_ROOT / "bluenoise.cpp"
+    p = args.v4_util / "bluenoise.cpp"
     ints = extract_ints(p)
     expect = 48 * 128 * 128
     print(f"bluenoise.cpp: parsed {len(ints)} integers, expected {expect}")
     if len(ints) != expect:
         print(f"  WARN: count mismatch — trailing {len(ints) - expect} ignored")
         ints = ints[:expect]
-    out = OUT_ROOT / "bluenoise_textures.bin"
+    out = args.output_dir / "bluenoise_textures.bin"
     with out.open("wb") as f:
         for v in ints:
             f.write(struct.pack("<H", v))


### PR DESCRIPTION
Remove machine-specific absolute paths from the table extraction tools.

Changes:
- Add CLI overrides for pbrt-v4 source and generated output paths.
- Derive default paths from the script location.
- Validate required input files before extraction.

Validation:
- cargo fmt --check
- Python syntax checks
- PMJ and BlueNoise outputs match the existing binaries.