### PR TITLE
release: merge v4.0.2 into develop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbrt-r4"
-version = "4.0.1"
+version = "4.0.2"
 edition = "2021"
 build = "build/main.rs"
 default-run = "pbrt-r4"


### PR DESCRIPTION
Merge the v4.0.2 release branch into develop.

- Includes the self-contained tensor BSDF test fixture.
- pbrt-r4 v4.0.2 has been published to crates.io.
- The v4.0.2 tag points to the release commit.