### PR TITLE
feat: add initial plytool CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ bool_assert_comparison = "allow"
 name = "pbrt-r4"
 path = "src/cmd/pbrt.rs"
 
+[[bin]]
+name = "plytool"
+path = "src/cmd/plytool.rs"
+
 # `[profile.release]` left at cargo defaults (opt-level=3, no LTO).
 # We tried `lto = "fat"` + `codegen-units = 1`: small win (~5%) on the
 # BSSRDF-heavy head.pbrt path but slightly regressed (5-10%) simple

--- a/src/cmd/plytool.rs
+++ b/src/cmd/plytool.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter};
 use std::fs::File;
+use std::io::Write;
 use std::path::Path;
 
 use pbrt_r4::util::base::{Float, Normal3f, Point2f, Point3f, Vector3f};
@@ -8,12 +9,6 @@ use pbrt_r4::util::geometry::Bounds3f;
 use pbrt_r4::util::image::{Image, ImageWrapMode};
 use pbrt_r4::util::imageio::read_raw_image_gamma_correct;
 use pbrt_r4::util::mesh::TriQuadMesh;
-
-use ply_rs::ply::{
-    DefaultElement, ElementDef, Encoding, Header, Ply, Property, PropertyAccess, PropertyDef,
-};
-use ply_rs::ply::{PropertyType, ScalarType};
-use ply_rs::writer::Writer;
 
 #[derive(Debug)]
 struct PlyToolError {
@@ -332,79 +327,66 @@ fn write_triangle_ply(
     normals: &[Normal3f],
     uvs: &[Point2f],
 ) -> Result<(), PlyToolError> {
-    let mut header = Header::new();
-    header.encoding = Encoding::BinaryLittleEndian;
-    let mut vertex = ElementDef::new("vertex".to_string());
-    vertex.count = points.len();
-    for name in ["x", "y", "z"] {
-        vertex.properties.insert(
-            name.to_string(),
-            PropertyDef::new(name.to_string(), PropertyType::Scalar(ScalarType::Float)),
-        );
+    if indices.len() % 3 != 0 {
+        return Err(error_message(
+            "triangle index count must be a multiple of three",
+        ));
+    }
+    if (!normals.is_empty() && normals.len() != points.len())
+        || (!uvs.is_empty() && uvs.len() != points.len())
+    {
+        return Err(error_message(
+            "vertex attribute count does not match position count",
+        ));
+    }
+
+    let mut file = File::create(filename).map_err(error)?;
+    writeln!(file, "ply").map_err(error)?;
+    writeln!(file, "format binary_little_endian 1.0").map_err(error)?;
+    writeln!(file, "element vertex {}", points.len()).map_err(error)?;
+    for property in ["x", "y", "z"] {
+        writeln!(file, "property float {property}").map_err(error)?;
     }
     if !normals.is_empty() {
-        for name in ["nx", "ny", "nz"] {
-            vertex.properties.insert(
-                name.to_string(),
-                PropertyDef::new(name.to_string(), PropertyType::Scalar(ScalarType::Float)),
-            );
+        for property in ["nx", "ny", "nz"] {
+            writeln!(file, "property float {property}").map_err(error)?;
         }
     }
     if !uvs.is_empty() {
-        for name in ["u", "v"] {
-            vertex.properties.insert(
-                name.to_string(),
-                PropertyDef::new(name.to_string(), PropertyType::Scalar(ScalarType::Float)),
-            );
+        for property in ["u", "v"] {
+            writeln!(file, "property float {property}").map_err(error)?;
         }
     }
-    header.elements.insert("vertex".to_string(), vertex);
-    let mut face = ElementDef::new("face".to_string());
-    face.count = indices.len() / 3;
-    face.properties.insert(
-        "vertex_indices".to_string(),
-        PropertyDef::new(
-            "vertex_indices".to_string(),
-            PropertyType::List(ScalarType::UChar, ScalarType::Int),
-        ),
-    );
-    header.elements.insert("face".to_string(), face);
+    writeln!(file, "element face {}", indices.len() / 3).map_err(error)?;
+    writeln!(file, "property list uchar int vertex_indices").map_err(error)?;
+    writeln!(file, "end_header").map_err(error)?;
 
-    let mut ply = Ply::<DefaultElement>::new();
-    ply.header = header;
-    let mut vertices = Vec::with_capacity(points.len());
     for index in 0..points.len() {
-        let mut vertex = DefaultElement::new();
-        vertex.set_property("x".to_string(), Property::Float(points[index].x as f32));
-        vertex.set_property("y".to_string(), Property::Float(points[index].y as f32));
-        vertex.set_property("z".to_string(), Property::Float(points[index].z as f32));
+        for value in [points[index].x, points[index].y, points[index].z] {
+            file.write_all(&(value as f32).to_le_bytes())
+                .map_err(error)?;
+        }
         if !normals.is_empty() {
-            vertex.set_property("nx".to_string(), Property::Float(normals[index].x as f32));
-            vertex.set_property("ny".to_string(), Property::Float(normals[index].y as f32));
-            vertex.set_property("nz".to_string(), Property::Float(normals[index].z as f32));
+            for value in [normals[index].x, normals[index].y, normals[index].z] {
+                file.write_all(&(value as f32).to_le_bytes())
+                    .map_err(error)?;
+            }
         }
         if !uvs.is_empty() {
-            vertex.set_property("u".to_string(), Property::Float(uvs[index].x as f32));
-            vertex.set_property("v".to_string(), Property::Float(uvs[index].y as f32));
+            for value in [uvs[index].x, uvs[index].y] {
+                file.write_all(&(value as f32).to_le_bytes())
+                    .map_err(error)?;
+            }
         }
-        vertices.push(vertex);
     }
-    ply.payload.insert("vertex".to_string(), vertices);
-    let mut faces = Vec::with_capacity(indices.len() / 3);
     for triangle in indices.chunks_exact(3) {
-        let mut face = DefaultElement::new();
-        face.set_property(
-            "vertex_indices".to_string(),
-            Property::ListInt(triangle.iter().map(|&index| index as i32).collect()),
-        );
-        faces.push(face);
+        file.write_all(&[3]).map_err(error)?;
+        for &index in triangle {
+            file.write_all(&(index as i32).to_le_bytes())
+                .map_err(error)?;
+        }
     }
-    ply.payload.insert("face".to_string(), faces);
-    let mut file = File::create(filename).map_err(error)?;
-    Writer::new()
-        .write_ply(&mut file, &mut ply)
-        .map(|_| ())
-        .map_err(error)
+    file.flush().map_err(error)
 }
 
 fn read_mesh(path: &str) -> Result<TriQuadMesh, PlyToolError> {

--- a/src/cmd/plytool.rs
+++ b/src/cmd/plytool.rs
@@ -1,0 +1,535 @@
+use std::ffi::OsString;
+use std::fmt::{Display, Formatter};
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::Path;
+
+use pbrt_r4::util::base::{Float, Normal3f, Point2f, Point3f, Vector3f};
+use pbrt_r4::util::geometry::Bounds3f;
+use pbrt_r4::util::image::{Image, ImageWrapMode};
+use pbrt_r4::util::imageio::read_raw_image_gamma_correct;
+use pbrt_r4::util::mesh::TriQuadMesh;
+
+use ply_rs::ply::{
+    DefaultElement, ElementDef, Encoding, Header, Ply, Property, PropertyAccess, PropertyDef,
+};
+use ply_rs::ply::{PropertyType, ScalarType};
+use ply_rs::writer::Writer;
+
+#[derive(Debug)]
+struct PlyToolError {
+    message: String,
+    show_help: bool,
+}
+
+impl PlyToolError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            show_help: false,
+        }
+    }
+
+    fn with_help(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            show_help: true,
+        }
+    }
+
+    fn show_help(&self) -> bool {
+        self.show_help
+    }
+}
+
+impl Display for PlyToolError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for PlyToolError {}
+
+/// Text from `pbrt-v4/src/pbrt/cmd/plytool.cpp::help`.
+fn help_text() -> &'static str {
+    "plytool provides a number of operations on PLY meshes.\n\
+\n\
+usage: plytool <command> [options]\n\
+\n\
+where <command> is:\n\
+\n\
+cat: Print a text representation of the mesh.\n\
+\n\
+displace: Apply displacement mapping to a mesh.\n\
+\n\
+info: Print general information about the mesh.\n\
+\n\
+split: Split the mesh into multiple PLY files.\n\
+\n\
+\"plytool help <command>\" provides detailed information about <command>.\n"
+}
+
+/// Per-command usage corresponding to `plytool.cpp::help(std::vector<std::string>)`.
+fn command_help(command: &str) -> Result<&'static str, PlyToolError> {
+    match command {
+        "cat" => Ok("usage: plytool cat <filename>\n"),
+        "info" => Ok("usage: plytool info <filename...>\n"),
+        "displace" => Ok("usage: plytool displace [options] <filename>\n\n\
+options:\n\
+  --scale <s>       Scale to apply to displacement value in image.\n\
+                    (Default: 1)\n\
+  --uvscale <s>     Scale to apply to uv texture coordinates in image.\n\
+                    (Default: 1)\n\
+  --edge-length <s> Maximum length of an edge in the undisplaced mesh.\n\
+                    (Default: 1)\n\
+  --image <name>    Filename for image used to define displacements.\n\
+  --outfile <name>  Filename name for emitted PLY file.\n"),
+        "split" => Ok("usage: plytool split [options] <filename>\n\n\
+options:\n\
+  --maxfaces <n>    Maximum number of faces in an output PLY file.\n\
+                    (Default: 1000000)\n\
+  --outbase <name>  Base name for emitted PLY files.  Consecutive numbers\n\
+                    and a \".ply\" suffix will be appended to <name>.\n\
+                    (Default: based on <source.ply>.)\n"),
+        _ => Err(PlyToolError::with_help(format!(
+            "{command}: command unknown"
+        ))),
+    }
+}
+
+/// Corresponds to `pbrt-v4/src/pbrt/cmd/plytool.cpp::info`.
+fn info_text(path: &Path) -> Result<String, PlyToolError> {
+    let filename = path
+        .to_str()
+        .ok_or_else(|| PlyToolError::new("PLY path is not valid UTF-8"))?;
+    let mesh =
+        TriQuadMesh::read_ply(filename).map_err(|error| PlyToolError::new(error.to_string()))?;
+
+    let mut points = mesh.p.iter();
+    let first_point = points
+        .next()
+        .ok_or_else(|| PlyToolError::new("PLY file contains no vertex positions"))?;
+    let mut bounds = Bounds3f::from((first_point.x, first_point.y, first_point.z));
+    for point in points {
+        bounds = bounds.union_p(point);
+    }
+
+    let mut output = String::new();
+    output.push_str(&format!("{}:\n", path.display()));
+    output.push_str(&format!("\tTriangles: {}\n", mesh.tri_indices.len() / 3));
+    output.push_str(&format!("\tQuads: {}\n", mesh.quad_indices.len() / 4));
+    output.push_str(&format!("\tVertex positions: {}\n", mesh.p.len()));
+    output.push_str(&format!("\tVertex normals: {}\n", mesh.n.len()));
+    output.push_str(&format!("\tVertex uvs: {}\n", mesh.uv.len()));
+    output.push_str(&format!("\tFace indices: {}\n", mesh.face_indices.len()));
+
+    let mut vertex_used = vec![false; mesh.p.len()];
+    for &index in mesh.tri_indices.iter().chain(mesh.quad_indices.iter()) {
+        let index = index as usize;
+        if index >= vertex_used.len() {
+            return Err(PlyToolError::new(format!(
+                "vertex index {index} is out of bounds for {} vertices",
+                vertex_used.len()
+            )));
+        }
+        vertex_used[index] = true;
+    }
+    for (index, used) in vertex_used.iter().enumerate() {
+        if !used {
+            output.push_str(&format!("Notice: vertex {index} is not used.\n"));
+        }
+    }
+
+    output.push_str(&format!(
+        "\tBounding box: [ {} {} {} ] - [ {} {} {} ]\n",
+        bounds.min.x, bounds.min.y, bounds.min.z, bounds.max.x, bounds.max.y, bounds.max.z
+    ));
+    Ok(output)
+}
+
+fn info(paths: &[OsString]) -> Result<(), PlyToolError> {
+    for path in paths {
+        let path = Path::new(path);
+        print!("{}", info_text(path)?);
+    }
+    Ok(())
+}
+
+fn cat(paths: &[OsString]) -> Result<(), PlyToolError> {
+    let path = single_path(paths, "PLY filename")?;
+    let mesh = read_mesh(&path)?;
+
+    for triangle in mesh.tri_indices.chunks_exact(3) {
+        println!("Triangle: {} {} {}", triangle[0], triangle[1], triangle[2]);
+    }
+    for quad in mesh.quad_indices.chunks_exact(4) {
+        println!("Quad: {} {} {} {}", quad[0], quad[1], quad[2], quad[3]);
+    }
+    for (index, point) in mesh.p.iter().enumerate() {
+        println!("Vertex position {index}: {:?}", point);
+    }
+    for (index, normal) in mesh.n.iter().enumerate() {
+        println!("Vertex normal {index}: {:?}", normal);
+    }
+    for (index, uv) in mesh.uv.iter().enumerate() {
+        println!("Vertex uv {index}: {:?}", uv);
+    }
+    Ok(())
+}
+
+fn displace(args: &[OsString]) -> Result<(), PlyToolError> {
+    let mut scale = 1.0;
+    let mut uv_scale = 1.0;
+    let mut edge_length = 1.0;
+    let mut source = None;
+    let mut image_path = None;
+    let mut output = None;
+    let mut index = 0;
+    while index < args.len() {
+        let argument = args[index].to_string_lossy();
+        match argument.as_ref() {
+            "--scale" => scale = parse_option(&args, &mut index, "scale")?,
+            "--uvscale" => uv_scale = parse_option(&args, &mut index, "uvscale")?,
+            "--edge-length" => edge_length = parse_option(&args, &mut index, "edge-length")?,
+            "--image" => image_path = Some(option_string(&args, &mut index, "image")?),
+            "--outfile" => output = Some(option_string(&args, &mut index, "outfile")?),
+            value if value.starts_with('-') => {
+                return Err(usage_error(format!("unexpected argument \"{value}\"")));
+            }
+            _ if source.is_none() => source = Some(path_string(&args[index])?),
+            _ => return Err(usage_error(format!("unexpected argument \"{argument}\""))),
+        }
+        index += 1;
+    }
+
+    let source = required_path(source, "source PLY filename")?;
+    let image_path = required_path(image_path, "image displacement map")?;
+    let output = required_path(output, "output PLY filename")?;
+    let mesh = read_mesh(&source)?;
+    let raw = read_raw_image_gamma_correct(&image_path, false).map_err(error)?;
+    let image = Image::from_channels(raw.resolution, raw.channel_names(), raw.data_f32());
+    let displaced = mesh
+        .displace(
+            |p0, p1| (p0 - p1).length(),
+            edge_length,
+            |point, normal, uv| {
+                let uv = Point2f::new(uv_scale * uv.x, 1.0 - uv_scale * uv.y);
+                let value: Float = (0..image.n_channels())
+                    .map(|channel| {
+                        image.bilerp_channel_with_wrap(
+                            &uv,
+                            channel,
+                            ImageWrapMode::Repeat,
+                            ImageWrapMode::Repeat,
+                        )
+                    })
+                    .sum::<Float>()
+                    / image.n_channels() as Float;
+                point + Vector3f::new(normal.x, normal.y, normal.z) * (scale * value)
+            },
+        )
+        .map_err(error)?;
+    write_triangle_ply(
+        &output,
+        &displaced.tri_indices,
+        &displaced.p,
+        &displaced.n,
+        &displaced.uv,
+    )
+}
+
+fn split(args: &[OsString]) -> Result<(), PlyToolError> {
+    let mut max_faces = 1_000_000usize;
+    let mut source = None;
+    let mut outbase = None;
+    let mut index = 0;
+    while index < args.len() {
+        let argument = args[index].to_string_lossy();
+        match argument.as_ref() {
+            "--maxfaces" => {
+                max_faces = parse_option_usize(&args, &mut index, "maxfaces")?;
+                if max_faces == 0 {
+                    return Err(usage_error("--maxfaces must be greater than zero"));
+                }
+            }
+            "--outbase" => outbase = Some(option_string(&args, &mut index, "outbase")?),
+            value if value.starts_with('-') => {
+                return Err(usage_error(format!("unexpected argument \"{value}\"")));
+            }
+            _ if source.is_none() => source = Some(path_string(&args[index])?),
+            _ => return Err(usage_error(format!("unexpected argument \"{argument}\""))),
+        }
+        index += 1;
+    }
+
+    let source = required_path(source, "source PLY filename")?;
+    let mesh = read_mesh(&source)?;
+    if !mesh.quad_indices.is_empty() {
+        return Err(error_message(format!(
+            "{source}: sorry, mesh has quad faces. plytool currently only supports triangle meshes."
+        )));
+    }
+    if !mesh.face_indices.is_empty() {
+        return Err(error_message(format!(
+            "{source}: sorry, mesh has faceIndices, which are not currently supported by plytool."
+        )));
+    }
+
+    let face_count = mesh.tri_indices.len() / 3;
+    if face_count <= max_faces {
+        eprintln!("{source}: mesh has {face_count} faces and so has not been split up.");
+        return Ok(());
+    }
+
+    let output_base = outbase.unwrap_or_else(|| remove_extension(&source));
+    let mesh_count = face_count.div_ceil(max_faces);
+    eprintln!("{source}: mesh has {face_count} faces and will be split into {mesh_count} meshes.");
+    let faces_per_mesh = face_count / mesh_count;
+    for mesh_index in 0..mesh_count {
+        let first_face = mesh_index * faces_per_mesh;
+        let last_face = if mesh_index == mesh_count - 1 {
+            face_count
+        } else {
+            (mesh_index + 1) * faces_per_mesh
+        };
+        let (indices, points, normals, uvs) = remap_triangle_range(&mesh, first_face, last_face);
+        let filename = format!("{output_base}-{mesh_index:03}.ply");
+        write_triangle_ply(&filename, &indices, &points, &normals, &uvs)?;
+    }
+    Ok(())
+}
+
+fn remap_triangle_range(
+    mesh: &TriQuadMesh,
+    first_face: usize,
+    last_face: usize,
+) -> (Vec<u32>, Vec<Point3f>, Vec<Normal3f>, Vec<Point2f>) {
+    let mut remap = std::collections::HashMap::new();
+    let mut indices = Vec::new();
+    let mut points = Vec::new();
+    let mut normals = Vec::new();
+    let mut uvs = Vec::new();
+    for &old_index in &mesh.tri_indices[3 * first_face..3 * last_face] {
+        let new_index = if let Some(&new_index) = remap.get(&old_index) {
+            new_index
+        } else {
+            let new_index = points.len() as u32;
+            remap.insert(old_index, new_index);
+            points.push(mesh.p[old_index as usize]);
+            if !mesh.n.is_empty() {
+                normals.push(mesh.n[old_index as usize]);
+            }
+            if !mesh.uv.is_empty() {
+                uvs.push(mesh.uv[old_index as usize]);
+            }
+            new_index
+        };
+        indices.push(new_index);
+    }
+    (indices, points, normals, uvs)
+}
+
+fn write_triangle_ply(
+    filename: &str,
+    indices: &[u32],
+    points: &[Point3f],
+    normals: &[Normal3f],
+    uvs: &[Point2f],
+) -> Result<(), PlyToolError> {
+    let mut header = Header::new();
+    header.encoding = Encoding::BinaryLittleEndian;
+    let mut vertex = ElementDef::new("vertex".to_string());
+    vertex.count = points.len();
+    for name in ["x", "y", "z"] {
+        vertex.properties.insert(
+            name.to_string(),
+            PropertyDef::new(name.to_string(), PropertyType::Scalar(ScalarType::Float)),
+        );
+    }
+    if !normals.is_empty() {
+        for name in ["nx", "ny", "nz"] {
+            vertex.properties.insert(
+                name.to_string(),
+                PropertyDef::new(name.to_string(), PropertyType::Scalar(ScalarType::Float)),
+            );
+        }
+    }
+    if !uvs.is_empty() {
+        for name in ["u", "v"] {
+            vertex.properties.insert(
+                name.to_string(),
+                PropertyDef::new(name.to_string(), PropertyType::Scalar(ScalarType::Float)),
+            );
+        }
+    }
+    header.elements.insert("vertex".to_string(), vertex);
+    let mut face = ElementDef::new("face".to_string());
+    face.count = indices.len() / 3;
+    face.properties.insert(
+        "vertex_indices".to_string(),
+        PropertyDef::new(
+            "vertex_indices".to_string(),
+            PropertyType::List(ScalarType::UChar, ScalarType::Int),
+        ),
+    );
+    header.elements.insert("face".to_string(), face);
+
+    let mut ply = Ply::<DefaultElement>::new();
+    ply.header = header;
+    let mut vertices = Vec::with_capacity(points.len());
+    for index in 0..points.len() {
+        let mut vertex = DefaultElement::new();
+        vertex.set_property("x".to_string(), Property::Float(points[index].x as f32));
+        vertex.set_property("y".to_string(), Property::Float(points[index].y as f32));
+        vertex.set_property("z".to_string(), Property::Float(points[index].z as f32));
+        if !normals.is_empty() {
+            vertex.set_property("nx".to_string(), Property::Float(normals[index].x as f32));
+            vertex.set_property("ny".to_string(), Property::Float(normals[index].y as f32));
+            vertex.set_property("nz".to_string(), Property::Float(normals[index].z as f32));
+        }
+        if !uvs.is_empty() {
+            vertex.set_property("u".to_string(), Property::Float(uvs[index].x as f32));
+            vertex.set_property("v".to_string(), Property::Float(uvs[index].y as f32));
+        }
+        vertices.push(vertex);
+    }
+    ply.payload.insert("vertex".to_string(), vertices);
+    let mut faces = Vec::with_capacity(indices.len() / 3);
+    for triangle in indices.chunks_exact(3) {
+        let mut face = DefaultElement::new();
+        face.set_property(
+            "vertex_indices".to_string(),
+            Property::ListInt(triangle.iter().map(|&index| index as i32).collect()),
+        );
+        faces.push(face);
+    }
+    ply.payload.insert("face".to_string(), faces);
+    let file = File::create(filename).map_err(error)?;
+    Writer::new()
+        .write_ply(&mut BufWriter::new(file), &mut ply)
+        .map(|_| ())
+        .map_err(error)
+}
+
+fn read_mesh(path: &str) -> Result<TriQuadMesh, PlyToolError> {
+    TriQuadMesh::read_ply(path).map_err(error)
+}
+
+fn single_path(args: &[OsString], label: &str) -> Result<String, PlyToolError> {
+    if args.len() != 1 {
+        return Err(usage_error(format!("must specify exactly one {label}")));
+    }
+    path_string(&args[0])
+}
+
+fn required_path(value: Option<String>, label: &str) -> Result<String, PlyToolError> {
+    value.ok_or_else(|| usage_error(format!("must specify {label}")))
+}
+
+fn path_string(value: &OsString) -> Result<String, PlyToolError> {
+    value
+        .to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| error_message("path is not valid UTF-8"))
+}
+
+fn option_string(args: &[OsString], index: &mut usize, name: &str) -> Result<String, PlyToolError> {
+    *index += 1;
+    let value = args
+        .get(*index)
+        .ok_or_else(|| usage_error(format!("missing value for --{name}")))?;
+    path_string(value)
+}
+
+fn parse_option(args: &[OsString], index: &mut usize, name: &str) -> Result<Float, PlyToolError> {
+    let value = option_string(args, index, name)?;
+    value
+        .parse::<Float>()
+        .map_err(|_| usage_error(format!("invalid value for --{name}: {value}")))
+}
+
+fn parse_option_usize(
+    args: &[OsString],
+    index: &mut usize,
+    name: &str,
+) -> Result<usize, PlyToolError> {
+    let value = option_string(args, index, name)?;
+    value
+        .parse::<usize>()
+        .map_err(|_| usage_error(format!("invalid value for --{name}: {value}")))
+}
+
+fn remove_extension(path: &str) -> String {
+    Path::new(path)
+        .with_extension("")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn error(value: impl Display) -> PlyToolError {
+    error_message(value.to_string())
+}
+
+fn error_message(message: impl Into<String>) -> PlyToolError {
+    PlyToolError::new(message)
+}
+
+fn usage_error(message: impl Into<String>) -> PlyToolError {
+    PlyToolError::with_help(message)
+}
+
+fn run<I, T>(args: I) -> Result<(), PlyToolError>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString>,
+{
+    let mut args = args.into_iter().map(Into::into);
+    let _program = args.next();
+    let Some(command) = args.next() else {
+        print!("{}", help_text());
+        return Ok(());
+    };
+    let command = command
+        .into_string()
+        .map_err(|_| PlyToolError::new("command is not valid UTF-8"))?;
+    let arguments: Vec<OsString> = args.collect();
+
+    match command.as_str() {
+        "help" => {
+            if arguments.is_empty() {
+                print!("{}", help_text());
+            } else {
+                for command in arguments {
+                    let command = command
+                        .into_string()
+                        .map_err(|_| PlyToolError::new("command is not valid UTF-8"))?;
+                    print!("{}", command_help(&command)?);
+                }
+            }
+            Ok(())
+        }
+        "info" => {
+            info(&arguments)?;
+            Ok(())
+        }
+        "cat" => cat(&arguments),
+        "displace" => displace(&arguments),
+        "split" => split(&arguments),
+        _ => Err(PlyToolError::with_help(format!(
+            "{command}: command unknown"
+        ))),
+    }
+}
+
+fn main() {
+    match run(std::env::args_os()) {
+        Ok(()) => std::process::exit(0),
+        Err(error) => {
+            eprintln!("plytool: {error}");
+            if error.show_help() {
+                print!("{}", help_text());
+            }
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/cmd/plytool.rs
+++ b/src/cmd/plytool.rs
@@ -327,6 +327,10 @@ fn write_triangle_ply(
     normals: &[Normal3f],
     uvs: &[Point2f],
 ) -> Result<(), PlyToolError> {
+    // Work around ply-rs 0.1.3 writing the element count instead of the
+    // actual list length for binary list properties. pbrt-v4 emits binary
+    // little-endian PLY files, so keep that format and write the payload
+    // directly until the dependency can provide a compatible fix.
     if indices.len() % 3 != 0 {
         return Err(error_message(
             "triangle index count must be a multiple of three",

--- a/src/cmd/plytool.rs
+++ b/src/cmd/plytool.rs
@@ -140,10 +140,7 @@ fn info_text(path: &Path) -> Result<String, PlyToolError> {
         }
     }
 
-    output.push_str(&format!(
-        "\tBounding box: [ {} {} {} ] - [ {} {} {} ]\n",
-        bounds.min.x, bounds.min.y, bounds.min.z, bounds.max.x, bounds.max.y, bounds.max.z
-    ));
+    output.push_str(&format!("\tBounding box: {}\n", format_bounds(&bounds)));
     Ok(output)
 }
 
@@ -166,13 +163,13 @@ fn cat(paths: &[OsString]) -> Result<(), PlyToolError> {
         println!("Quad: {} {} {} {}", quad[0], quad[1], quad[2], quad[3]);
     }
     for (index, point) in mesh.p.iter().enumerate() {
-        println!("Vertex position {index}: {:?}", point);
+        println!("Vertex position {index}: {}", format_point3(point));
     }
     for (index, normal) in mesh.n.iter().enumerate() {
-        println!("Vertex normal {index}: {:?}", normal);
+        println!("Vertex normal {index}: {}", format_point3(normal));
     }
     for (index, uv) in mesh.uv.iter().enumerate() {
-        println!("Vertex uv {index}: {:?}", uv);
+        println!("Vertex uv {index}: {}", format_point2(uv));
     }
     Ok(())
 }
@@ -464,6 +461,23 @@ fn remove_extension(path: &str) -> String {
         .with_extension("")
         .to_string_lossy()
         .into_owned()
+}
+
+// Matches pbrt-v4's Vector2/Vector3 and Bounds3 ToString() formatting.
+fn format_point2(point: &Point2f) -> String {
+    format!("[ {:.6}, {:.6} ]", point.x, point.y)
+}
+
+fn format_point3(point: &Point3f) -> String {
+    format!("[ {:.6}, {:.6}, {:.6} ]", point.x, point.y, point.z)
+}
+
+fn format_bounds(bounds: &Bounds3f) -> String {
+    format!(
+        "[ {} - {} ]",
+        format_point3(&bounds.min),
+        format_point3(&bounds.max)
+    )
 }
 
 fn error(value: impl Display) -> PlyToolError {

--- a/src/cmd/plytool.rs
+++ b/src/cmd/plytool.rs
@@ -1,7 +1,6 @@
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter};
 use std::fs::File;
-use std::io::BufWriter;
 use std::path::Path;
 
 use pbrt_r4::util::base::{Float, Normal3f, Point2f, Point3f, Vector3f};
@@ -403,7 +402,7 @@ fn write_triangle_ply(
     ply.payload.insert("face".to_string(), faces);
     let file = File::create(filename).map_err(error)?;
     Writer::new()
-        .write_ply(&mut BufWriter::new(file), &mut ply)
+        .write_ply(&mut file, &mut ply)
         .map(|_| ())
         .map_err(error)
 }

--- a/src/cmd/plytool.rs
+++ b/src/cmd/plytool.rs
@@ -400,7 +400,7 @@ fn write_triangle_ply(
         faces.push(face);
     }
     ply.payload.insert("face".to_string(), faces);
-    let file = File::create(filename).map_err(error)?;
+    let mut file = File::create(filename).map_err(error)?;
     Writer::new()
         .write_ply(&mut file, &mut ply)
         .map(|_| ())

--- a/tests/plytool.rs
+++ b/tests/plytool.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 use std::process::Command;
 
+use pbrt_r4::util::mesh::TriQuadMesh;
 use tempfile::{NamedTempFile, TempDir};
 
 #[test]
@@ -84,6 +85,19 @@ fn cat_prints_mesh_elements() {
 }
 
 #[test]
+fn cat_prints_uvs_in_v4_format() {
+    let file = source_ply_with_uvs();
+    let output = Command::new(env!("CARGO_BIN_EXE_plytool"))
+        .args(["cat", file.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Vertex uv 0: [ 0.000000, 0.000000 ]"));
+    assert!(stdout.contains("Vertex uv 1: [ 1.000000, 0.000000 ]"));
+}
+
+#[test]
 fn split_writes_remapped_triangle_files() {
     let file = source_ply_with_two_triangles();
     let directory = TempDir::new().unwrap();
@@ -100,8 +114,14 @@ fn split_writes_remapped_triangle_files() {
         .output()
         .unwrap();
     assert!(output.status.success());
-    assert!(directory.path().join("part-000.ply").exists());
-    assert!(directory.path().join("part-001.ply").exists());
+    let first =
+        TriQuadMesh::read_ply(directory.path().join("part-000.ply").to_str().unwrap()).unwrap();
+    let second =
+        TriQuadMesh::read_ply(directory.path().join("part-001.ply").to_str().unwrap()).unwrap();
+    assert_eq!(first.p.len(), 3);
+    assert_eq!(first.tri_indices, vec![0, 1, 2]);
+    assert_eq!(second.p.len(), 3);
+    assert_eq!(second.tri_indices, vec![0, 1, 2]);
 }
 
 #[test]
@@ -110,7 +130,7 @@ fn displace_reads_image_and_writes_ply() {
     let directory = TempDir::new().unwrap();
     let image_path = directory.path().join("displacement.png");
     let output_path = directory.path().join("displaced.ply");
-    let image = image::GrayImage::from_pixel(1, 1, image::Luma([128]));
+    let image = image::GrayImage::from_pixel(1, 1, image::Luma([255]));
     image.save(&image_path).unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_plytool"))
@@ -118,6 +138,8 @@ fn displace_reads_image_and_writes_ply() {
             "displace",
             "--edge-length",
             "10",
+            "--scale",
+            "2",
             "--image",
             image_path.to_str().unwrap(),
             "--outfile",
@@ -127,7 +149,25 @@ fn displace_reads_image_and_writes_ply() {
         .output()
         .unwrap();
     assert!(output.status.success());
-    assert!(output_path.exists());
+    let displaced = TriQuadMesh::read_ply(output_path.to_str().unwrap()).unwrap();
+    assert_eq!(displaced.p.len(), 3);
+    assert!((displaced.p[0].z - 2.0).abs() < 1e-6);
+    assert!((displaced.p[1].z - 2.0).abs() < 1e-6);
+    assert!((displaced.p[2].z - 2.0).abs() < 1e-6);
+    assert_eq!(displaced.uv, source_ply_uvs());
+}
+
+#[test]
+fn split_rejects_quads_and_face_indices() {
+    for contents in [quad_ply(), face_indices_ply()] {
+        let file = source_ply_with_contents(contents);
+        let output = Command::new(env!("CARGO_BIN_EXE_plytool"))
+            .args(["split", file.path().to_str().unwrap()])
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        assert!(!output.stderr.is_empty());
+    }
 }
 
 fn source_ply() -> NamedTempFile {
@@ -146,6 +186,22 @@ fn source_ply_with_uvs() -> NamedTempFile {
     source_ply_with_contents(
         "ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\nproperty float y\nproperty float z\nproperty float u\nproperty float v\nelement face 1\nproperty list uchar int vertex_indices\nend_header\n0 0 0 0 0\n1 0 0 1 0\n0 1 0 0 1\n3 0 1 2\n",
     )
+}
+
+fn source_ply_uvs() -> Vec<pbrt_r4::util::base::Point2f> {
+    vec![
+        pbrt_r4::util::base::Point2f::new(0.0, 0.0),
+        pbrt_r4::util::base::Point2f::new(1.0, 0.0),
+        pbrt_r4::util::base::Point2f::new(0.0, 1.0),
+    ]
+}
+
+fn quad_ply() -> &'static str {
+    "ply\nformat ascii 1.0\nelement vertex 4\nproperty float x\nproperty float y\nproperty float z\nelement face 1\nproperty list uchar int vertex_indices\nend_header\n0 0 0\n1 0 0\n1 1 0\n0 1 0\n4 0 1 2 3\n"
+}
+
+fn face_indices_ply() -> &'static str {
+    "ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\nproperty float y\nproperty float z\nelement face 1\nproperty list uchar int vertex_indices\nproperty int face_indices\nend_header\n0 0 0\n1 0 0\n0 1 0\n3 0 1 2 7\n"
 }
 
 fn source_ply_with_contents(contents: &str) -> NamedTempFile {

--- a/tests/plytool.rs
+++ b/tests/plytool.rs
@@ -20,7 +20,9 @@ fn reports_mesh_counts_and_bounds() {
     assert!(output.contains("Vertex uvs: 0"));
     assert!(output.contains("Face indices: 0"));
     assert!(output.contains("Notice: vertex 3 is not used."));
-    assert!(output.contains("Bounding box: [ 0 0 0 ] - [ 9 9 9 ]"));
+    assert!(output.contains(
+        "Bounding box: [ [ 0.000000, 0.000000, 0.000000 ] - [ 9.000000, 9.000000, 9.000000 ] ]"
+    ));
 }
 
 #[test]
@@ -33,7 +35,9 @@ fn reports_bounds_for_negative_coordinates() {
     .unwrap();
 
     let output = run_info(file.path());
-    assert!(output.contains("Bounding box: [ -3 -6 -5 ] - [ -1 -2 -3 ]"));
+    assert!(output.contains(
+        "Bounding box: [ [ -3.000000, -6.000000, -5.000000 ] - [ -1.000000, -2.000000, -3.000000 ] ]"
+    ));
 }
 
 fn run_info(path: &std::path::Path) -> String {
@@ -76,7 +80,7 @@ fn cat_prints_mesh_elements() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("Triangle: 0 1 2"));
-    assert!(stdout.contains("Vertex position 0:"));
+    assert!(stdout.contains("Vertex position 0: [ 0.000000, 0.000000, 0.000000 ]"));
 }
 
 #[test]

--- a/tests/plytool.rs
+++ b/tests/plytool.rs
@@ -1,0 +1,151 @@
+use std::io::Write;
+use std::process::Command;
+
+use tempfile::{NamedTempFile, TempDir};
+
+#[test]
+fn reports_mesh_counts_and_bounds() {
+    let mut file = NamedTempFile::with_suffix(".ply").unwrap();
+    writeln!(
+        file,
+        "ply\nformat ascii 1.0\nelement vertex 4\nproperty float x\nproperty float y\nproperty float z\nelement face 1\nproperty list uchar int vertex_indices\nend_header\n0 0 0\n1 0 0\n0 1 0\n9 9 9\n3 0 1 2"
+    )
+    .unwrap();
+
+    let output = run_info(file.path());
+    assert!(output.contains("Triangles: 1"));
+    assert!(output.contains("Quads: 0"));
+    assert!(output.contains("Vertex positions: 4"));
+    assert!(output.contains("Vertex normals: 0"));
+    assert!(output.contains("Vertex uvs: 0"));
+    assert!(output.contains("Face indices: 0"));
+    assert!(output.contains("Notice: vertex 3 is not used."));
+    assert!(output.contains("Bounding box: [ 0 0 0 ] - [ 9 9 9 ]"));
+}
+
+#[test]
+fn reports_bounds_for_negative_coordinates() {
+    let mut file = NamedTempFile::with_suffix(".ply").unwrap();
+    writeln!(
+        file,
+        "ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\nproperty float y\nproperty float z\nelement face 1\nproperty list uchar int vertex_indices\nend_header\n-3 -4 -5\n-1 -2 -3\n-2 -6 -4\n3 0 1 2"
+    )
+    .unwrap();
+
+    let output = run_info(file.path());
+    assert!(output.contains("Bounding box: [ -3 -6 -5 ] - [ -1 -2 -3 ]"));
+}
+
+fn run_info(path: &std::path::Path) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_plytool"))
+        .arg("info")
+        .arg(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "plytool info failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn binary_matches_cli_error_and_empty_info_behavior() {
+    let binary = env!("CARGO_BIN_EXE_plytool");
+
+    let empty_info = Command::new(binary).arg("info").output().unwrap();
+    assert!(empty_info.status.success());
+    assert!(empty_info.stdout.is_empty());
+
+    let unknown = Command::new(binary).arg("unknown").output().unwrap();
+    assert!(!unknown.status.success());
+    assert!(String::from_utf8_lossy(&unknown.stderr).contains("unknown: command unknown"));
+    assert!(String::from_utf8_lossy(&unknown.stdout).contains("usage: plytool <command>"));
+}
+
+#[test]
+fn cat_prints_mesh_elements() {
+    let file = source_ply();
+    let output = Command::new(env!("CARGO_BIN_EXE_plytool"))
+        .args(["cat", file.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Triangle: 0 1 2"));
+    assert!(stdout.contains("Vertex position 0:"));
+}
+
+#[test]
+fn split_writes_remapped_triangle_files() {
+    let file = source_ply_with_two_triangles();
+    let directory = TempDir::new().unwrap();
+    let outbase = directory.path().join("part");
+    let output = Command::new(env!("CARGO_BIN_EXE_plytool"))
+        .args([
+            "split",
+            "--maxfaces",
+            "1",
+            "--outbase",
+            outbase.to_str().unwrap(),
+            file.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(directory.path().join("part-000.ply").exists());
+    assert!(directory.path().join("part-001.ply").exists());
+}
+
+#[test]
+fn displace_reads_image_and_writes_ply() {
+    let file = source_ply_with_uvs();
+    let directory = TempDir::new().unwrap();
+    let image_path = directory.path().join("displacement.png");
+    let output_path = directory.path().join("displaced.ply");
+    let image = image::GrayImage::from_pixel(1, 1, image::Luma([128]));
+    image.save(&image_path).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_plytool"))
+        .args([
+            "displace",
+            "--edge-length",
+            "10",
+            "--image",
+            image_path.to_str().unwrap(),
+            "--outfile",
+            output_path.to_str().unwrap(),
+            file.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(output_path.exists());
+}
+
+fn source_ply() -> NamedTempFile {
+    source_ply_with_contents(
+        "ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\nproperty float y\nproperty float z\nelement face 1\nproperty list uchar int vertex_indices\nend_header\n0 0 0\n1 0 0\n0 1 0\n3 0 1 2\n",
+    )
+}
+
+fn source_ply_with_two_triangles() -> NamedTempFile {
+    source_ply_with_contents(
+        "ply\nformat ascii 1.0\nelement vertex 4\nproperty float x\nproperty float y\nproperty float z\nelement face 2\nproperty list uchar int vertex_indices\nend_header\n0 0 0\n1 0 0\n0 1 0\n1 1 0\n3 0 1 2\n3 1 3 2\n",
+    )
+}
+
+fn source_ply_with_uvs() -> NamedTempFile {
+    source_ply_with_contents(
+        "ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\nproperty float y\nproperty float z\nproperty float u\nproperty float v\nelement face 1\nproperty list uchar int vertex_indices\nend_header\n0 0 0 0 0\n1 0 0 1 0\n0 1 0 0 1\n3 0 1 2\n",
+    )
+}
+
+fn source_ply_with_contents(contents: &str) -> NamedTempFile {
+    let mut file = NamedTempFile::with_suffix(".ply").unwrap();
+    file.write_all(contents.as_bytes()).unwrap();
+    file
+}


### PR DESCRIPTION
## Summary

- port the pbrt-v4 `plytool` commands:
  - `cat`
  - `info`
  - `displace`
  - `split`
- keep the v4 directory correspondence by using `src/cmd/plytool.rs` directly as the Cargo bin target
- reuse the existing r4 PLY loader, mesh refinement/displacement, image evaluation, and mesh data types
- match v4 behavior for command help, empty `info` input, error exit status, stdout/stderr usage, bounds reporting, displacement sampling, and triangle splitting
- add process-level integration tests under `tests/plytool.rs` using `CARGO_BIN_EXE_plytool`
- format `cat` and `info` vector/bounds output to match pbrt-v4

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test plytool` was attempted; the test binary requires compiling the full `pbrt-r4` library and the local build did not reach test execution within the available wait

The remaining test work is focused on asserting the generated PLY contents and numeric displacement results.

Base branch: `develop`