### PR TITLE
fix: configure BVH default builder settings

### DIFF
--- a/src/cpu/aggregates/bvh/create_bvh_accelerator.rs
+++ b/src/cpu/aggregates/bvh/create_bvh_accelerator.rs
@@ -7,6 +7,9 @@ use crate::util::error::*;
 
 use std::sync::Arc;
 
+const DEFAULT_SPLIT_METHOD: &str = "hlbvh";
+const DEFAULT_MAX_PRIMS_IN_NODE: i32 = 8;
+
 pub fn create_bvh_accelerator(
     prims: &[Arc<Primitive>],
     params: &ParameterDictionary,
@@ -17,7 +20,15 @@ pub fn create_bvh_accelerator(
         ));
     }
 
-    let split_name = params.get_one_string("splitmethod", "sah");
+    // Use HLBVH until the current SAH implementation's over-splitting is
+    // corrected. An explicit scene parameter still takes precedence. The
+    // environment variable is an operational override for unparameterized
+    // scenes, useful for comparing BVH builders without editing scene files.
+    let default_split_method = std::env::var("PBRT_BVH_SPLITMETHOD")
+        .ok()
+        .filter(|value| matches!(value.as_str(), "sah" | "hlbvh" | "middle" | "equal"))
+        .unwrap_or_else(|| DEFAULT_SPLIT_METHOD.to_owned());
+    let split_name = params.get_one_string("splitmethod", &default_split_method);
     let split_method = match &split_name as &str {
         "sah" => SplitMethod::SAH,
         "hlbvh" => SplitMethod::HLBVH,
@@ -26,7 +37,12 @@ pub fn create_bvh_accelerator(
         _ => SplitMethod::SAH,
     };
 
-    let max_prims_in_node: usize = params.get_one_int("maxnodeprims", 4) as usize;
+    let default_max_prims_in_node = std::env::var("PBRT_BVH_MAXNODEPRIMS")
+        .ok()
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(DEFAULT_MAX_PRIMS_IN_NODE);
+    let max_prims_in_node: usize =
+        params.get_one_int("maxnodeprims", default_max_prims_in_node) as usize;
     return Ok(Primitive::Accel(Accel::BVH(Arc::new(BVHAccel::new(
         prims,
         max_prims_in_node,

--- a/src/parser/scene_builder/build.rs
+++ b/src/parser/scene_builder/build.rs
@@ -981,7 +981,7 @@ impl SceneBuilder {
                 _ => unreachable!(),
             };
             let final_prim = if piece_prims.len() > 1 {
-                match self.create_shape_accelerator(&piece_prims, use_dedicated_mesh_accelerator) {
+                match self.create_shape_accelerator(&piece_prims) {
                     Ok(accel) => accel,
                     Err(e) => {
                         return Err(e);
@@ -1007,7 +1007,7 @@ impl SceneBuilder {
 
         // Static shapes normally follow pbrt-v4 and emit leaf primitives
         // directly. Large or displaced PLY meshes are the exception: their
-        // triangle sets get a dedicated HLBVH before entering the scene BVH.
+        // triangle sets get a dedicated accelerator before entering the scene BVH.
         let mut piece_prims = Vec::with_capacity(shapes.len());
         for s in shapes {
             let area_light = if let Some(al_idx) = shape.area_light_index {
@@ -1035,7 +1035,7 @@ impl SceneBuilder {
             piece_prims.push(prim);
         }
         if use_dedicated_mesh_accelerator && piece_prims.len() > 1 {
-            out_prims.push(self.create_shape_accelerator(&piece_prims, true)?);
+            out_prims.push(self.create_shape_accelerator(&piece_prims)?);
         } else {
             out_prims.extend(piece_prims);
         }
@@ -1045,17 +1045,8 @@ impl SceneBuilder {
     fn create_shape_accelerator(
         &self,
         prims: &[Arc<Primitive>],
-        displaced_mesh: bool,
     ) -> Result<Arc<Primitive>, PbrtError> {
-        let mut params = self.accelerator_params.clone();
-        let name = if displaced_mesh {
-            params.replace_one_string("string splitmethod", "hlbvh");
-            params.replace_one_int("integer maxnodeprims", 16);
-            "bvh"
-        } else {
-            &self.accelerator_name
-        };
-        create_accelerator(name, prims, &params)
+        create_accelerator(&self.accelerator_name, prims, &self.accelerator_params)
             .map(Arc::new)
             .map_err(|e| PbrtError::error(&format!("create_accelerator failed: {}", e.msg)))
     }


### PR DESCRIPTION
## Summary
- Use HLBVH and maxnodeprims=8 as the temporary BVH defaults.
- Remove displaced-mesh-specific splitmethod, maxnodeprims, and accelerator overrides.
- Add PBRT_BVH_SPLITMETHOD and PBRT_BVH_MAXNODEPRIMS environment overrides for unparameterized scenes.
- Preserve explicit scene parameters over environment defaults.

## Validation
- cargo fmt --all
- cargo test --test create_accelerator
- cargo check --bin pbrt-r4
- git diff --check