### PR TITLE
fix: align SAH BVH construction with pbrt-v4

### DIFF
--- a/src/cpu/aggregates/bvh/build/node.rs
+++ b/src/cpu/aggregates/bvh/build/node.rs
@@ -31,17 +31,21 @@ pub fn recursive_build(
     let start = 0;
     let end = primitive_info.len();
     let n_primitives = end;
+
+    // Compute bounds of all primitives in BVH node
     let mut bounds = primitive_info[start].bounds.clone();
     for i in (start + 1)..end {
         bounds = Bounds3f::union(&bounds, &primitive_info[i].bounds);
     }
     if bounds.surface_area() == 0.0 || n_primitives == 1 {
+        // Create leaf _BVHBuildNode_
         let offset = ordered_indices.len();
         for i in start..end {
             ordered_indices.push(primitive_info[i].primitive_number);
         }
         return Box::new(BVHBuildNode::init_leaf(offset, n_primitives, &bounds));
     } else {
+        // Compute bound of primitive centroids and choose split dimension _dim_
         let center = primitive_info[start].centroid;
         let mut c_bounds = Bounds3f::new(&center, &center);
         for i in (start + 1)..end {
@@ -49,15 +53,30 @@ pub fn recursive_build(
             c_bounds = c_bounds.union_p(&p);
         }
         let dim = c_bounds.maximum_extent();
+        // Partition primitives into two sets and build children
         if c_bounds.min[dim] == c_bounds.max[dim] {
+            // Create leaf _BVHBuildNode_
             let offset = ordered_indices.len();
             for i in start..end {
                 ordered_indices.push(primitive_info[i].primitive_number);
             }
             return Box::new(BVHBuildNode::init_leaf(offset, n_primitives, &bounds));
         }
+        if n_primitives <= 2 {
+            // Partition primitives into equally sized subsets
+            return split_equal_counts(
+                dim,
+                primitive_info,
+                ordered_indices,
+                max_prims_in_node,
+                split_method,
+            );
+        }
+
+        // Partition primitives based on _splitMethod_
         match split_method {
             SplitMethod::Middle => {
+                // Partition primitives through node's midpoint
                 let p_mid = (c_bounds.min[dim] + c_bounds.max[dim]) / 2.0;
                 return split_middle(
                     dim,
@@ -69,6 +88,7 @@ pub fn recursive_build(
                 );
             }
             SplitMethod::EqualCounts => {
+                // Partition primitives into equally sized subsets
                 return split_equal_counts(
                     dim,
                     primitive_info,
@@ -78,6 +98,7 @@ pub fn recursive_build(
                 );
             }
             SplitMethod::SAH => {
+                // Partition primitives using approximate SAH
                 return split_sah(
                     dim,
                     primitive_info,

--- a/src/cpu/aggregates/bvh/build/sah.rs
+++ b/src/cpu/aggregates/bvh/build/sah.rs
@@ -1,10 +1,11 @@
+use super::equal_counts::*;
 use super::node::*;
 use super::types::*;
 use crate::util::base::*;
 use crate::util::geometry::*;
 
 #[derive(Debug, Clone, Copy, Default)]
-struct BucketInfo {
+struct BVHSplitBucket {
     count: i32,
     bounds: Bounds3f,
 }
@@ -46,113 +47,107 @@ pub fn split_sah(
             &primitive_info[0].bounds,
         ));
     } else if n_primitives == 2 {
-        // Partition primitives into equally-sized subsets
-        let mid = n_primitives / 2;
-        primitive_info.sort_by(|a: &BVHPrimitiveInfo, b: &BVHPrimitiveInfo| {
-            a.centroid[dim].total_cmp(&b.centroid[dim])
-        });
+        // Partition primitives into equally sized subsets
+        return split_equal_counts(
+            dim,
+            primitive_info,
+            ordered_indices,
+            max_prims_in_node,
+            split_method,
+        );
+    }
+
+    // Compute bounds of all primitives in BVH node
+    let bounds = get_bounds(primitive_info);
+
+    // Compute bound of primitive centroids, choose split dimension _dim_
+    let centroid_bounds = get_centroid_bounds(primitive_info);
+
+    // Allocate _BVHSplitBucket_ for SAH partition buckets
+    const N_BUCKETS: usize = 12;
+    let mut buckets = [BVHSplitBucket::default(); N_BUCKETS];
+
+    // Initialize _BVHSplitBucket_ for SAH partition buckets
+    for i in 0..primitive_info.len() {
+        let b = (Float::floor(
+            N_BUCKETS as Float * centroid_bounds.offset(&primitive_info[i].centroid)[dim],
+        ) as i32)
+            .min(N_BUCKETS as i32 - 1)
+            .max(0) as usize;
+        buckets[b].count += 1;
+        buckets[b].bounds = Bounds3f::union(&buckets[b].bounds, &primitive_info[i].bounds);
+    }
+
+    // Compute costs for splitting after each bucket
+    let mut cost = [0.0; N_BUCKETS - 1];
+
+    // Partially initialize _costs_ using a forward scan over splits
+    let mut count_below = 0;
+    let mut bound_below = buckets[0].bounds;
+    for i in 0..(N_BUCKETS - 1) {
+        bound_below = Bounds3f::union(&bound_below, &buckets[i].bounds);
+        count_below += buckets[i].count;
+        cost[i] += count_below as Float * bound_below.surface_area();
+    }
+
+    // Finish initializing _costs_ using a backwards scan over splits
+    let mut count_above = 0;
+    let mut bound_above = Bounds3f::default();
+    for i in (1..N_BUCKETS).rev() {
+        bound_above = Bounds3f::union(&bound_above, &buckets[i].bounds);
+        count_above += buckets[i].count;
+        cost[i - 1] += count_above as Float * bound_above.surface_area();
+    }
+
+    // Find bucket to split at that minimizes SAH metric
+    let mut min_cost = Float::INFINITY;
+    let mut min_cost_split_bucket = 0;
+    for i in 0..(N_BUCKETS - 1) {
+        // Compute cost for candidate split and update minimum if necessary
+        if cost[i] < min_cost {
+            min_cost = cost[i];
+            min_cost_split_bucket = i;
+        }
+    }
+
+    // Compute leaf cost and SAH split cost for chosen split
+    let leaf_cost = n_primitives as Float;
+    min_cost = 0.5 + min_cost / bounds.surface_area();
+
+    // Either create leaf or split primitives at selected SAH bucket
+    if n_primitives > max_prims_in_node || min_cost < leaf_cost {
+        let (mut left, mut right): (Vec<BVHPrimitiveInfo>, Vec<BVHPrimitiveInfo>) =
+            primitive_info.iter().partition(|pi| -> bool {
+                let b =
+                    (Float::floor(N_BUCKETS as Float * centroid_bounds.offset(&pi.centroid)[dim])
+                        as i32)
+                        .min(N_BUCKETS as i32 - 1)
+                        .max(0) as usize;
+                b <= min_cost_split_bucket
+            });
         let c0 = Some(recursive_build(
-            &mut primitive_info[0..mid],
+            &mut left,
             ordered_indices,
             max_prims_in_node,
             split_method,
         ));
         let c1 = Some(recursive_build(
-            &mut primitive_info[mid..],
+            &mut right,
             ordered_indices,
             max_prims_in_node,
             split_method,
         ));
         return Box::new(BVHBuildNode::init_interior(dim, c0, c1));
     } else {
-        // Compute bounds of all primitives in BVH node
-        let bounds = get_bounds(primitive_info);
-
-        // Compute bound of primitive centroids, choose split dimension _dim_
-        let centroid_bounds = get_centroid_bounds(primitive_info);
-
-        // Allocate _BucketInfo_ for SAH partition buckets
-        const N_BUCKETS: usize = 12;
-        let mut buckets = [BucketInfo::default(); N_BUCKETS];
-
-        // Initialize _BucketInfo_ for SAH partition buckets
-        for i in 0..primitive_info.len() {
-            let b = (Float::floor(
-                N_BUCKETS as Float * centroid_bounds.offset(&primitive_info[i].centroid)[dim],
-            ) as i32)
-                .min(N_BUCKETS as i32 - 1)
-                .max(0) as usize;
-            buckets[b].count += 1;
-            buckets[b].bounds = Bounds3f::union(&buckets[b].bounds, &primitive_info[i].bounds);
+        // Create leaf _BVHBuildNode_
+        let first_prim_offset = ordered_indices.len();
+        for i in 0..n_primitives {
+            ordered_indices.push(primitive_info[i].primitive_number);
         }
-
-        // Compute costs for splitting after each bucket
-        let mut cost = [0.0; N_BUCKETS - 1];
-        for i in 0..cost.len() {
-            let mut count0 = 0;
-            let mut count1 = 0;
-            let mut b0 = buckets[i + 0].bounds;
-            let mut b1 = buckets[i + 1].bounds;
-
-            for j in 0..=i {
-                b0 = Bounds3f::union(&b0, &buckets[j].bounds);
-                count0 += buckets[j].count;
-            }
-            for j in i + 1..N_BUCKETS {
-                b1 = Bounds3f::union(&b1, &buckets[j].bounds);
-                count1 += buckets[j].count;
-            }
-            cost[i] = 0.5
-                + (count0 as Float * b0.surface_area() + count1 as Float * b1.surface_area())
-                    / bounds.surface_area();
-        }
-        // Find bucket to split at that minimizes SAH metric
-        let mut min_cost = cost[0];
-        let mut min_cost_split_bucket = 0;
-        for i in 1..cost.len() {
-            if cost[i] < min_cost {
-                min_cost = cost[i];
-                min_cost_split_bucket = i;
-            }
-        }
-
-        // Either create leaf or split primitives at selected SAH
-        // bucket
-        let leaf_cost = n_primitives as Float;
-        if n_primitives > max_prims_in_node || min_cost < leaf_cost {
-            let (mut left, mut right): (Vec<BVHPrimitiveInfo>, Vec<BVHPrimitiveInfo>) =
-                primitive_info.iter().partition(|pi| -> bool {
-                    let b = (Float::floor(
-                        N_BUCKETS as Float * centroid_bounds.offset(&pi.centroid)[dim],
-                    ) as i32)
-                        .min(N_BUCKETS as i32 - 1)
-                        .max(0) as usize;
-                    b <= min_cost_split_bucket
-                });
-            let c0 = Some(recursive_build(
-                &mut left,
-                ordered_indices,
-                max_prims_in_node,
-                split_method,
-            ));
-            let c1 = Some(recursive_build(
-                &mut right,
-                ordered_indices,
-                max_prims_in_node,
-                split_method,
-            ));
-            return Box::new(BVHBuildNode::init_interior(dim, c0, c1));
-        } else {
-            // Create leaf _BVHBuildNode_
-            let first_prim_offset = ordered_indices.len();
-            for i in 0..n_primitives {
-                ordered_indices.push(primitive_info[i].primitive_number);
-            }
-            return Box::new(BVHBuildNode::init_leaf(
-                first_prim_offset,
-                n_primitives,
-                &bounds,
-            ));
-        }
+        return Box::new(BVHBuildNode::init_leaf(
+            first_prim_offset,
+            n_primitives,
+            &bounds,
+        ));
     }
 }

--- a/tests/bvh_build.rs
+++ b/tests/bvh_build.rs
@@ -1,4 +1,5 @@
-use pbrt_r4::cpu::bvh::BVHBuildNode;
+use pbrt_r4::cpu::bvh::sah::split_sah;
+use pbrt_r4::cpu::bvh::{BVHBuildNode, BVHPrimitiveInfo, SplitMethod};
 use pbrt_r4::prelude::*;
 
 #[test]
@@ -19,4 +20,36 @@ fn bvh_build_node_interior_without_children_does_not_panic() {
     assert_eq!(interior.bounds, Bounds3f::default());
     assert!(interior.children[0].is_none());
     assert!(interior.children[1].is_none());
+}
+
+#[test]
+fn sah_matches_v4_split_decision_even_below_max_primitives() {
+    let bounds = [
+        Bounds3f::from(((0.0, 0.0, 0.0), (1.0, 1.0, 1.0))),
+        Bounds3f::from(((10.0, 0.0, 0.0), (11.0, 1.0, 1.0))),
+        Bounds3f::from(((20.0, 0.0, 0.0), (21.0, 1.0, 1.0))),
+    ];
+    let mut primitive_info: Vec<_> = bounds
+        .iter()
+        .enumerate()
+        .map(|(index, bound)| {
+            let centroid = (bound.min + bound.max) * 0.5;
+            BVHPrimitiveInfo::new(index, bound, &centroid)
+        })
+        .collect();
+    let mut ordered_indices = Vec::new();
+
+    let node = split_sah(
+        0,
+        &mut primitive_info,
+        &mut ordered_indices,
+        8,
+        SplitMethod::SAH,
+    );
+
+    assert_eq!(node.n_primitives, 0);
+    assert!(node.children[0].is_some());
+    assert!(node.children[1].is_some());
+    assert_eq!(node.primitive_count(), 3);
+    assert_eq!(ordered_indices.len(), 3);
 }


### PR DESCRIPTION
## Summary
- Align recursive SAH construction with the pbrt-v4 buildRecursive path.
- Restore v4 small-node handling for one and two primitives.
- Use v4-style forward/backward SAH cost accumulation and leaf decisions.
- Align BVH/SAH comments and terminology with pbrt-v4.
- Add regression coverage for splitting below the maximum leaf primitive count.

## Validation
- cargo fmt --all
- git diff --check
- cargo test --test bvh_build