### PR TITLE
feat(cli): add nanovdb2pbrt converter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,10 @@ path = "src/cmd/plytool.rs"
 name = "imgtool"
 path = "src/cmd/imgtool/mod.rs"
 
+[[bin]]
+name = "nanovdb2pbrt"
+path = "src/cmd/nanovdb2pbrt.rs"
+
 # `[profile.release]` left at cargo defaults (opt-level=3, no LTO).
 # We tried `lto = "fat"` + `codegen-units = 1`: small win (~5%) on the
 # BSSRDF-heavy head.pbrt path but slightly regressed (5-10%) simple

--- a/src/cmd/nanovdb2pbrt.rs
+++ b/src/cmd/nanovdb2pbrt.rs
@@ -62,14 +62,14 @@ where
         } else if let Some(value) = argument.strip_prefix("-grid=") {
             grid = parse_nonempty(value, "--grid")?;
         } else if argument == "--grid" || argument == "-grid" {
-            grid = next_option_value(&mut arguments, "--grid")?;
+            grid = next_option_value(&mut arguments, "--grid", false)?;
         } else if let Some(value) = argument.strip_prefix("--downsample=") {
             downsample = parse_i32(value, "--downsample")?;
         } else if let Some(value) = argument.strip_prefix("-downsample=") {
             downsample = parse_i32(value, "--downsample")?;
         } else if argument == "--downsample" || argument == "-downsample" {
             downsample = parse_i32(
-                &next_option_value(&mut arguments, "--downsample")?,
+                &next_option_value(&mut arguments, "--downsample", true)?,
                 "--downsample",
             )?;
         } else if argument.starts_with('-') {
@@ -94,13 +94,14 @@ where
 fn next_option_value<I>(
     arguments: &mut std::iter::Peekable<I>,
     name: &str,
+    allow_leading_dash: bool,
 ) -> Result<String, CliError>
 where
     I: Iterator<Item = String>,
 {
     arguments
         .next()
-        .filter(|value| !value.starts_with('-'))
+        .filter(|value| allow_leading_dash || !value.starts_with('-'))
         .ok_or_else(|| CliError::usage(format!("missing value for {name}")))
 }
 

--- a/src/cmd/nanovdb2pbrt.rs
+++ b/src/cmd/nanovdb2pbrt.rs
@@ -1,0 +1,271 @@
+use nanovdb_rs::{GridClass, GridType, NvdbFile};
+use std::env;
+use std::fmt::{Display, Formatter};
+use std::io::{self, Write};
+use std::path::Path;
+use std::process::ExitCode;
+
+#[derive(Debug)]
+struct CliError {
+    message: String,
+    show_usage: bool,
+}
+
+impl CliError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            show_usage: false,
+        }
+    }
+
+    fn usage(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            show_usage: true,
+        }
+    }
+}
+
+impl Display for CliError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for CliError {}
+
+const USAGE: &str = "usage: nanovdb2pbrt [<options>] <filename.nvdb>\n\nOptions:\n  --grid <name>        Name of grid to extract. Default: \"density\"\n";
+
+struct Arguments {
+    filename: String,
+    grid: String,
+    _downsample: i32,
+}
+
+fn parse_arguments<I, T>(arguments: I) -> Result<Option<Arguments>, CliError>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<String>,
+{
+    let mut filename = None;
+    let mut grid = String::from("density");
+    let mut downsample = 0;
+    let mut arguments = arguments.into_iter().map(Into::into).peekable();
+
+    while let Some(argument) = arguments.next() {
+        if argument == "--help" || argument == "-help" || argument == "-h" {
+            return Ok(None);
+        }
+        if let Some(value) = argument.strip_prefix("--grid=") {
+            grid = parse_nonempty(value, "--grid")?;
+        } else if let Some(value) = argument.strip_prefix("-grid=") {
+            grid = parse_nonempty(value, "--grid")?;
+        } else if argument == "--grid" || argument == "-grid" {
+            grid = next_option_value(&mut arguments, "--grid")?;
+        } else if let Some(value) = argument.strip_prefix("--downsample=") {
+            downsample = parse_i32(value, "--downsample")?;
+        } else if let Some(value) = argument.strip_prefix("-downsample=") {
+            downsample = parse_i32(value, "--downsample")?;
+        } else if argument == "--downsample" || argument == "-downsample" {
+            downsample = parse_i32(
+                &next_option_value(&mut arguments, "--downsample")?,
+                "--downsample",
+            )?;
+        } else if argument.starts_with('-') {
+            return Err(CliError::usage(format!("unknown option: {argument}")));
+        } else if filename.is_some() {
+            return Err(CliError::usage("multiple input filenames provided"));
+        } else {
+            filename = Some(argument);
+        }
+    }
+
+    let Some(filename) = filename else {
+        return Err(CliError::usage("must specify a nanovdb filename"));
+    };
+    Ok(Some(Arguments {
+        filename,
+        grid,
+        _downsample: downsample,
+    }))
+}
+
+fn next_option_value<I>(
+    arguments: &mut std::iter::Peekable<I>,
+    name: &str,
+) -> Result<String, CliError>
+where
+    I: Iterator<Item = String>,
+{
+    arguments
+        .next()
+        .filter(|value| !value.starts_with('-'))
+        .ok_or_else(|| CliError::usage(format!("missing value for {name}")))
+}
+
+fn parse_nonempty(value: &str, name: &str) -> Result<String, CliError> {
+    if value.is_empty() {
+        Err(CliError::usage(format!("missing value for {name}")))
+    } else {
+        Ok(value.to_owned())
+    }
+}
+
+fn parse_i32(value: &str, name: &str) -> Result<i32, CliError> {
+    value
+        .parse()
+        .map_err(|_| CliError::usage(format!("invalid value for {name}: {value}")))
+}
+
+fn convert(arguments: &Arguments) -> Result<String, CliError> {
+    let file = NvdbFile::open(Path::new(&arguments.filename))
+        .map_err(|error| CliError::new(format!("{}: {error}", arguments.filename)))?;
+    let grid = file
+        .grids()
+        .iter()
+        .find(|grid| grid.name() == arguments.grid && grid.value_type() == GridType::Float)
+        .ok_or_else(|| {
+            CliError::new(format!(
+                "{}: didn't find \"{}\" Float grid",
+                arguments.filename, arguments.grid
+            ))
+        })?;
+
+    if !matches!(
+        grid.grid_metadata().grid_class,
+        GridClass::FogVolume | GridClass::Unknown
+    ) {
+        return Err(CliError::new(format!(
+            "{}: \"{}\" isn't a FogVolume grid",
+            arguments.filename, arguments.grid
+        )));
+    }
+    let (index_min, index_max) = grid.index_bbox();
+    if index_min.iter().zip(index_max).any(|(&min, max)| min > max) {
+        return Err(CliError::new(format!(
+            "{}: \"{}\" has an empty index bounding box",
+            arguments.filename, arguments.grid
+        )));
+    }
+    let (world_min, world_max) = grid.world_bbox();
+    let world_values = [
+        world_min.x,
+        world_min.y,
+        world_min.z,
+        world_max.x,
+        world_max.y,
+        world_max.z,
+    ];
+    if world_values.iter().any(|value| !value.is_finite()) {
+        return Err(CliError::new(format!(
+            "{}: \"{}\" has a non-finite world bounding box",
+            arguments.filename, arguments.grid
+        )));
+    }
+
+    let upper = index_max.map(|value| {
+        value.checked_add(1).ok_or_else(|| {
+            CliError::new(format!(
+                "{}: index bounding box is too large",
+                arguments.filename
+            ))
+        })
+    });
+    let upper = upper.into_iter().collect::<Result<Vec<_>, _>>()?;
+    let dimensions = upper
+        .iter()
+        .zip(index_min)
+        .map(|(&max, min)| i64::from(max) - i64::from(min) + 1)
+        .collect::<Vec<_>>();
+    if dimensions
+        .iter()
+        .any(|&dimension| dimension <= 0 || dimension > i64::from(i32::MAX))
+    {
+        return Err(CliError::new(format!(
+            "{}: index bounding box dimensions are invalid",
+            arguments.filename
+        )));
+    }
+    let expected = dimensions.iter().try_fold(1usize, |product, &dimension| {
+        product.checked_mul(dimension as usize).ok_or_else(|| {
+            CliError::new(format!("{}: dense grid is too large", arguments.filename))
+        })
+    })?;
+
+    let mut accessor = grid
+        .float_read_accessor()
+        .ok_or_else(|| CliError::new("failed to create Float grid accessor"))?;
+    let mut values = Vec::with_capacity(expected);
+    for z in index_min[2]..=upper[2] {
+        for y in index_min[1]..=upper[1] {
+            for x in index_min[0]..=upper[0] {
+                values.push(accessor.get_value([x, y, z]));
+            }
+        }
+    }
+    if values.len() != expected {
+        return Err(CliError::new(format!(
+            "internal error: voxel count does not match dimensions",
+        )));
+    }
+
+    let mut output = String::new();
+    output.push_str(&format!(
+        "\"integer nx\" {} \"integer ny\" {}  \"integer nz\" {}\n",
+        dimensions[0], dimensions[1], dimensions[2]
+    ));
+    output.push_str(&format!(
+        "\t\"point3 p0\" [ {:.6} {:.6} {:.6} ] \"point3 p1\" [ {:.6} {:.6} {:.6} ]\n",
+        world_min.x as f32,
+        world_min.y as f32,
+        world_min.z as f32,
+        world_max.x as f32,
+        world_max.y as f32,
+        world_max.z as f32
+    ));
+    output.push_str(&format!("\t\"float {}\" [\n", arguments.grid));
+    for (index, value) in values.iter().enumerate() {
+        if *value == 0.0 {
+            output.push_str("0 ");
+        } else {
+            output.push_str(&format!("{value:.6} "));
+        }
+        if index % 20 == 19 {
+            output.push('\n');
+        }
+    }
+    output.push_str("]\n");
+    Ok(output)
+}
+
+fn run<I, T>(arguments: I) -> Result<Option<String>, CliError>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<String>,
+{
+    let Some(arguments) = parse_arguments(arguments)? else {
+        return Ok(Some(USAGE.to_owned()));
+    };
+    convert(&arguments).map(Some)
+}
+
+fn main() -> ExitCode {
+    match run(env::args().skip(1)) {
+        Ok(Some(output)) => match io::stdout().write_all(output.as_bytes()) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(error) => {
+                eprintln!("nanovdb2pbrt: failed to write stdout: {error}");
+                ExitCode::from(1)
+            }
+        },
+        Ok(None) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("nanovdb2pbrt: {}", error.message);
+            if error.show_usage {
+                eprintln!("\n{USAGE}");
+            }
+            ExitCode::from(1)
+        }
+    }
+}

--- a/tests/nanovdb2pbrt.rs
+++ b/tests/nanovdb2pbrt.rs
@@ -34,3 +34,32 @@ fn missing_file_is_reported_without_dense_expansion() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("does-not-exist.nvdb"));
     assert!(output.stdout.is_empty());
 }
+
+#[test]
+fn negative_downsample_value_is_parsed_before_file_open() {
+    let output = nanovdb2pbrt()
+        .args(["--downsample", "-1", "does-not-exist.nvdb"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("does-not-exist.nvdb"));
+    assert!(!stderr.contains("missing value for --downsample"));
+}
+
+#[test]
+#[ignore = "requires a NanoVDB fixture specified by PBRT_NANOVDB_TEST_FILE"]
+fn configured_fixture_is_converted() {
+    let filename = std::env::var("PBRT_NANOVDB_TEST_FILE")
+        .expect("PBRT_NANOVDB_TEST_FILE must name a test .nvdb fixture");
+    let output = nanovdb2pbrt().arg(filename).output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"integer nx\""));
+    assert!(stdout.contains("\"point3 p0\""));
+    assert!(stdout.contains("\"float density\""));
+}

--- a/tests/nanovdb2pbrt.rs
+++ b/tests/nanovdb2pbrt.rs
@@ -1,0 +1,36 @@
+use std::process::Command;
+
+fn nanovdb2pbrt() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_nanovdb2pbrt"))
+}
+
+#[test]
+fn help_exits_successfully() {
+    let output = nanovdb2pbrt().arg("--help").output().unwrap();
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("nanovdb2pbrt"));
+}
+
+#[test]
+fn missing_filename_is_an_argument_error() {
+    let output = nanovdb2pbrt().output().unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("must specify a nanovdb filename"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("usage: nanovdb2pbrt"));
+}
+
+#[test]
+fn missing_file_is_reported_without_dense_expansion() {
+    let output = nanovdb2pbrt()
+        .args([
+            "--downsample=2",
+            "--grid",
+            "not-present",
+            "does-not-exist.nvdb",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("does-not-exist.nvdb"));
+    assert!(output.stdout.is_empty());
+}


### PR DESCRIPTION
Summary:
- Add the CPU nanovdb2pbrt CLI and Cargo bin target.
- Convert Float FogVolume/Unknown NanoVDB grids to v4-compatible pbrt dense-grid parameters.
- Add argument/error tests and an ignored fixture-based success test.
- Match v4 output for fire.nvdb, including full output comparison.

Validation:
- cargo fmt --all
- cargo test --test nanovdb2pbrt -q
- cargo check --bin nanovdb2pbrt -q
- cargo test --lib -q
- git diff --check

Fixture comparison:
- r4 and v4 output for pbrt-v4-scenes/explosion/fire.nvdb are byte-identical.
- PBRT_NANOVDB_TEST_FILE enables the ignored success-path integration test.