### PR TITLE
release: merge v4.0.1 into develop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbrt-r4"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 build = "build/main.rs"
 default-run = "pbrt-r4"


### PR DESCRIPTION
Merge the v4.0.1 release branch into develop.

- Includes the portable table extraction tool fixes.
- pbrt-r4 v4.0.1 has been published to crates.io.
- The v4.0.1 tag points to the release commit.