### PR TITLE
fix(build): avoid regenerating spectrum tables

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -4,6 +4,10 @@ mod spectrum;
 mod utils;
 
 fn main() {
+    // The build script is split across modules under `build/`. Register the
+    // directory at the entry point so Cargo notices changes to those modules
+    // before it can reuse stale rerun-if-changed output.
+    println!("cargo:rerun-if-changed=build");
     spectrum::build();
     sensor::build();
     mipmap::build();

--- a/build/sensor/build_pixel_sensor.rs
+++ b/build/sensor/build_pixel_sensor.rs
@@ -139,9 +139,18 @@ pub fn build_core(path: &str) {
 }
 
 pub fn build() {
-    println!(
-        "cargo:rerun-if-changed=build/sensor/sensor_data.rs;build/sensor/swatch_data.rs;build/sensor/cie_s_data.rs;build/sensor/illuminant.rs;build/sensor/math.rs;build/sensor/build_pixel_sensor.rs;build/spectrum/cie_data.rs;build/spectrum/spectrum_config.rs"
-    );
+    for path in [
+        "build/sensor/sensor_data.rs",
+        "build/sensor/swatch_data.rs",
+        "build/sensor/cie_s_data.rs",
+        "build/sensor/illuminant.rs",
+        "build/sensor/math.rs",
+        "build/sensor/build_pixel_sensor.rs",
+        "build/spectrum/cie_data.rs",
+        "build/spectrum/spectrum_config.rs",
+    ] {
+        println!("cargo:rerun-if-changed={path}");
+    }
     let target = "pixel_sensor_data.rs";
     let out_dir = env::var("OUT_DIR").unwrap();
     let path = Path::new(&out_dir).join(target);

--- a/build/spectrum/build_cie.rs
+++ b/build/spectrum/build_cie.rs
@@ -35,7 +35,8 @@ pub fn build_core(path: &str) {
 }
 
 pub fn build() {
-    println!("cargo:rerun-if-changed=build/spectrum/cie_data.rs;build/spectrum/build_cie.rs");
+    println!("cargo:rerun-if-changed=build/spectrum/cie_data.rs");
+    println!("cargo:rerun-if-changed=build/spectrum/build_cie.rs");
     let depends = ["build/spectrum/cie_data.rs", "build/spectrum/build_cie.rs"];
     let target = "spectrum_data_cie.rs";
     let out_dir = env::var("OUT_DIR").unwrap();

--- a/build/spectrum/build_rgb_refl.rs
+++ b/build/spectrum/build_rgb_refl.rs
@@ -109,9 +109,15 @@ pub fn build_core(path: &str) {
 }
 
 pub fn build() {
-    println!(
-        "cargo:rerun-if-changed=build/spectrum/rgb_data.rs;build/spectrum/build_rgb_refl.rs;build/spectrum/utils.rs;build/spectrum/config.rs;build/spectrum/spectrum_config.rs"
-    );
+    for path in [
+        "build/spectrum/rgb_data.rs",
+        "build/spectrum/build_rgb_refl.rs",
+        "build/spectrum/utils.rs",
+        "build/spectrum/config.rs",
+        "build/spectrum/spectrum_config.rs",
+    ] {
+        println!("cargo:rerun-if-changed={path}");
+    }
     let depends = [
         "build/spectrum/rgb_data.rs",
         "build/spectrum/build_rgb_refl.rs",

--- a/build/spectrum/build_rgb_to_spectrum.rs
+++ b/build/spectrum/build_rgb_to_spectrum.rs
@@ -23,6 +23,15 @@ pub fn build() {
         ("dci_p3", Gamut::DciP3),
         ("rec2020", Gamut::Rec2020),
     ];
+    let expected_bytes =
+        (RESOLUTION + 3 * RESOLUTION * RESOLUTION * RESOLUTION * 3) * std::mem::size_of::<f32>();
+    if specifications.iter().all(|(name, _)| {
+        fs::metadata(Path::new(&out_dir).join(format!("rgb_to_spectrum_{name}.bin")))
+            .map(|metadata| metadata.len() as usize == expected_bytes)
+            .unwrap_or(false)
+    }) {
+        return;
+    }
 
     let generated = std::thread::scope(|scope| {
         specifications
@@ -48,8 +57,6 @@ pub fn build() {
         let dst = Path::new(&out_dir).join(format!("rgb_to_spectrum_{}.bin", name));
         let tmp = dst.with_extension("bin.tmp");
         rgb2spec_opt::write_table(&tmp, &table);
-        let expected_bytes = (RESOLUTION + 3 * RESOLUTION * RESOLUTION * RESOLUTION * 3)
-            * std::mem::size_of::<f32>();
         let actual_bytes = fs::metadata(&tmp)
             .unwrap_or_else(|error| panic!("rgb2spec_opt: inspect {:?}: {}", tmp, error))
             .len() as usize;

--- a/build/spectrum/build_xyz.rs
+++ b/build/spectrum/build_xyz.rs
@@ -43,9 +43,15 @@ pub fn build_core(path: &str) {
 }
 
 pub fn build() {
-    println!(
-        "cargo:rerun-if-changed=build/spectrum/cie_data.rs;build/spectrum/build_xyz.rs;build/spectrum/utils.rs;build/spectrum/config.rs;build/spectrum/spectrum_config.rs"
-    );
+    for path in [
+        "build/spectrum/cie_data.rs",
+        "build/spectrum/build_xyz.rs",
+        "build/spectrum/utils.rs",
+        "build/spectrum/config.rs",
+        "build/spectrum/spectrum_config.rs",
+    ] {
+        println!("cargo:rerun-if-changed={path}");
+    }
     let depends = [
         "build/spectrum/cie_data.rs",
         "build/spectrum/build_xyz.rs",


### PR DESCRIPTION
## Summary

- fix malformed `cargo:rerun-if-changed` directives that used semicolon-separated paths
- register the `build/` directory at the build-script entry point so module changes are tracked reliably
- skip RGB-to-spectrum `.bin` regeneration when all existing tables have the expected size

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check --bin plytool -j 16`
- repeated `cargo check --bin plytool -j 16 -vv`: `Fresh pbrt-r4`, spectrum `.bin` mtime unchanged
- `cargo test --test plytool -j 16`: 8 passed, 0 failed
