### PR TITLE
refactor: own simple primitive shapes by value

### DIFF
--- a/src/base/shape.rs
+++ b/src/base/shape.rs
@@ -64,10 +64,10 @@ impl From<&Interaction> for ShapeSampleContext {
 }
 
 fn wrap_alpha_masks(
-    shapes: Vec<Arc<Shape>>,
+    shapes: Vec<Shape>,
     params: &ParameterDictionary,
     float_textures: &HashMap<String, Arc<FloatTexture>>,
-) -> Result<Vec<Arc<Shape>>, PbrtError> {
+) -> Result<Vec<Shape>, PbrtError> {
     let alpha_mask_info = get_alpha_texture(params, float_textures)?;
     let shadow_alpha_mask_info = get_shadow_alpha_texture(params, float_textures)?;
     if alpha_mask_info.is_none() && shadow_alpha_mask_info.is_none() {
@@ -77,24 +77,14 @@ fn wrap_alpha_masks(
     Ok(shapes
         .into_iter()
         .map(|shape| {
-            Arc::new(Shape::AlphaMask(Box::new(AlphaMaskShape::new(
+            let shape = Arc::new(shape);
+            Shape::AlphaMask(Box::new(AlphaMaskShape::new(
                 &shape,
                 &alpha_mask_info,
                 &shadow_alpha_mask_info,
-            ))))
+            )))
         })
         .collect())
-}
-
-fn into_owned_shapes(shapes: Vec<Arc<Shape>>) -> Result<Vec<Shape>, PbrtError> {
-    shapes
-        .into_iter()
-        .map(|shape| {
-            Arc::try_unwrap(shape).map_err(|_| {
-                PbrtError::error("shape was unexpectedly shared while creating a scene shape")
-            })
-        })
-        .collect()
 }
 
 /// Shape enum that unifies all shape types
@@ -165,9 +155,7 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                let s = Arc::new(Shape::Sphere(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures)
-                    .and_then(into_owned_shapes);
+                return wrap_alpha_masks(vec![Shape::Sphere(Box::new(s))], params, float_textures);
             }
             "cylinder" => {
                 let s = Cylinder::create(
@@ -176,9 +164,11 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                let s = Arc::new(Shape::Cylinder(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures)
-                    .and_then(into_owned_shapes);
+                return wrap_alpha_masks(
+                    vec![Shape::Cylinder(Box::new(s))],
+                    params,
+                    float_textures,
+                );
             }
             "disk" => {
                 let s = Disk::create(
@@ -187,9 +177,7 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                let s = Arc::new(Shape::Disk(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures)
-                    .and_then(into_owned_shapes);
+                return wrap_alpha_masks(vec![Shape::Disk(Box::new(s))], params, float_textures);
             }
             "cone" => {
                 let s = Cone::create(
@@ -198,9 +186,7 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                let s = Arc::new(Shape::Cone(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures)
-                    .and_then(into_owned_shapes);
+                return wrap_alpha_masks(vec![Shape::Cone(Box::new(s))], params, float_textures);
             }
             "paraboloid" => {
                 let s = Paraboloid::create(
@@ -209,9 +195,11 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                let s = Arc::new(Shape::Paraboloid(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures)
-                    .and_then(into_owned_shapes);
+                return wrap_alpha_masks(
+                    vec![Shape::Paraboloid(Box::new(s))],
+                    params,
+                    float_textures,
+                );
             }
             "hyperboloid" => {
                 let s = Hyperboloid::create(
@@ -220,9 +208,11 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                let s = Arc::new(Shape::Hyperboloid(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures)
-                    .and_then(into_owned_shapes);
+                return wrap_alpha_masks(
+                    vec![Shape::Hyperboloid(Box::new(s))],
+                    params,
+                    float_textures,
+                );
             }
             "curve" => {
                 let curves = Curve::create(
@@ -231,12 +221,8 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                let shapes = curves
-                    .into_iter()
-                    .map(|c| Arc::new(Shape::Curve(c)))
-                    .collect();
-                return wrap_alpha_masks(shapes, params, float_textures)
-                    .and_then(into_owned_shapes);
+                let shapes = curves.into_iter().map(Shape::Curve).collect();
+                return wrap_alpha_masks(shapes, params, float_textures);
             }
             "trianglemesh" => {
                 return TriangleMesh::create(
@@ -245,8 +231,7 @@ impl Shape {
                     reverse_orientation,
                     params,
                     float_textures,
-                )
-                .and_then(into_owned_shapes);
+                );
             }
             "bilinearmesh" => {
                 return BilinearPatchMesh::create(
@@ -255,8 +240,7 @@ impl Shape {
                     reverse_orientation,
                     params,
                     float_textures,
-                )
-                .and_then(into_owned_shapes);
+                );
             }
             "plymesh" => {
                 return PlyMesh::create(
@@ -265,8 +249,7 @@ impl Shape {
                     reverse_orientation,
                     params,
                     float_textures,
-                )
-                .and_then(into_owned_shapes);
+                );
             }
             "heightfield" => {
                 let shapes = HeightField::create(
@@ -275,8 +258,7 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                return wrap_alpha_masks(shapes, params, float_textures)
-                    .and_then(into_owned_shapes);
+                return wrap_alpha_masks(shapes, params, float_textures);
             }
             "loopsubdiv" => {
                 let shapes = LoopSubdiv::create(
@@ -285,8 +267,7 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                return wrap_alpha_masks(shapes, params, float_textures)
-                    .and_then(into_owned_shapes);
+                return wrap_alpha_masks(shapes, params, float_textures);
             }
             "nurbs" => {
                 let shapes = NURBS::create(
@@ -295,8 +276,7 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                return wrap_alpha_masks(shapes, params, float_textures)
-                    .and_then(into_owned_shapes);
+                return wrap_alpha_masks(shapes, params, float_textures);
             }
             _ => {
                 return Err(PbrtError::error(&format!("{} shape cannot create", name)));

--- a/src/base/shape.rs
+++ b/src/base/shape.rs
@@ -86,6 +86,17 @@ fn wrap_alpha_masks(
         .collect())
 }
 
+fn into_owned_shapes(shapes: Vec<Arc<Shape>>) -> Result<Vec<Shape>, PbrtError> {
+    shapes
+        .into_iter()
+        .map(|shape| {
+            Arc::try_unwrap(shape).map_err(|_| {
+                PbrtError::error("shape was unexpectedly shared while creating a scene shape")
+            })
+        })
+        .collect()
+}
+
 /// Shape enum that unifies all shape types
 ///
 /// Benefits:
@@ -137,7 +148,7 @@ impl Shape {
     /// * `float_textures` - Map of available float textures for displacement mapping
     ///
     /// # Returns
-    /// * `Result<Vec<Arc<Shape>>, PbrtError>` - Vector of created shapes (may be multiple for meshes)
+    /// * `Result<Vec<Shape>, PbrtError>` - Vector of created shapes (may be multiple for meshes)
     pub fn create(
         name: &str,
         render_from_object: &Transform,
@@ -145,7 +156,7 @@ impl Shape {
         reverse_orientation: bool,
         params: &ParameterDictionary,
         float_textures: &HashMap<String, Arc<FloatTexture>>,
-    ) -> Result<Vec<Arc<Shape>>, PbrtError> {
+    ) -> Result<Vec<Shape>, PbrtError> {
         match name {
             "sphere" => {
                 let s = Sphere::create(
@@ -155,7 +166,8 @@ impl Shape {
                     params,
                 )?;
                 let s = Arc::new(Shape::Sphere(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures);
+                return wrap_alpha_masks(vec![s], params, float_textures)
+                    .and_then(into_owned_shapes);
             }
             "cylinder" => {
                 let s = Cylinder::create(
@@ -165,7 +177,8 @@ impl Shape {
                     params,
                 )?;
                 let s = Arc::new(Shape::Cylinder(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures);
+                return wrap_alpha_masks(vec![s], params, float_textures)
+                    .and_then(into_owned_shapes);
             }
             "disk" => {
                 let s = Disk::create(
@@ -175,7 +188,8 @@ impl Shape {
                     params,
                 )?;
                 let s = Arc::new(Shape::Disk(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures);
+                return wrap_alpha_masks(vec![s], params, float_textures)
+                    .and_then(into_owned_shapes);
             }
             "cone" => {
                 let s = Cone::create(
@@ -185,7 +199,8 @@ impl Shape {
                     params,
                 )?;
                 let s = Arc::new(Shape::Cone(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures);
+                return wrap_alpha_masks(vec![s], params, float_textures)
+                    .and_then(into_owned_shapes);
             }
             "paraboloid" => {
                 let s = Paraboloid::create(
@@ -195,7 +210,8 @@ impl Shape {
                     params,
                 )?;
                 let s = Arc::new(Shape::Paraboloid(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures);
+                return wrap_alpha_masks(vec![s], params, float_textures)
+                    .and_then(into_owned_shapes);
             }
             "hyperboloid" => {
                 let s = Hyperboloid::create(
@@ -205,7 +221,8 @@ impl Shape {
                     params,
                 )?;
                 let s = Arc::new(Shape::Hyperboloid(Box::new(s)));
-                return wrap_alpha_masks(vec![s], params, float_textures);
+                return wrap_alpha_masks(vec![s], params, float_textures)
+                    .and_then(into_owned_shapes);
             }
             "curve" => {
                 let curves = Curve::create(
@@ -218,7 +235,8 @@ impl Shape {
                     .into_iter()
                     .map(|c| Arc::new(Shape::Curve(c)))
                     .collect();
-                return wrap_alpha_masks(shapes, params, float_textures);
+                return wrap_alpha_masks(shapes, params, float_textures)
+                    .and_then(into_owned_shapes);
             }
             "trianglemesh" => {
                 return TriangleMesh::create(
@@ -227,7 +245,8 @@ impl Shape {
                     reverse_orientation,
                     params,
                     float_textures,
-                );
+                )
+                .and_then(into_owned_shapes);
             }
             "bilinearmesh" => {
                 return BilinearPatchMesh::create(
@@ -236,7 +255,8 @@ impl Shape {
                     reverse_orientation,
                     params,
                     float_textures,
-                );
+                )
+                .and_then(into_owned_shapes);
             }
             "plymesh" => {
                 return PlyMesh::create(
@@ -245,7 +265,8 @@ impl Shape {
                     reverse_orientation,
                     params,
                     float_textures,
-                );
+                )
+                .and_then(into_owned_shapes);
             }
             "heightfield" => {
                 let shapes = HeightField::create(
@@ -254,7 +275,8 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                return wrap_alpha_masks(shapes, params, float_textures);
+                return wrap_alpha_masks(shapes, params, float_textures)
+                    .and_then(into_owned_shapes);
             }
             "loopsubdiv" => {
                 let shapes = LoopSubdiv::create(
@@ -263,7 +285,8 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                return wrap_alpha_masks(shapes, params, float_textures);
+                return wrap_alpha_masks(shapes, params, float_textures)
+                    .and_then(into_owned_shapes);
             }
             "nurbs" => {
                 let shapes = NURBS::create(
@@ -272,7 +295,8 @@ impl Shape {
                     reverse_orientation,
                     params,
                 )?;
-                return wrap_alpha_masks(shapes, params, float_textures);
+                return wrap_alpha_masks(shapes, params, float_textures)
+                    .and_then(into_owned_shapes);
             }
             _ => {
                 return Err(PbrtError::error(&format!("{} shape cannot create", name)));

--- a/src/cpu/primitive/geometric_primitive.rs
+++ b/src/cpu/primitive/geometric_primitive.rs
@@ -42,7 +42,6 @@ impl GeometricPrimitive {
 
         let s = self.shape.as_ref();
         if let Some(mut si) = s.intersect(r, t_max) {
-            si.intr.set_shape(&self.shape);
             si.intr.set_intersection_properties(
                 &self.material,
                 &self.area_light,

--- a/src/cpu/primitive/primitive.rs
+++ b/src/cpu/primitive/primitive.rs
@@ -17,9 +17,8 @@ use crate::cpu::aggregates::Accel;
 
 /// Primitive is an enum that can hold different types of primitives
 /// This follows pbrt-v4's TaggedPointer approach
-#[derive(Clone)]
 pub enum Primitive {
-    Simple(SimplePrimitive),
+    Simple(Box<SimplePrimitive>),
     Geometric(Box<GeometricPrimitive>),
     Transformed(TransformedPrimitive),
     Animated(AnimatedPrimitive),
@@ -28,7 +27,7 @@ pub enum Primitive {
 
 impl Primitive {
     pub fn new_geometric(
-        shape: Arc<Shape>,
+        shape: Shape,
         material: &Option<Arc<Material>>,
         area_light: &Option<Arc<Light>>,
         mi: &MediumInterface,
@@ -37,9 +36,24 @@ impl Primitive {
         // fields on every primitive when neither is active.
         if area_light.is_none() && !mi.is_medium_transition() {
             if let Some(material) = material {
-                return Primitive::Simple(SimplePrimitive::new(shape, Arc::clone(material)));
+                return Primitive::Simple(Box::new(SimplePrimitive::new(
+                    shape,
+                    Arc::clone(material),
+                )));
             }
         }
+        let shape = Arc::new(shape);
+        Primitive::Geometric(Box::new(GeometricPrimitive::new(
+            shape, material, area_light, mi,
+        )))
+    }
+
+    pub fn new_geometric_shared(
+        shape: Arc<Shape>,
+        material: &Option<Arc<Material>>,
+        area_light: &Option<Arc<Light>>,
+        mi: &MediumInterface,
+    ) -> Self {
         Primitive::Geometric(Box::new(GeometricPrimitive::new(
             shape, material, area_light, mi,
         )))

--- a/src/cpu/primitive/simple_primitive.rs
+++ b/src/cpu/primitive/simple_primitive.rs
@@ -8,27 +8,25 @@ use crate::util::profile::*;
 use std::sync::Arc;
 
 /// SimplePrimitive represents a shape with a material but no area light or medium interface
-#[derive(Clone)]
 pub struct SimplePrimitive {
-    pub shape: Arc<Shape>,
+    pub shape: Shape,
     pub material: Arc<Material>,
 }
 
 impl SimplePrimitive {
-    pub fn new(shape: Arc<Shape>, material: Arc<Material>) -> Self {
+    pub fn new(shape: Shape, material: Arc<Material>) -> Self {
         SimplePrimitive { shape, material }
     }
 
     pub fn bounds(&self) -> Bounds3f {
-        self.shape.as_ref().world_bound()
+        self.shape.world_bound()
     }
 
     pub fn intersect(&self, r: &Ray, t_max: Float) -> Option<ShapeIntersection> {
         let _p = ProfilePhase::new(Prof::GeometricPrimitiveIntersect);
 
-        let s = self.shape.as_ref();
+        let s = &self.shape;
         if let Some(mut si) = s.intersect(r, t_max) {
-            si.intr.set_shape(&self.shape);
             si.intr.set_intersection_properties(
                 &Some(self.material.clone()),
                 &None,
@@ -43,7 +41,6 @@ impl SimplePrimitive {
     pub fn intersect_p(&self, r: &Ray, t_max: Float) -> bool {
         let _p = ProfilePhase::new(Prof::GeometricPrimitiveIntersectP);
 
-        let s = self.shape.as_ref();
-        s.intersect_p(r, t_max)
+        self.shape.intersect_p(r, t_max)
     }
 }

--- a/src/interaction/surface_interaction.rs
+++ b/src/interaction/surface_interaction.rs
@@ -3,7 +3,6 @@ use crate::base::bxdf::*;
 use crate::base::camera::Camera;
 use crate::base::material::Material;
 use crate::base::sampler::Sampler;
-use crate::base::shape::Shape;
 use crate::base::Light;
 use crate::bsdf::BSDF;
 use crate::bxdfs::DiffuseBxDF;
@@ -16,7 +15,7 @@ use crate::util::geometry::*;
 use crate::util::spectrum::*;
 
 use std::fmt;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct SurfaceInteractionShading {
@@ -40,7 +39,6 @@ pub struct SurfaceInteraction {
     pub dpdv: Vector3f,
     pub dndu: Normal3f,
     pub dndv: Normal3f,
-    pub shape: Option<Weak<Shape>>,
     pub material: Option<Arc<Material>>,
     pub area_light: Option<Arc<Light>>,
     pub shading: SurfaceInteractionShading,
@@ -71,7 +69,6 @@ impl fmt::Debug for SurfaceInteraction {
             .field("dpdv", &self.dpdv)
             .field("dndu", &self.dndu)
             .field("dndv", &self.dndv)
-            .field("has_shape", &self.shape.is_some())
             .field("has_material", &self.material.is_some())
             .field("has_area_light", &self.area_light.is_some())
             .field("shading", &self.shading)
@@ -121,7 +118,6 @@ impl SurfaceInteraction {
             dndu: *dndu,
             dndv: *dndv,
             time,
-            shape: None,
             material: None,
             area_light: None,
             shading,
@@ -184,17 +180,6 @@ impl SurfaceInteraction {
             dndvs,
             orientation_is_authoritative,
         );
-    }
-
-    pub fn set_shape(&mut self, shape: &Arc<Shape>) {
-        self.shape = Some(Arc::downgrade(shape));
-    }
-
-    pub fn get_shape(&self) -> Option<Arc<Shape>> {
-        if let Some(wp) = self.shape.as_ref() {
-            return wp.upgrade();
-        }
-        return None;
     }
 
     pub fn set_intersection_properties(

--- a/src/parser/scene_builder/build.rs
+++ b/src/parser/scene_builder/build.rs
@@ -956,9 +956,9 @@ impl SceneBuilder {
         if animated {
             // Animated shapes: no area light (warned at parse time).
             let mut piece_prims: Vec<Arc<Primitive>> = Vec::with_capacity(shapes.len());
-            for s in &shapes {
+            for s in shapes {
                 let prim = Arc::new(Primitive::new_geometric(
-                    s.clone(),
+                    s,
                     &material,
                     &None,
                     &medium_interface,
@@ -1010,29 +1010,42 @@ impl SceneBuilder {
         // triangle sets get a dedicated accelerator before entering the scene BVH.
         let mut piece_prims = Vec::with_capacity(shapes.len());
         for s in shapes {
-            let area_light = if let Some(al_idx) = shape.area_light_index {
+            if let Some(al_idx) = shape.area_light_index {
                 let al = &self.area_lights[al_idx];
                 let al_params = make_absolute_path(&al.base.params, &self.seen_work_dirs);
                 let al_mi = build_medium_interface(&al.medium_interface, named_media);
-                match Light::create_area(&al.base.name, &object_to_world, &al_mi, &al_params, &s) {
+                let shared_shape = Arc::new(s);
+                let area_light = match Light::create_area(
+                    &al.base.name,
+                    &object_to_world,
+                    &al_mi,
+                    &al_params,
+                    &shared_shape,
+                ) {
                     Ok(l) => {
                         out_area_lights.push(Arc::clone(&l));
-                        Some(l)
+                        l
                     }
                     Err(e) => {
                         return Err(e);
                     }
-                }
+                };
+                let prim = Arc::new(Primitive::new_geometric_shared(
+                    shared_shape,
+                    &material,
+                    &Some(area_light),
+                    &medium_interface,
+                ));
+                piece_prims.push(prim);
             } else {
-                None
-            };
-            let prim = Arc::new(Primitive::new_geometric(
-                s,
-                &material,
-                &area_light,
-                &medium_interface,
-            ));
-            piece_prims.push(prim);
+                let prim = Arc::new(Primitive::new_geometric(
+                    s,
+                    &material,
+                    &None,
+                    &medium_interface,
+                ));
+                piece_prims.push(prim);
+            }
         }
         if use_dedicated_mesh_accelerator && piece_prims.len() > 1 {
             out_prims.push(self.create_shape_accelerator(&piece_prims)?);

--- a/src/shapes/bilinearmesh.rs
+++ b/src/shapes/bilinearmesh.rs
@@ -44,7 +44,7 @@ impl BilinearPatchMesh {
         reverse_orientation: bool,
         params: &ParameterDictionary,
         float_textures: &FloatTextureMap,
-    ) -> Result<Vec<Arc<Shape>>, PbrtError> {
+    ) -> Result<Vec<Shape>, PbrtError> {
         create_bilinear_mesh_shape(o2w, w2o, reverse_orientation, params, float_textures)
     }
 }
@@ -770,7 +770,7 @@ pub fn create_bilinear_mesh_shape(
     reverse_orientation: bool,
     params: &ParameterDictionary,
     float_textures: &FloatTextureMap,
-) -> Result<Vec<Arc<Shape>>, PbrtError> {
+) -> Result<Vec<Shape>, PbrtError> {
     let mut p: Vec<Point3f> = Vec::new();
     if let Some(points) = params.get_points_ref("P") {
         let point_count = points.len() / 3;
@@ -830,7 +830,7 @@ pub fn create_bilinear_mesh_shape(
         face_indices.extend(indices.iter().copied());
     }
 
-    let mut shapes: Vec<Arc<Shape>> = create_bilinear_patch_mesh(
+    let shapes: Vec<Shape> = create_bilinear_patch_mesh(
         o2w,
         w2o,
         reverse_orientation,
@@ -841,19 +841,23 @@ pub fn create_bilinear_mesh_shape(
         face_indices,
     )?
     .into_iter()
-    .map(|patch| Arc::new(Shape::BilinearPatch(patch)))
+    .map(Shape::BilinearPatch)
     .collect();
 
     let alpha_mask_info = get_alpha_texture(params, float_textures)?;
     let shadow_alpha_mask_info = get_shadow_alpha_texture(params, float_textures)?;
     if alpha_mask_info.is_some() || shadow_alpha_mask_info.is_some() {
-        for shape in &mut shapes {
-            *shape = Arc::new(Shape::AlphaMask(Box::new(AlphaMaskShape::new(
-                shape,
-                &alpha_mask_info,
-                &shadow_alpha_mask_info,
-            ))));
-        }
+        return Ok(shapes
+            .into_iter()
+            .map(|shape| {
+                let shape = Arc::new(shape);
+                Shape::AlphaMask(Box::new(AlphaMaskShape::new(
+                    &shape,
+                    &alpha_mask_info,
+                    &shadow_alpha_mask_info,
+                )))
+            })
+            .collect());
     }
 
     Ok(shapes)

--- a/src/shapes/heightfield.rs
+++ b/src/shapes/heightfield.rs
@@ -7,8 +7,6 @@ use crate::util::base::*;
 use crate::util::error::*;
 // Includes cos_theta, abs_cos_theta, same_hemisphere, etc.
 
-use std::sync::Arc;
-
 pub struct HeightField;
 
 impl HeightField {
@@ -17,7 +15,7 @@ impl HeightField {
         w2o: &Transform,
         reverse_orientation: bool,
         params: &ParameterDictionary,
-    ) -> Result<Vec<Arc<Shape>>, PbrtError> {
+    ) -> Result<Vec<Shape>, PbrtError> {
         create_heightfield(o2w, w2o, reverse_orientation, params)
     }
 }
@@ -27,7 +25,7 @@ pub fn create_heightfield(
     w2o: &Transform,
     reverse_orientation: bool,
     params: &ParameterDictionary,
-) -> Result<Vec<Arc<Shape>>, PbrtError> {
+) -> Result<Vec<Shape>, PbrtError> {
     let nx = params.get_one_int("nu", -1);
     let ny = params.get_one_int("nv", -1);
     if nx == -1 || ny == -1 {
@@ -91,10 +89,7 @@ pub fn create_heightfield(
             uvs,
             &nparams,
         )?;
-        let mesh: Vec<Arc<Shape>> = mesh
-            .into_iter()
-            .map(|tri| Arc::new(Shape::Triangle(tri)))
-            .collect();
+        let mesh: Vec<Shape> = mesh.into_iter().map(Shape::Triangle).collect();
         return Ok(mesh);
     } else {
         return Err(PbrtError::error(

--- a/src/shapes/loopsubdiv.rs
+++ b/src/shapes/loopsubdiv.rs
@@ -22,7 +22,7 @@ impl LoopSubdiv {
         w2o: &Transform,
         reverse_orientation: bool,
         params: &ParameterDictionary,
-    ) -> Result<Vec<Arc<Shape>>, PbrtError> {
+    ) -> Result<Vec<Shape>, PbrtError> {
         create_loop_subdiv(o2w, w2o, reverse_orientation, params)
     }
 }
@@ -347,7 +347,7 @@ fn loop_subdiv(
     vertex_indices: Vec<u32>,
     p: Vec<Point3f>,
     params: &ParameterDictionary,
-) -> Result<Vec<Arc<Shape>>, PbrtError> {
+) -> Result<Vec<Shape>, PbrtError> {
     let mut vertices = Vec::new();
     let mut faces = Vec::new();
 
@@ -732,10 +732,7 @@ fn loop_subdiv(
         _uv,
         params,
     )?;
-    let mesh: Vec<Arc<Shape>> = mesh
-        .into_iter()
-        .map(|tri| Arc::new(Shape::Triangle(tri)))
-        .collect();
+    let mesh: Vec<Shape> = mesh.into_iter().map(Shape::Triangle).collect();
     return Ok(mesh);
 }
 
@@ -744,7 +741,7 @@ pub fn create_loop_subdiv(
     w2o: &Transform,
     reverse_orientation: bool,
     params: &ParameterDictionary,
-) -> Result<Vec<Arc<Shape>>, PbrtError> {
+) -> Result<Vec<Shape>, PbrtError> {
     let n_levels = params.get_one_int("levels", params.get_one_int("nlevels", 3));
 
     let mut vertex_indices = Vec::new();

--- a/src/shapes/nurbs.rs
+++ b/src/shapes/nurbs.rs
@@ -6,8 +6,6 @@ use crate::util::base::*;
 use crate::util::error::*;
 // Includes cos_theta, abs_cos_theta, same_hemisphere, etc.
 
-use std::sync::Arc;
-
 use super::create_triangle_mesh;
 
 pub struct NURBS;
@@ -18,7 +16,7 @@ impl NURBS {
         w2o: &Transform,
         reverse_orientation: bool,
         params: &ParameterDictionary,
-    ) -> Result<Vec<Arc<Shape>>, PbrtError> {
+    ) -> Result<Vec<Shape>, PbrtError> {
         create_nurbs(o2w, w2o, reverse_orientation, params)
     }
 }
@@ -198,7 +196,7 @@ fn create_tesselated_mesh(
     vrange: (Float, Float),
     dicev: usize,
     pw: &[Homogeneous3],
-) -> Result<Vec<Arc<Shape>>, PbrtError> {
+) -> Result<Vec<Shape>, PbrtError> {
     let u0 = urange.0;
     let u1 = urange.1;
     let v0 = vrange.0;
@@ -265,10 +263,7 @@ fn create_tesselated_mesh(
         uvs,
         &params,
     )?;
-    let mesh: Vec<Arc<Shape>> = mesh
-        .into_iter()
-        .map(|tri| Arc::new(Shape::Triangle(tri)))
-        .collect();
+    let mesh: Vec<Shape> = mesh.into_iter().map(Shape::Triangle).collect();
     return Ok(mesh);
 }
 
@@ -289,7 +284,7 @@ pub fn create_nurbs(
     w2o: &Transform,
     reverse_orientation: bool,
     params: &ParameterDictionary,
-) -> Result<Vec<Arc<Shape>>, PbrtError> {
+) -> Result<Vec<Shape>, PbrtError> {
     let nu = params.get_one_int("nu", -1);
     if nu == -1 {
         return Err(PbrtError::error(

--- a/src/shapes/plymesh.rs
+++ b/src/shapes/plymesh.rs
@@ -19,6 +19,25 @@ use std::sync::Arc;
 
 type FloatTextureMap = HashMap<String, Arc<FloatTexture>>;
 
+fn memory_probe_ply_stage(stage: &str, filename: &str) {
+    if std::env::var_os("PBRT_MEMORY_PROFILE").is_none() {
+        return;
+    }
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    let rss_kb = status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmRSS:")
+                .and_then(|rest| rest.split_whitespace().next())
+                .and_then(|value| value.parse::<u64>().ok())
+        })
+        .unwrap_or(0);
+    eprintln!(
+        "[MEM-INVESTIGATION] ply-stage={} rss_kb={} file={}",
+        stage, rss_kb, filename
+    );
+}
+
 pub struct PlyMesh;
 
 pub fn create_ply_mesh(
@@ -27,9 +46,10 @@ pub fn create_ply_mesh(
     reverse_orientation: bool,
     params: &ParameterDictionary,
     float_textures: &FloatTextureMap,
-) -> Result<Vec<Arc<Shape>>, PbrtError> {
+) -> Result<Vec<Shape>, PbrtError> {
     let filename = params.get_one_string("filename", "");
     let mut tri_quad_mesh = TriQuadMesh::read_ply(&filename)?;
+    memory_probe_ply_stage("read", &filename);
 
     let edge_length =
         params.get_one_float("edgelength", 1.0) * PbrtOptions::get().displacement_edge_scale;
@@ -61,8 +81,9 @@ pub fn create_ply_mesh(
         )?;
     }
 
-    let mut mesh: Vec<Arc<Shape>> = Vec::new();
+    let mut mesh: Vec<Shape> = Vec::new();
     if !tri_quad_mesh.tri_indices.is_empty() {
+        memory_probe_ply_stage("before-triangle-clone", &filename);
         let tris = create_triangle_mesh(
             o2w,
             w2o,
@@ -74,7 +95,8 @@ pub fn create_ply_mesh(
             tri_quad_mesh.uv.clone(),
             params,
         )?;
-        mesh.extend(tris.into_iter().map(|tri| Arc::new(Shape::Triangle(tri))));
+        memory_probe_ply_stage("after-triangle-create", &filename);
+        mesh.extend(tris.into_iter().map(Shape::Triangle));
     }
     if !tri_quad_mesh.quad_indices.is_empty() {
         let patches = create_bilinear_patch_mesh(
@@ -87,11 +109,7 @@ pub fn create_ply_mesh(
             tri_quad_mesh.uv,
             tri_quad_mesh.face_indices,
         )?;
-        mesh.extend(
-            patches
-                .into_iter()
-                .map(|patch| Arc::new(Shape::BilinearPatch(patch))),
-        );
+        mesh.extend(patches.into_iter().map(Shape::BilinearPatch));
     }
     if mesh.is_empty() {
         warn!(
@@ -103,13 +121,17 @@ pub fn create_ply_mesh(
     let alpha_mask_info = get_alpha_texture(params, float_textures)?;
     let shadow_alpha_mask_info = get_shadow_alpha_texture(params, float_textures)?;
     if alpha_mask_info.is_some() || shadow_alpha_mask_info.is_some() {
-        for i in 0..mesh.len() {
-            mesh[i] = Arc::new(Shape::AlphaMask(Box::new(AlphaMaskShape::new(
-                &mesh[i],
-                &alpha_mask_info,
-                &shadow_alpha_mask_info,
-            ))));
-        }
+        return Ok(mesh
+            .into_iter()
+            .map(|shape| {
+                let shape = Arc::new(shape);
+                Shape::AlphaMask(Box::new(AlphaMaskShape::new(
+                    &shape,
+                    &alpha_mask_info,
+                    &shadow_alpha_mask_info,
+                )))
+            })
+            .collect());
     }
 
     Ok(mesh)
@@ -122,7 +144,7 @@ impl PlyMesh {
         reverse_orientation: bool,
         params: &ParameterDictionary,
         float_textures: &FloatTextureMap,
-    ) -> Result<Vec<Arc<Shape>>, PbrtError> {
+    ) -> Result<Vec<Shape>, PbrtError> {
         create_ply_mesh(o2w, w2o, reverse_orientation, params, float_textures)
     }
 }

--- a/src/shapes/plymesh.rs
+++ b/src/shapes/plymesh.rs
@@ -19,25 +19,6 @@ use std::sync::Arc;
 
 type FloatTextureMap = HashMap<String, Arc<FloatTexture>>;
 
-fn memory_probe_ply_stage(stage: &str, filename: &str) {
-    if std::env::var_os("PBRT_MEMORY_PROFILE").is_none() {
-        return;
-    }
-    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
-    let rss_kb = status
-        .lines()
-        .find_map(|line| {
-            line.strip_prefix("VmRSS:")
-                .and_then(|rest| rest.split_whitespace().next())
-                .and_then(|value| value.parse::<u64>().ok())
-        })
-        .unwrap_or(0);
-    eprintln!(
-        "[MEM-INVESTIGATION] ply-stage={} rss_kb={} file={}",
-        stage, rss_kb, filename
-    );
-}
-
 pub struct PlyMesh;
 
 pub fn create_ply_mesh(
@@ -49,7 +30,6 @@ pub fn create_ply_mesh(
 ) -> Result<Vec<Shape>, PbrtError> {
     let filename = params.get_one_string("filename", "");
     let mut tri_quad_mesh = TriQuadMesh::read_ply(&filename)?;
-    memory_probe_ply_stage("read", &filename);
 
     let edge_length =
         params.get_one_float("edgelength", 1.0) * PbrtOptions::get().displacement_edge_scale;
@@ -83,7 +63,6 @@ pub fn create_ply_mesh(
 
     let mut mesh: Vec<Shape> = Vec::new();
     if !tri_quad_mesh.tri_indices.is_empty() {
-        memory_probe_ply_stage("before-triangle-clone", &filename);
         let tris = create_triangle_mesh(
             o2w,
             w2o,
@@ -95,7 +74,6 @@ pub fn create_ply_mesh(
             tri_quad_mesh.uv.clone(),
             params,
         )?;
-        memory_probe_ply_stage("after-triangle-create", &filename);
         mesh.extend(tris.into_iter().map(Shape::Triangle));
     }
     if !tri_quad_mesh.quad_indices.is_empty() {

--- a/src/shapes/triangle.rs
+++ b/src/shapes/triangle.rs
@@ -19,25 +19,6 @@ use std::sync::Arc;
 thread_local!(static TESTS: StatPercent = StatPercent::new("Intersections/Ray-triangle intersection tests"));
 thread_local!(static TRI_MESH_BYTES: StatMemoryCounter = StatMemoryCounter::new("Memory/Triangle meshes"));
 
-fn memory_probe_triangle(stage: &str, count: usize) {
-    if std::env::var_os("PBRT_MEMORY_PROFILE").is_none() {
-        return;
-    }
-    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
-    let rss_kb = status
-        .lines()
-        .find_map(|line| {
-            line.strip_prefix("VmRSS:")
-                .and_then(|rest| rest.split_whitespace().next())
-                .and_then(|value| value.parse::<u64>().ok())
-        })
-        .unwrap_or(0);
-    eprintln!(
-        "[MEM-INVESTIGATION] triangle-stage={} rss_kb={} count={}",
-        stage, rss_kb, count
-    );
-}
-
 pub struct TriangleMesh {
     pub object_to_world: Transform,
     pub world_to_object: Transform,
@@ -957,7 +938,6 @@ pub fn create_triangle_mesh(
         n,
         uv,
     ));
-    memory_probe_triangle("mesh-created", n_triangles);
     let mut tris: Vec<Triangle> = Vec::with_capacity(n_triangles);
     for i in 0..n_triangles {
         let tri = Triangle::new(&mesh, i as u32);
@@ -965,7 +945,6 @@ pub fn create_triangle_mesh(
             tris.push(tri);
         }
     }
-    memory_probe_triangle("triangles-created", tris.len());
     return Ok(tris);
 }
 

--- a/src/shapes/triangle.rs
+++ b/src/shapes/triangle.rs
@@ -19,6 +19,25 @@ use std::sync::Arc;
 thread_local!(static TESTS: StatPercent = StatPercent::new("Intersections/Ray-triangle intersection tests"));
 thread_local!(static TRI_MESH_BYTES: StatMemoryCounter = StatMemoryCounter::new("Memory/Triangle meshes"));
 
+fn memory_probe_triangle(stage: &str, count: usize) {
+    if std::env::var_os("PBRT_MEMORY_PROFILE").is_none() {
+        return;
+    }
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    let rss_kb = status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmRSS:")
+                .and_then(|rest| rest.split_whitespace().next())
+                .and_then(|value| value.parse::<u64>().ok())
+        })
+        .unwrap_or(0);
+    eprintln!(
+        "[MEM-INVESTIGATION] triangle-stage={} rss_kb={} count={}",
+        stage, rss_kb, count
+    );
+}
+
 pub struct TriangleMesh {
     pub object_to_world: Transform,
     pub world_to_object: Transform,
@@ -115,7 +134,7 @@ impl TriangleMesh {
         reverse_orientation: bool,
         params: &ParameterDictionary,
         float_textures: &HashMap<String, Arc<FloatTexture>>,
-    ) -> Result<Vec<Arc<Shape>>, PbrtError> {
+    ) -> Result<Vec<Shape>, PbrtError> {
         create_triangle_mesh_shape(o2w, w2o, reverse_orientation, params, float_textures)
     }
 }
@@ -938,6 +957,7 @@ pub fn create_triangle_mesh(
         n,
         uv,
     ));
+    memory_probe_triangle("mesh-created", n_triangles);
     let mut tris: Vec<Triangle> = Vec::with_capacity(n_triangles);
     for i in 0..n_triangles {
         let tri = Triangle::new(&mesh, i as u32);
@@ -945,6 +965,7 @@ pub fn create_triangle_mesh(
             tris.push(tri);
         }
     }
+    memory_probe_triangle("triangles-created", tris.len());
     return Ok(tris);
 }
 
@@ -956,7 +977,7 @@ pub fn create_triangle_mesh_shape(
     reverse_orientation: bool,
     params: &ParameterDictionary,
     float_textures: &FloatTextureMap,
-) -> Result<Vec<Arc<Shape>>, PbrtError> {
+) -> Result<Vec<Shape>, PbrtError> {
     let mut vertex_indices = Vec::new();
     let mut p: Vec<Point3f> = Vec::new();
     let mut s: Vec<Vector3f> = Vec::new();
@@ -1023,21 +1044,22 @@ pub fn create_triangle_mesh_shape(
             uv,
             params,
         )?;
-        let mut mesh: Vec<Arc<Shape>> = mesh
-            .into_iter()
-            .map(|tri| Arc::new(Shape::Triangle(tri)))
-            .collect();
+        let mesh: Vec<Shape> = mesh.into_iter().map(Shape::Triangle).collect();
 
         let alpha_mask_info = get_alpha_texture(params, float_textures)?;
         let shadow_alpha_mask_info = get_shadow_alpha_texture(params, float_textures)?;
         if alpha_mask_info.is_some() || shadow_alpha_mask_info.is_some() {
-            for i in 0..mesh.len() {
-                mesh[i] = Arc::new(Shape::AlphaMask(Box::new(AlphaMaskShape::new(
-                    &mesh[i],
-                    &alpha_mask_info,
-                    &shadow_alpha_mask_info,
-                ))));
-            }
+            return Ok(mesh
+                .into_iter()
+                .map(|shape| {
+                    let shape = Arc::new(shape);
+                    Shape::AlphaMask(Box::new(AlphaMaskShape::new(
+                        &shape,
+                        &alpha_mask_info,
+                        &shadow_alpha_mask_info,
+                    )))
+                })
+                .collect());
         }
         return Ok(mesh);
     } else {

--- a/tests/plymesh_create.rs
+++ b/tests/plymesh_create.rs
@@ -133,5 +133,5 @@ end_header
     .expect("ply quad should parse into a bilinear patch");
 
     assert_eq!(shapes.len(), 1);
-    assert!(matches!(shapes[0].as_ref(), Shape::BilinearPatch(_)));
+    assert!(matches!(shapes[0], Shape::BilinearPatch(_)));
 }

--- a/tests/primitive_layout.rs
+++ b/tests/primitive_layout.rs
@@ -6,7 +6,7 @@ use pbrt_r4::cpu::primitive::{
 #[test]
 fn primitive_enum_stays_small_for_triangle_heavy_scenes() {
     assert!(std::mem::size_of::<Primitive>() <= 24);
-    assert_eq!(std::mem::size_of::<SimplePrimitive>(), 16);
+    assert_eq!(std::mem::size_of::<SimplePrimitive>(), 40);
     assert_eq!(std::mem::size_of::<TransformedPrimitive>(), 16);
     assert_eq!(std::mem::size_of::<AnimatedPrimitive>(), 16);
     assert_eq!(std::mem::size_of::<Accel>(), 16);

--- a/tests/shape_enum.rs
+++ b/tests/shape_enum.rs
@@ -127,7 +127,7 @@ fn test_shape_create_bilinear_mesh() {
     .unwrap();
 
     assert_eq!(shapes.len(), 1);
-    assert!(matches!(shapes[0].as_ref(), Shape::BilinearPatch(_)));
+    assert!(matches!(shapes[0], Shape::BilinearPatch(_)));
 }
 
 #[test]

--- a/tests/shapes.rs
+++ b/tests/shapes.rs
@@ -64,6 +64,7 @@ fn constant_zero_alpha_area_light_is_delta_position() {
     )
     .expect("sphere shape")
     .remove(0);
+    let shape = Arc::new(shape);
 
     let light = Light::create_area(
         "diffuse",


### PR DESCRIPTION
## Summary
- Return owned `Shape` values from `Shape::create()`.
- Store simple primitive shapes by value while preserving `Arc<Shape>` for shared area-light and alpha-mask paths.
- Remove the redundant `Shape` reference from `SurfaceInteraction`.

## Validation
- `cargo fmt --all`
- `cargo check --lib`
- `cargo build --release`
- focused shape, primitive, accelerator, and alpha tests
- crown_tiny memory measurement: no significant RSS regression observed.