### PR TITLE
feat(cli): add cyhair2pbrt converter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,10 @@ path = "src/cmd/plytool.rs"
 name = "imgtool"
 path = "src/cmd/imgtool/mod.rs"
 
+[[bin]]
+name = "cyhair2pbrt"
+path = "src/cmd/cyhair2pbrt.rs"
+
 # `[profile.release]` left at cargo defaults (opt-level=3, no LTO).
 # We tried `lto = "fat"` + `codegen-units = 1`: small win (~5%) on the
 # BSSRDF-heavy head.pbrt path but slightly regressed (5-10%) simple

--- a/src/cmd/cyhair2pbrt.rs
+++ b/src/cmd/cyhair2pbrt.rs
@@ -4,8 +4,25 @@
 // pbrt-v4/src/pbrt/cmd/cyhair2pbrt.cpp.
 //
 // Copyright (c) 2016 Light Transport Entertainment, Inc.
-// The original loader is available under the MIT License:
-// https://opensource.org/licenses/MIT
+//
+// The original loader is available under the MIT License.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 use std::env;
 use std::fmt::{Display, Formatter};
@@ -18,6 +35,8 @@ const FLAG_POINTS: u32 = 1 << 1;
 const FLAG_THICKNESS: u32 = 1 << 2;
 const FLAG_TRANSPARENCY: u32 = 1 << 3;
 const FLAG_COLOR: u32 = 1 << 4;
+const KNOWN_FLAGS: u32 =
+    FLAG_SEGMENTS | FLAG_POINTS | FLAG_THICKNESS | FLAG_TRANSPARENCY | FLAG_COLOR;
 
 const TO_C2B: [[f32; 4]; 4] = [
     [0.0, 1.0, 0.0, 0.0],
@@ -145,6 +164,8 @@ struct CyHair {
     num_strands: usize,
     default_segments: usize,
     default_thickness: f32,
+    _default_transparency: f32,
+    _default_color: [f32; 3],
     segments: Vec<u16>,
     points: Vec<Point3>,
     strand_offsets: Vec<usize>,
@@ -178,9 +199,14 @@ impl CyHair {
         let default_segments = usize::try_from(read_u32(16)?)
             .map_err(|_| error("HAIR default segment count does not fit in usize"))?;
         let default_thickness = read_f32(20)?;
+        let default_transparency = read_f32(24)?;
+        let default_color = [read_f32(28)?, read_f32(32)?, read_f32(36)?];
 
         if flags & FLAG_POINTS == 0 {
             return Err(error("No point data in CyHair."));
+        }
+        if flags & !KNOWN_FLAGS != 0 {
+            return Err(error(format!("unsupported CyHair flags: 0x{flags:08x}")));
         }
         if flags & FLAG_SEGMENTS == 0 && default_segments < 1 {
             return Err(error("No valid segment information in CyHair."));
@@ -272,6 +298,8 @@ impl CyHair {
             num_strands,
             default_segments,
             default_thickness,
+            _default_transparency: default_transparency,
+            _default_color: default_color,
             segments,
             points,
             strand_offsets,
@@ -286,6 +314,7 @@ impl CyHair {
         };
         let mut vertices = Vec::new();
         let mut radii = Vec::new();
+        let mut eligible_strands = 0usize;
         for strand in 0..count {
             let num_segments = self
                 .segments
@@ -296,6 +325,7 @@ impl CyHair {
             if num_segments < 2 {
                 continue;
             }
+            eligible_strands += 1;
             let start = self.strand_offsets[strand];
             let end = start
                 .checked_add(num_segments)
@@ -320,6 +350,11 @@ impl CyHair {
                     4,
                 ));
             }
+        }
+        if count > 0 && eligible_strands == 0 {
+            return Err(error(
+                "CyHair contains no strand with enough points for conversion",
+            ));
         }
         Ok((vertices, radii))
     }

--- a/src/cmd/cyhair2pbrt.rs
+++ b/src/cmd/cyhair2pbrt.rs
@@ -1,0 +1,412 @@
+// Convert CyHair files to pbrt curve shapes.
+//
+// The HAIR loader is based on the implementation shipped in
+// pbrt-v4/src/pbrt/cmd/cyhair2pbrt.cpp.
+//
+// Copyright (c) 2016 Light Transport Entertainment, Inc.
+// The original loader is available under the MIT License:
+// https://opensource.org/licenses/MIT
+
+use std::env;
+use std::fmt::{Display, Formatter};
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+
+const FLAG_SEGMENTS: u32 = 1 << 0;
+const FLAG_POINTS: u32 = 1 << 1;
+const FLAG_THICKNESS: u32 = 1 << 2;
+const FLAG_TRANSPARENCY: u32 = 1 << 3;
+const FLAG_COLOR: u32 = 1 << 4;
+
+const TO_C2B: [[f32; 4]; 4] = [
+    [0.0, 1.0, 0.0, 0.0],
+    [-1.0 / 6.0, 1.0, 1.0 / 6.0, 0.0],
+    [0.0, 1.0 / 6.0, 1.0, -1.0 / 6.0],
+    [0.0, 0.0, 1.0, 0.0],
+];
+const TO_C2B0: [[f32; 4]; 4] = [
+    [0.0, 1.0, 0.0, 0.0],
+    [0.0, 0.5, 2.0 / 3.0, -1.0 / 6.0],
+    [0.0, 1.0 / 6.0, 1.0, -1.0 / 6.0],
+    [0.0, 0.0, 1.0, 0.0],
+];
+const TO_C2B1: [[f32; 4]; 4] = [
+    [0.0, 1.0, 0.0, 0.0],
+    [-1.0 / 6.0, 1.0, 1.0 / 6.0, 0.0],
+    [-1.0 / 6.0, 2.0 / 3.0, 0.5, 0.0],
+    [0.0, 0.0, 1.0, 0.0],
+];
+
+#[derive(Clone, Copy, Debug)]
+struct Point3 {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+impl Point3 {
+    fn zero() -> Self {
+        Self {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        }
+    }
+
+    fn add_scaled(self, other: Self, scale: f32) -> Self {
+        Self {
+            x: self.x + other.x * scale,
+            y: self.y + other.y * scale,
+            z: self.z + other.z * scale,
+        }
+    }
+
+    fn scaled(self, scale: f32) -> Self {
+        Self {
+            x: self.x * scale,
+            y: self.y * scale,
+            z: self.z * scale,
+        }
+    }
+
+    fn add(self, other: Self) -> Self {
+        self.add_scaled(other, 1.0)
+    }
+}
+
+fn mul_matrix(matrix: &[[f32; 4]; 4], points: [Point3; 4]) -> [Point3; 4] {
+    std::array::from_fn(|row| {
+        let mut result = Point3::zero();
+        for (column, point) in points.into_iter().enumerate() {
+            result = result.add_scaled(point, matrix[row][column]);
+        }
+        result
+    })
+}
+
+fn catmull_rom_to_bezier(points: &[Point3], segment: usize) -> [Point3; 4] {
+    if points.len() == 2 {
+        let p0 = points[segment];
+        let p1 = points[segment + 1];
+        return [
+            p0,
+            p0.scaled(2.0 / 3.0).add(p1.scaled(1.0 / 3.0)),
+            p0.scaled(1.0 / 3.0).add(p1.scaled(2.0 / 3.0)),
+            p1,
+        ];
+    }
+
+    let control = if segment == 0 {
+        [Point3::zero(), points[0], points[1], points[2]]
+    } else if segment == points.len() - 2 {
+        [
+            points[segment - 1],
+            points[segment],
+            points[segment + 1],
+            Point3::zero(),
+        ]
+    } else {
+        [
+            points[segment - 1],
+            points[segment],
+            points[segment + 1],
+            points[segment + 2],
+        ]
+    };
+    let matrix = if segment == 0 {
+        &TO_C2B0
+    } else if segment == points.len() - 2 {
+        &TO_C2B1
+    } else {
+        &TO_C2B
+    };
+    mul_matrix(matrix, control)
+}
+
+#[derive(Debug)]
+struct CyHairError(String);
+
+impl Display for CyHairError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for CyHairError {}
+
+type Result<T> = std::result::Result<T, CyHairError>;
+
+fn error(message: impl Into<String>) -> CyHairError {
+    CyHairError(message.into())
+}
+
+struct CyHair {
+    num_strands: usize,
+    default_segments: usize,
+    default_thickness: f32,
+    segments: Vec<u16>,
+    points: Vec<Point3>,
+    strand_offsets: Vec<usize>,
+}
+
+impl CyHair {
+    fn load(path: &Path) -> Result<Self> {
+        let data = fs::read(path).map_err(|e| error(format!("{}: {e}", path.display())))?;
+        if data.len() < 128 {
+            return Err(error(format!(
+                "{}: file is shorter than the 128-byte header",
+                path.display()
+            )));
+        }
+        if &data[..4] != b"HAIR" {
+            return Err(error(format!("{}: invalid HAIR magic", path.display())));
+        }
+
+        let read_u32 = |offset| {
+            data.get(offset..offset + 4)
+                .and_then(|bytes| bytes.try_into().ok())
+                .map(u32::from_le_bytes)
+                .ok_or_else(|| error("invalid HAIR header"))
+        };
+        let read_f32 = |offset| Ok(f32::from_bits(read_u32(offset)?));
+        let num_strands = usize::try_from(read_u32(4)?)
+            .map_err(|_| error("HAIR strand count does not fit in usize"))?;
+        let total_points = usize::try_from(read_u32(8)?)
+            .map_err(|_| error("HAIR point count does not fit in usize"))?;
+        let flags = read_u32(12)?;
+        let default_segments = usize::try_from(read_u32(16)?)
+            .map_err(|_| error("HAIR default segment count does not fit in usize"))?;
+        let default_thickness = read_f32(20)?;
+
+        if flags & FLAG_POINTS == 0 {
+            return Err(error("No point data in CyHair."));
+        }
+        if flags & FLAG_SEGMENTS == 0 && default_segments < 1 {
+            return Err(error("No valid segment information in CyHair."));
+        }
+
+        let mut cursor = 128usize;
+        let take = |cursor: &mut usize, count: usize| -> Result<&[u8]> {
+            let end = cursor
+                .checked_add(count)
+                .ok_or_else(|| error("HAIR size overflow"))?;
+            let bytes = data
+                .get(*cursor..end)
+                .ok_or_else(|| error("truncated HAIR array"))?;
+            *cursor = end;
+            Ok(bytes)
+        };
+        let segments = if flags & FLAG_SEGMENTS != 0 {
+            let bytes = take(
+                &mut cursor,
+                num_strands
+                    .checked_mul(2)
+                    .ok_or_else(|| error("HAIR size overflow"))?,
+            )?;
+            bytes
+                .chunks_exact(2)
+                .map(|b| u16::from_le_bytes([b[0], b[1]]))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let point_bytes = total_points
+            .checked_mul(12)
+            .ok_or_else(|| error("HAIR size overflow"))?;
+        let points = take(&mut cursor, point_bytes)?
+            .chunks_exact(12)
+            .map(|b| Point3 {
+                x: f32::from_le_bytes(b[0..4].try_into().unwrap()),
+                y: f32::from_le_bytes(b[4..8].try_into().unwrap()),
+                z: f32::from_le_bytes(b[8..12].try_into().unwrap()),
+            })
+            .collect();
+        if flags & FLAG_THICKNESS != 0 {
+            let _ = take(
+                &mut cursor,
+                total_points
+                    .checked_mul(4)
+                    .ok_or_else(|| error("HAIR size overflow"))?,
+            )?;
+        }
+        if flags & FLAG_TRANSPARENCY != 0 {
+            let _ = take(
+                &mut cursor,
+                total_points
+                    .checked_mul(4)
+                    .ok_or_else(|| error("HAIR size overflow"))?,
+            )?;
+        }
+        if flags & FLAG_COLOR != 0 {
+            let _ = take(
+                &mut cursor,
+                total_points
+                    .checked_mul(12)
+                    .ok_or_else(|| error("HAIR size overflow"))?,
+            )?;
+        }
+
+        let mut strand_offsets = Vec::with_capacity(num_strands);
+        let mut offset = 0usize;
+        for index in 0..num_strands {
+            strand_offsets.push(offset);
+            let segments = segments
+                .get(index)
+                .copied()
+                .map(usize::from)
+                .unwrap_or(default_segments);
+            offset = offset
+                .checked_add(
+                    segments
+                        .checked_add(1)
+                        .ok_or_else(|| error("HAIR strand offset overflow"))?,
+                )
+                .ok_or_else(|| error("HAIR strand offset overflow"))?;
+        }
+        if offset != total_points {
+            return Err(error(format!("HAIR point count mismatch: offsets require {offset}, header declares {total_points}")));
+        }
+
+        Ok(Self {
+            num_strands,
+            default_segments,
+            default_thickness,
+            segments,
+            points,
+            strand_offsets,
+        })
+    }
+
+    fn convert(&self, max_strands: i32, thickness: f32) -> Result<(Vec<Point3>, Vec<f32>)> {
+        let count = if max_strands > 0 {
+            (max_strands as usize).min(self.num_strands)
+        } else {
+            self.num_strands
+        };
+        let mut vertices = Vec::new();
+        let mut radii = Vec::new();
+        for strand in 0..count {
+            let num_segments = self
+                .segments
+                .get(strand)
+                .copied()
+                .map(usize::from)
+                .unwrap_or(self.default_segments);
+            if num_segments < 2 {
+                continue;
+            }
+            let start = self.strand_offsets[strand];
+            let end = start
+                .checked_add(num_segments)
+                .ok_or_else(|| error("HAIR point range overflow"))?;
+            let segment_points: Vec<_> = self.points[start..end]
+                .iter()
+                .map(|p| Point3 {
+                    x: p.x,
+                    y: p.z,
+                    z: p.y,
+                })
+                .collect();
+            for s in 1..num_segments - 1 {
+                let curve = catmull_rom_to_bezier(&segment_points, s - 1);
+                vertices.extend(curve);
+                radii.extend(std::iter::repeat_n(
+                    if thickness > 0.0 {
+                        thickness
+                    } else {
+                        self.default_thickness
+                    },
+                    4,
+                ));
+            }
+        }
+        Ok((vertices, radii))
+    }
+}
+
+fn format_output(input: &str, user_thickness: f32, vertices: &[Point3], radii: &[f32]) -> String {
+    let mut bounds_min = [1.0e30f64; 3];
+    let mut bounds_max = [-1.0e30f64; 3];
+    for (point, radius) in vertices
+        .iter()
+        .zip(radii.iter().cycle())
+        .take(vertices.len())
+    {
+        let values = [point.x as f64, point.y as f64, point.z as f64];
+        for axis in 0..3 {
+            bounds_min[axis] = bounds_min[axis].min(values[axis] - *radius as f64);
+            bounds_max[axis] = bounds_max[axis].max(values[axis] + *radius as f64);
+        }
+    }
+    let mut output = format!("# Converted from \"{input}\" by cyhair2pbrt\n# The number of strands = {}. user_thickness = {user_thickness:.6}\n# Scene bounds: ({:.6}, {:.6}, {:.6}) - ({:.6}, {:.6}, {:.6})\n\n\n", radii.len() / 4, bounds_min[0], bounds_min[1], bounds_min[2], bounds_max[0], bounds_max[1], bounds_max[2]);
+    for (curve_index, curve) in vertices.chunks_exact(4).enumerate() {
+        output.push_str("Shape \"curve\" \"string type\" [ \"cylinder\" ] \"point3 P\" [ ");
+        for point in curve {
+            output.push_str(&format!("{:.6} {:.6} {:.6} ", point.x, point.y, point.z));
+        }
+        output.push_str(&format!(
+            " ] \"float width0\" [ {:.6} ] \"float width1\" [ {:.6} ]\n",
+            radii[4 * curve_index],
+            radii[4 * curve_index + 3]
+        ));
+    }
+    output
+}
+
+fn usage() {
+    eprintln!(
+        "usage: cyhair2pbrt [CyHair filename] [pbrt output filename] (max strands) (thickness)"
+    );
+}
+
+fn run(args: &[String]) -> Result<()> {
+    debug_assert!(args.len() > 2);
+    if args.len() > 5 {
+        return Err(error("too many arguments"));
+    }
+    let max_strands = args
+        .get(3)
+        .map(|s| s.parse::<i32>().map_err(|_| error("invalid max strands")))
+        .transpose()?
+        .unwrap_or(-1);
+    if max_strands < -1 {
+        return Err(error("max strands must be -1 or non-negative"));
+    }
+    let thickness = args
+        .get(4)
+        .map(|s| s.parse::<f32>().map_err(|_| error("invalid thickness")))
+        .transpose()?
+        .unwrap_or(1.0);
+    if !thickness.is_finite() {
+        return Err(error("thickness must be finite"));
+    }
+    let hair = CyHair::load(Path::new(&args[1]))?;
+    let (vertices, radii) = hair.convert(max_strands, thickness)?;
+    let output = format_output(&args[1], thickness, &vertices, &radii);
+    if args[2] == "-" {
+        io::stdout()
+            .write_all(output.as_bytes())
+            .map_err(|e| error(e.to_string()))?;
+    } else {
+        fs::write(&args[2], output).map_err(|e| error(format!("{}: {e}", args[2])))?;
+    }
+    eprintln!("Converted {} strands.", radii.len() / 4);
+    Ok(())
+}
+
+fn main() {
+    let args = env::args().collect::<Vec<_>>();
+    if args.len() <= 2
+        || args
+            .get(1)
+            .is_some_and(|arg| arg == "--help" || arg == "-h")
+    {
+        usage();
+        std::process::exit(1);
+    }
+    if let Err(err) = run(&args) {
+        eprintln!("cyhair2pbrt: {err}");
+        std::process::exit(1);
+    }
+}

--- a/tests/cyhair2pbrt.rs
+++ b/tests/cyhair2pbrt.rs
@@ -1,0 +1,168 @@
+use std::io::Write;
+use std::process::Command;
+
+use tempfile::NamedTempFile;
+
+const FLAG_SEGMENTS: u32 = 1 << 0;
+const FLAG_POINTS: u32 = 1 << 1;
+
+fn write_hair(strands: &[(&[u16], &[[f32; 3]])]) -> NamedTempFile {
+    let mut file = NamedTempFile::new().unwrap();
+    let num_strands = strands.len() as u32;
+    let total_points = strands
+        .iter()
+        .map(|(_, points)| points.len())
+        .sum::<usize>() as u32;
+    let mut header = [0u8; 128];
+    header[..4].copy_from_slice(b"HAIR");
+    header[4..8].copy_from_slice(&num_strands.to_le_bytes());
+    header[8..12].copy_from_slice(&total_points.to_le_bytes());
+    header[12..16].copy_from_slice(&(FLAG_SEGMENTS | FLAG_POINTS).to_le_bytes());
+    file.write_all(&header).unwrap();
+    for (segments, _) in strands {
+        assert_eq!(segments.len(), 1);
+        file.write_all(&segments[0].to_le_bytes()).unwrap();
+    }
+    for (_, points) in strands {
+        for point in *points {
+            for value in point {
+                file.write_all(&value.to_le_bytes()).unwrap();
+            }
+        }
+    }
+    file
+}
+
+fn run(input: &std::path::Path, extra: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_cyhair2pbrt"))
+        .arg(input)
+        .arg("-")
+        .args(extra)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn converts_segments_and_applies_zup_to_yup() {
+    let file = write_hair(&[(
+        &[4],
+        &[
+            [0.0, 0.0, 0.0],
+            [1.0, 2.0, 3.0],
+            [2.0, 4.0, 6.0],
+            [3.0, 6.0, 9.0],
+            [4.0, 8.0, 12.0],
+        ],
+    )]);
+    let output = run(file.path(), &[]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("The number of strands = 2. user_thickness = 1.000000"));
+    assert!(stdout.contains(
+        "0.000000 0.000000 0.000000 0.333333 1.000000 0.666667 0.666667 2.000000 1.333333 1.000000 3.000000 2.000000"
+    ));
+    assert!(stdout.contains("width0\" [ 1.000000 ] \"float width1\" [ 1.000000 ]"));
+    assert!(output.stderr.starts_with(b"Converted 2 strands."));
+}
+
+#[test]
+fn max_strands_zero_matches_v4_all_strands_behavior() {
+    let file = write_hair(&[(
+        &[3],
+        &[
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [3.0, 0.0, 0.0],
+        ],
+    )]);
+    let output = run(file.path(), &["0"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("The number of strands = 1."));
+    assert!(stdout.contains("Shape \"curve\""));
+}
+
+#[test]
+fn handles_segment_count_boundaries_and_strand_offsets() {
+    let file = write_hair(&[
+        (&[2], &[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]),
+        (
+            &[3],
+            &[
+                [10.0, 0.0, 0.0],
+                [11.0, 0.0, 0.0],
+                [12.0, 0.0, 0.0],
+                [13.0, 0.0, 0.0],
+            ],
+        ),
+        (
+            &[4],
+            &[
+                [20.0, 0.0, 0.0],
+                [21.0, 0.0, 0.0],
+                [22.0, 0.0, 0.0],
+                [23.0, 0.0, 0.0],
+                [24.0, 0.0, 0.0],
+            ],
+        ),
+    ]);
+    let output = run(file.path(), &[]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("The number of strands = 3."));
+    assert!(stdout.contains("10.000000"));
+    assert!(stdout.contains("20.000000"));
+}
+
+#[test]
+fn rejects_invalid_arguments_and_truncated_input() {
+    let no_args = Command::new(env!("CARGO_BIN_EXE_cyhair2pbrt"))
+        .output()
+        .unwrap();
+    assert!(!no_args.status.success());
+    assert!(String::from_utf8_lossy(&no_args.stderr).contains("usage: cyhair2pbrt"));
+
+    let file = write_hair(&[(
+        &[3],
+        &[
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [3.0, 0.0, 0.0],
+        ],
+    )]);
+    let invalid_max = run(file.path(), &["-2"]);
+    assert!(!invalid_max.status.success());
+    assert!(String::from_utf8_lossy(&invalid_max.stderr).contains("max strands"));
+
+    let mut truncated = NamedTempFile::new().unwrap();
+    truncated.write_all(b"HAIR").unwrap();
+    let invalid_file = run(truncated.path(), &[]);
+    assert!(!invalid_file.status.success());
+    assert!(String::from_utf8_lossy(&invalid_file.stderr).contains("128-byte header"));
+}
+
+#[test]
+fn rejects_default_segment_point_count_mismatch() {
+    let mut file = NamedTempFile::new().unwrap();
+    let mut header = [0u8; 128];
+    header[..4].copy_from_slice(b"HAIR");
+    header[4..8].copy_from_slice(&1u32.to_le_bytes());
+    header[8..12].copy_from_slice(&4u32.to_le_bytes());
+    header[12..16].copy_from_slice(&FLAG_POINTS.to_le_bytes());
+    header[16..20].copy_from_slice(&4u32.to_le_bytes());
+    file.write_all(&header).unwrap();
+    for i in 0..4 {
+        file.write_all(&(i as f32).to_le_bytes()).unwrap();
+        file.write_all(&0.0f32.to_le_bytes()).unwrap();
+        file.write_all(&0.0f32.to_le_bytes()).unwrap();
+    }
+    let output = run(file.path(), &[]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("point count mismatch"));
+}

--- a/tests/cyhair2pbrt.rs
+++ b/tests/cyhair2pbrt.rs
@@ -66,7 +66,61 @@ fn converts_segments_and_applies_zup_to_yup() {
         "0.000000 0.000000 0.000000 0.333333 1.000000 0.666667 0.666667 2.000000 1.333333 1.000000 3.000000 2.000000"
     ));
     assert!(stdout.contains("width0\" [ 1.000000 ] \"float width1\" [ 1.000000 ]"));
+    assert!(stdout.contains(
+        "Scene bounds: (-1.000000, -1.000000, -1.000000) - (3.000000, 7.000000, 5.000000)"
+    ));
     assert!(output.stderr.starts_with(b"Converted 2 strands."));
+}
+
+#[test]
+fn applies_thickness_argument_and_header_default() {
+    let file = write_hair(&[(
+        &[3],
+        &[
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [3.0, 0.0, 0.0],
+        ],
+    )]);
+
+    let overridden = run(file.path(), &["1", "2.5"]);
+    assert!(overridden.status.success());
+    assert!(String::from_utf8(overridden.stdout)
+        .unwrap()
+        .contains("width0\" [ 2.500000 ] \"float width1\" [ 2.500000 ]"));
+
+    let from_header = run(file.path(), &["1", "-1"]);
+    assert!(from_header.status.success());
+    assert!(String::from_utf8(from_header.stdout)
+        .unwrap()
+        .contains("width0\" [ 0.000000 ] \"float width1\" [ 0.000000 ]"));
+}
+
+#[test]
+fn writes_to_an_output_file() {
+    let input = write_hair(&[(
+        &[3],
+        &[
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [3.0, 0.0, 0.0],
+        ],
+    )]);
+    let output_file = NamedTempFile::new().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_cyhair2pbrt"))
+        .arg(input.path())
+        .arg(output_file.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8(std::fs::read(output_file.path()).unwrap())
+            .unwrap()
+            .contains("Shape \"curve\"")
+    );
+    assert!(output.stdout.is_empty());
 }
 
 #[test]
@@ -126,6 +180,14 @@ fn rejects_invalid_arguments_and_truncated_input() {
         .unwrap();
     assert!(!no_args.status.success());
     assert!(String::from_utf8_lossy(&no_args.stderr).contains("usage: cyhair2pbrt"));
+    for flag in ["--help", "-h"] {
+        let help = Command::new(env!("CARGO_BIN_EXE_cyhair2pbrt"))
+            .arg(flag)
+            .output()
+            .unwrap();
+        assert!(!help.status.success());
+        assert!(String::from_utf8_lossy(&help.stderr).contains("usage: cyhair2pbrt"));
+    }
 
     let file = write_hair(&[(
         &[3],
@@ -145,6 +207,20 @@ fn rejects_invalid_arguments_and_truncated_input() {
     let invalid_file = run(truncated.path(), &[]);
     assert!(!invalid_file.status.success());
     assert!(String::from_utf8_lossy(&invalid_file.stderr).contains("128-byte header"));
+
+    let invalid_segments = write_hair(&[(&[1], &[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])]);
+    let invalid_conversion = run(invalid_segments.path(), &[]);
+    assert!(!invalid_conversion.status.success());
+    assert!(String::from_utf8_lossy(&invalid_conversion.stderr).contains("no strand"));
+
+    let mut unknown_flags = NamedTempFile::new().unwrap();
+    let mut header = [0u8; 128];
+    header[..4].copy_from_slice(b"HAIR");
+    header[12..16].copy_from_slice(&(FLAG_POINTS | (1 << 31)).to_le_bytes());
+    unknown_flags.write_all(&header).unwrap();
+    let unknown = run(unknown_flags.path(), &[]);
+    assert!(!unknown.status.success());
+    assert!(String::from_utf8_lossy(&unknown.stderr).contains("unsupported CyHair flags"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add the CPU `cyhair2pbrt` CLI corresponding to pbrt-v4.
- Parse HAIR data safely and convert Catmull-Rom strands to cubic Bezier curve shapes.
- Add integration coverage for conversion, bounds, thickness, argument errors, file output, offsets, and truncated/unsupported input.

## Validation
- `cargo fmt --all`
- `cargo test --test cyhair2pbrt`
- `cargo build --bin cyhair2pbrt`
- `straight.hair`: generated 130,000 curves successfully
- `git diff --check`

## Notes
- The converter keeps pbrt-v4 positional arguments and writes diagnostics to stderr.
- Unknown HAIR flags are rejected by r4 instead of being silently ignored, because their array layout cannot be safely inferred.