### PR TITLE
feat(texture): add ColorEncoding model

### DIFF
--- a/src/base/texture.rs
+++ b/src/base/texture.rs
@@ -5,6 +5,7 @@ use crate::paramdict::*;
 use crate::textures::*;
 use crate::util::base::*;
 use crate::util::error::*;
+use crate::util::imageio::ColorEncoding;
 use crate::util::spectrum::*;
 use crate::util::transform::*;
 
@@ -36,7 +37,7 @@ pub struct TexInfo {
     pub swrap_mode: ImageWrap,
     pub twrap_mode: ImageWrap,
     pub scale: Float,
-    pub gamma: bool,
+    pub encoding: ColorEncoding,
     pub flip_y: bool,
 }
 

--- a/src/cmd/imgtool/mod.rs
+++ b/src/cmd/imgtool/mod.rs
@@ -5,7 +5,7 @@ use pbrt_r4::util::error::PbrtError;
 use pbrt_r4::util::geometry::{equal_area_square_to_sphere, spherical_theta, Bounds2i, Vector2};
 use pbrt_r4::util::image::{Image, ImageMetadata, PixelFormat};
 use pbrt_r4::util::imageio::{
-    read_raw_image_exr_with_channels_and_metadata, read_raw_image_gamma_correct,
+    read_raw_image_exr_with_channels_and_metadata, read_raw_image_with_encoding, ColorEncoding,
 };
 use pbrt_r4::util::imageio::{write_image_bytes, RawImage, RawImageData};
 use pbrt_r4::util::math::safe_acos;
@@ -184,7 +184,7 @@ fn load_image(path: &Path) -> Result<LoadedImage, ImgToolError> {
             metadata,
         })
     } else {
-        let raw = read_raw_image_gamma_correct(path_string, false)?;
+        let raw = read_raw_image_with_encoding(path_string, ColorEncoding::Linear)?;
         let channel_names = raw.channel_names();
         let metadata = ImageMetadata {
             color_space: Some(&SRGB),

--- a/src/cmd/plytool.rs
+++ b/src/cmd/plytool.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use pbrt_r4::util::base::{Float, Normal3f, Point2f, Point3f, Vector3f};
 use pbrt_r4::util::geometry::Bounds3f;
 use pbrt_r4::util::image::{Image, ImageWrapMode};
-use pbrt_r4::util::imageio::read_raw_image_gamma_correct;
+use pbrt_r4::util::imageio::{read_raw_image_with_encoding, ColorEncoding};
 use pbrt_r4::util::mesh::TriQuadMesh;
 
 #[derive(Debug)]
@@ -197,7 +197,7 @@ fn displace(args: &[OsString]) -> Result<(), PlyToolError> {
     let image_path = required_path(image_path, "image displacement map")?;
     let output = required_path(output, "output PLY filename")?;
     let mesh = read_mesh(&source)?;
-    let raw = read_raw_image_gamma_correct(&image_path, false).map_err(error)?;
+    let raw = read_raw_image_with_encoding(&image_path, ColorEncoding::Linear).map_err(error)?;
     let image = Image::from_channels(raw.resolution, raw.channel_names(), raw.data_f32());
     let displaced = mesh
         .displace(

--- a/src/materials/normal_bump.rs
+++ b/src/materials/normal_bump.rs
@@ -3,7 +3,7 @@ use crate::paramdict::TextureParameterDictionary;
 use crate::textures::{FloatTexture, TextureEvalContext};
 use crate::util::base::*;
 use crate::util::error::PbrtError;
-use crate::util::imageio::{read_raw_image_gamma_correct, RawImage};
+use crate::util::imageio::{read_raw_image_with_encoding, ColorEncoding, RawImage};
 use crate::util::sampling::gram_schmidt;
 use crate::util::vecmath::Frame;
 
@@ -15,7 +15,7 @@ pub struct NormalMap {
 
 impl NormalMap {
     pub fn read(filename: &str) -> Result<Self, PbrtError> {
-        let raw = read_raw_image_gamma_correct(filename, false)?;
+        let raw = read_raw_image_with_encoding(filename, ColorEncoding::Linear)?;
         if raw.channels < 3 {
             return Err(PbrtError::error(&format!(
                 "{}: normal map image must contain R, G, and B channels",

--- a/src/textures/imagemap.rs
+++ b/src/textures/imagemap.rs
@@ -134,7 +134,7 @@ impl ImageTexture<Float, Float> {
         let texinfo = create_texinfo(parameters)?
             .ok_or_else(|| PbrtError::error("Image texture requires a non-empty filename."))?;
         let scale = texinfo.scale;
-        let gamma = texinfo.gamma;
+        let encoding = texinfo.encoding;
         let invert = parameters.get_one_bool("invert", false);
         let mipmap_texinfo = mipmap_texinfo(&texinfo);
         let mipmap_key = mipmap_key(&texinfo);
@@ -182,7 +182,7 @@ impl ImageTexture<Float, Float> {
         };
 
         let _p = ProfilePhase::new(Prof::TextureLoading);
-        let raw = read_raw_image_gamma_correct(&texinfo.filename, gamma)?;
+        let raw = read_raw_image_with_encoding(&texinfo.filename, encoding)?;
         let (mut data, channels) = normalize_raw_image_for_float(&raw)?;
         if texinfo.flip_y {
             flip_y(&mut data, &raw.resolution, channels);
@@ -305,16 +305,6 @@ impl ImageTexture<RGBSpectrum, Spectrum> {
         Spectrum::rgb_to_sampled(rgb, self.spectrum_type, lambda)
     }
 
-    fn igc(from: &RGBSpectrum) -> RGBSpectrum {
-        let rgb = from.to_rgb();
-        let rgb: Vec<Float> = rgb.iter().map(|x| inverse_gamma_correct(*x)).collect();
-        return RGBSpectrum::from(rgb);
-    }
-
-    pub fn convert_in(from: &RGBSpectrum, scale: Float, gamma: bool) -> RGBSpectrum {
-        return (if gamma { Self::igc(from) } else { *from }) * scale;
-    }
-
     pub fn convert_out(from: &RGBSpectrum, spectrum_type: SpectrumType) -> Spectrum {
         return Spectrum::from_rgb(&from.to_rgb(), spectrum_type);
     }
@@ -352,7 +342,7 @@ impl ImageTexture<RGBSpectrum, Spectrum> {
         let texinfo = create_texinfo(parameters)?
             .ok_or_else(|| PbrtError::error("Image texture requires a non-empty filename."))?;
         let scale = texinfo.scale;
-        let gamma = texinfo.gamma;
+        let encoding = texinfo.encoding;
         let invert = parameters.get_one_bool("invert", false);
         let mipmap_texinfo = mipmap_texinfo(&texinfo);
         let mipmap_key = mipmap_key(&texinfo);
@@ -394,14 +384,7 @@ impl ImageTexture<RGBSpectrum, Spectrum> {
         };
 
         let _p = ProfilePhase::new(Prof::TextureLoading);
-        let (mut data, resolution) = read_image_gamma_correct(&texinfo.filename, false)?;
-        // Apply scale / gamma in place — the old `.iter().map().collect()`
-        // path held the source Vec live alongside its freshly-allocated
-        // collected copy, doubling the largest transient allocation on
-        // sky.exr-class textures.
-        for spec in data.iter_mut() {
-            *spec = SpectrumImageTexture::convert_in(spec, 1.0, gamma);
-        }
+        let (mut data, resolution) = read_image_with_encoding(&texinfo.filename, encoding)?;
         if texinfo.flip_y {
             flip_y(&mut data, &resolution, 1);
         }
@@ -448,7 +431,7 @@ fn spectrum_mipmap_storage(texinfo: &TexInfo, resolution: &Point2i) -> MIPMapSto
         MIPMapStorageKind::F16
     } else {
         MIPMapStorageKind::U8 {
-            gamma: texinfo.gamma,
+            encoding: texinfo.encoding,
         }
     }
 }
@@ -530,13 +513,36 @@ pub fn create_texinfo(
     }
 
     let scale = parameters.get_one_float("scale", 1.0);
-    let gamma = {
-        let default_gamma = !has_extension(&filename, "exr");
-        let encoding = parameters.get_one_string("encoding", "");
-        if !encoding.is_empty() {
-            !matches!(encoding.as_str(), "linear")
+    let encoding = {
+        let default_encoding = if has_extension(&filename, "png") {
+            "sRGB"
         } else {
-            parameters.get_one_bool("gamma", default_gamma)
+            "linear"
+        };
+        let encoding_name = parameters.get_one_string("encoding", "");
+        if !encoding_name.is_empty() {
+            ColorEncoding::parse(&encoding_name)?
+        } else if parameters.parameter_dictionary().has_parameter("gamma") {
+            if !parameters
+                .parameter_dictionary()
+                .get_floats("gamma")
+                .is_empty()
+            {
+                ColorEncoding::parse(&format!(
+                    "gamma {}",
+                    parameters
+                        .parameter_dictionary()
+                        .get_one_float("gamma", 0.0)
+                ))?
+            } else {
+                ColorEncoding::from_legacy_gamma(
+                    parameters
+                        .parameter_dictionary()
+                        .get_one_bool("gamma", false),
+                )
+            }
+        } else {
+            ColorEncoding::parse(default_encoding)?
         }
     };
 
@@ -548,7 +554,7 @@ pub fn create_texinfo(
         swrap_mode,
         twrap_mode,
         scale,
-        gamma,
+        encoding,
         flip_y: true,
     }))
 }

--- a/src/textures/mipmap.rs
+++ b/src/textures/mipmap.rs
@@ -19,17 +19,20 @@ thread_local!(static N_EWA_LOOKUPS: StatCounter = StatCounter::new("Texture/EWA 
 thread_local!(static N_TRILERP_LOOKUPS: StatCounter = StatCounter::new("Texture/Trilinear lookups"));
 thread_local!(static MIP_MAP_MEMORY: StatMemoryCounter = StatMemoryCounter::new("Memory/Texture MIP maps"));
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MIPMapStorageKind {
     F32,
     F16,
-    U8 { gamma: bool },
+    U8 { encoding: ColorEncoding },
 }
 
 pub enum MIPMapLevelStorage {
     F32(Vec<f32>),
     F16(Vec<half::f16>),
-    U8 { data: Vec<u8>, gamma: bool },
+    U8 {
+        data: Vec<u8>,
+        encoding: ColorEncoding,
+    },
 }
 
 impl MIPMapLevelStorage {
@@ -39,19 +42,15 @@ impl MIPMapLevelStorage {
             MIPMapStorageKind::F16 => {
                 MIPMapLevelStorage::F16(data.into_iter().map(half::f16::from_f32).collect())
             }
-            MIPMapStorageKind::U8 { gamma } => MIPMapLevelStorage::U8 {
+            MIPMapStorageKind::U8 { encoding } => MIPMapLevelStorage::U8 {
                 data: data
                     .into_iter()
                     .map(|v| {
-                        let v = if gamma {
-                            gamma_correct(v as Float)
-                        } else {
-                            v as Float
-                        };
+                        let v = encoding.from_linear(v as Float);
                         (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8
                     })
                     .collect(),
-                gamma,
+                encoding,
             },
         }
     }
@@ -60,13 +59,9 @@ impl MIPMapLevelStorage {
         match self {
             MIPMapLevelStorage::F32(data) => data[i],
             MIPMapLevelStorage::F16(data) => data[i].to_f32(),
-            MIPMapLevelStorage::U8 { data, gamma } => {
+            MIPMapLevelStorage::U8 { data, encoding } => {
                 let v = data[i] as Float / 255.0;
-                if *gamma {
-                    inverse_gamma_correct(v) as f32
-                } else {
-                    v as f32
-                }
+                encoding.to_linear(v) as f32
             }
         }
     }
@@ -75,15 +70,11 @@ impl MIPMapLevelStorage {
         match self {
             MIPMapLevelStorage::F32(data) => data.clone(),
             MIPMapLevelStorage::F16(data) => data.iter().map(|v| v.to_f32()).collect(),
-            MIPMapLevelStorage::U8 { data, gamma } => data
+            MIPMapLevelStorage::U8 { data, encoding } => data
                 .iter()
                 .map(|v| {
                     let v = *v as Float / 255.0;
-                    if *gamma {
-                        inverse_gamma_correct(v) as f32
-                    } else {
-                        v as f32
-                    }
+                    encoding.to_linear(v) as f32
                 })
                 .collect(),
         }

--- a/src/util/imageio/color_encoding.rs
+++ b/src/util/imageio/color_encoding.rs
@@ -1,0 +1,83 @@
+use crate::util::base::{gamma_correct, inverse_gamma_correct, Float};
+use crate::util::error::PbrtError;
+
+/// The color encoding used to convert byte image samples to and from linear
+/// values. This is the CPU-side counterpart of pbrt-v4's ColorEncoding.
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum ColorEncoding {
+    Linear,
+    SRgb,
+    Gamma(Float),
+}
+
+impl ColorEncoding {
+    pub fn parse(name: &str) -> Result<Self, PbrtError> {
+        match name {
+            "linear" => Ok(Self::Linear),
+            "sRGB" | "srgb" => Ok(Self::SRgb),
+            _ => {
+                let mut parts = name.split_whitespace();
+                if parts.next() != Some("gamma") {
+                    return Err(PbrtError::error(&format!(
+                        "Unknown color encoding \"{}\".",
+                        name
+                    )));
+                }
+                let gamma = parts.next().ok_or_else(|| {
+                    PbrtError::error(&format!(
+                        "Color encoding \"{}\" requires a gamma value.",
+                        name
+                    ))
+                })?;
+                if parts.next().is_some() {
+                    return Err(PbrtError::error(&format!(
+                        "Invalid color encoding \"{}\".",
+                        name
+                    )));
+                }
+                let gamma = gamma.parse::<Float>().map_err(|_| {
+                    PbrtError::error(&format!("Invalid color encoding gamma \"{}\".", gamma))
+                })?;
+                if gamma <= 0.0 {
+                    return Err(PbrtError::error(&format!(
+                        "Color encoding gamma must be positive: {}.",
+                        gamma
+                    )));
+                }
+                Ok(Self::Gamma(gamma))
+            }
+        }
+    }
+
+    pub fn from_legacy_gamma(gamma: bool) -> Self {
+        if gamma {
+            Self::SRgb
+        } else {
+            Self::Linear
+        }
+    }
+
+    pub fn to_linear(self, encoded: Float) -> Float {
+        match self {
+            Self::Linear => encoded,
+            Self::SRgb => inverse_gamma_correct(encoded),
+            Self::Gamma(gamma) => encoded.powf(gamma),
+        }
+    }
+
+    pub fn from_linear(self, linear: Float) -> Float {
+        match self {
+            Self::Linear => linear,
+            Self::SRgb => gamma_correct(linear),
+            Self::Gamma(gamma) => linear.max(0.0).powf(1.0 / gamma),
+        }
+    }
+
+    pub fn name(self) -> String {
+        match self {
+            Self::Linear => "linear".to_string(),
+            Self::SRgb => "sRGB".to_string(),
+            Self::Gamma(gamma) => format!("gamma {}", gamma),
+        }
+    }
+}

--- a/src/util/imageio/mod.rs
+++ b/src/util/imageio/mod.rs
@@ -1,9 +1,11 @@
+pub mod color_encoding;
 pub mod read_image;
 pub mod read_image_exr;
 pub mod read_image_pfm;
 pub mod write_image;
 pub mod write_image_exr;
 
+pub use color_encoding::*;
 pub use read_image::*;
 pub use read_image_exr::*;
 pub use write_image::*;

--- a/src/util/imageio/read_image.rs
+++ b/src/util/imageio/read_image.rs
@@ -1,3 +1,4 @@
+use super::color_encoding::ColorEncoding;
 use super::read_image_pfm::*;
 use crate::util::base::*;
 use crate::util::error::*;
@@ -17,7 +18,10 @@ pub struct RawImage {
 pub enum RawImageData {
     F32(Vec<Float>),
     F16(Vec<half::f16>),
-    U8 { data: Vec<u8>, gamma: bool },
+    U8 {
+        data: Vec<u8>,
+        encoding: ColorEncoding,
+    },
 }
 
 impl RawImage {
@@ -44,13 +48,9 @@ impl RawImage {
         match &self.data {
             RawImageData::F32(data) => data[index],
             RawImageData::F16(data) => data[index].to_f32() as Float,
-            RawImageData::U8 { data, gamma } => {
+            RawImageData::U8 { data, encoding } => {
                 let v = data[index] as Float / 255.0;
-                if *gamma {
-                    inverse_gamma_correct(v)
-                } else {
-                    v
-                }
+                encoding.to_linear(v)
             }
         }
     }
@@ -67,7 +67,10 @@ impl RawImage {
     }
 }
 
-fn convert_from_luma8(img: &image::GrayImage, gamma: bool) -> (Vec<RGBSpectrum>, Point2i) {
+fn convert_from_luma8(
+    img: &image::GrayImage,
+    encoding: ColorEncoding,
+) -> (Vec<RGBSpectrum>, Point2i) {
     let (width, height) = img.dimensions();
     let mut spcs = vec![RGBSpectrum::zero(); (width * height) as usize];
     for y in 0..height {
@@ -76,9 +79,7 @@ fn convert_from_luma8(img: &image::GrayImage, gamma: bool) -> (Vec<RGBSpectrum>,
             let pixel = img[(x, y)];
             let mut r = pixel[0] as Float / 255.0;
 
-            if gamma {
-                r = inverse_gamma_correct(r);
-            }
+            r = encoding.to_linear(r);
 
             spcs[index] = RGBSpectrum::rgb_from_rgb(&[r, r, r]);
         }
@@ -86,19 +87,22 @@ fn convert_from_luma8(img: &image::GrayImage, gamma: bool) -> (Vec<RGBSpectrum>,
     return (spcs, Point2i::from((width as i32, height as i32)));
 }
 
-fn convert_raw_from_luma8(img: &image::GrayImage, gamma: bool) -> RawImage {
+fn convert_raw_from_luma8(img: &image::GrayImage, encoding: ColorEncoding) -> RawImage {
     let (width, height) = img.dimensions();
     RawImage {
         data: RawImageData::U8 {
             data: img.as_raw().clone(),
-            gamma,
+            encoding,
         },
         resolution: Point2i::from((width as i32, height as i32)),
         channels: 1,
     }
 }
 
-fn convert_from_lumaa8(img: &image::GrayAlphaImage, gamma: bool) -> (Vec<RGBSpectrum>, Point2i) {
+fn convert_from_lumaa8(
+    img: &image::GrayAlphaImage,
+    encoding: ColorEncoding,
+) -> (Vec<RGBSpectrum>, Point2i) {
     let (width, height) = img.dimensions();
     let mut spcs = vec![RGBSpectrum::zero(); (width * height) as usize];
     for y in 0..height {
@@ -108,9 +112,7 @@ fn convert_from_lumaa8(img: &image::GrayAlphaImage, gamma: bool) -> (Vec<RGBSpec
             let mut r = pixel[0] as Float / 255.0;
             let _a = pixel[1] as Float / 255.0; // Ignore alpha channel
 
-            if gamma {
-                r = inverse_gamma_correct(r);
-            }
+            r = encoding.to_linear(r);
 
             spcs[index] = RGBSpectrum::rgb_from_rgb(&[r, r, r]);
         }
@@ -118,19 +120,22 @@ fn convert_from_lumaa8(img: &image::GrayAlphaImage, gamma: bool) -> (Vec<RGBSpec
     return (spcs, Point2i::from((width as i32, height as i32)));
 }
 
-fn convert_raw_from_lumaa8(img: &image::GrayAlphaImage, gamma: bool) -> RawImage {
+fn convert_raw_from_lumaa8(img: &image::GrayAlphaImage, encoding: ColorEncoding) -> RawImage {
     let (width, height) = img.dimensions();
     RawImage {
         data: RawImageData::U8 {
             data: img.as_raw().clone(),
-            gamma,
+            encoding,
         },
         resolution: Point2i::from((width as i32, height as i32)),
         channels: 2,
     }
 }
 
-fn convert_from_rgb8(img: &image::RgbImage, gamma: bool) -> (Vec<RGBSpectrum>, Point2i) {
+fn convert_from_rgb8(
+    img: &image::RgbImage,
+    encoding: ColorEncoding,
+) -> (Vec<RGBSpectrum>, Point2i) {
     let (width, height) = img.dimensions();
     let mut spcs = vec![RGBSpectrum::zero(); (width * height) as usize];
     for y in 0..height {
@@ -141,11 +146,9 @@ fn convert_from_rgb8(img: &image::RgbImage, gamma: bool) -> (Vec<RGBSpectrum>, P
             let mut g = pixel[1] as Float / 255.0;
             let mut b = pixel[2] as Float / 255.0;
 
-            if gamma {
-                r = inverse_gamma_correct(r);
-                g = inverse_gamma_correct(g);
-                b = inverse_gamma_correct(b);
-            }
+            r = encoding.to_linear(r);
+            g = encoding.to_linear(g);
+            b = encoding.to_linear(b);
 
             spcs[index] = RGBSpectrum::rgb_from_rgb(&[r, g, b]);
         }
@@ -153,19 +156,22 @@ fn convert_from_rgb8(img: &image::RgbImage, gamma: bool) -> (Vec<RGBSpectrum>, P
     return (spcs, Point2i::from((width as i32, height as i32)));
 }
 
-fn convert_raw_from_rgb8(img: &image::RgbImage, gamma: bool) -> RawImage {
+fn convert_raw_from_rgb8(img: &image::RgbImage, encoding: ColorEncoding) -> RawImage {
     let (width, height) = img.dimensions();
     RawImage {
         data: RawImageData::U8 {
             data: img.as_raw().clone(),
-            gamma,
+            encoding,
         },
         resolution: Point2i::from((width as i32, height as i32)),
         channels: 3,
     }
 }
 
-fn convert_from_rgba8(img: &image::RgbaImage, gamma: bool) -> (Vec<RGBSpectrum>, Point2i) {
+fn convert_from_rgba8(
+    img: &image::RgbaImage,
+    encoding: ColorEncoding,
+) -> (Vec<RGBSpectrum>, Point2i) {
     let (width, height) = img.dimensions();
     let mut spcs = vec![RGBSpectrum::zero(); (width * height) as usize];
     for y in 0..height {
@@ -176,11 +182,9 @@ fn convert_from_rgba8(img: &image::RgbaImage, gamma: bool) -> (Vec<RGBSpectrum>,
             let mut g = pixel[1] as Float / 255.0;
             let mut b = pixel[2] as Float / 255.0;
 
-            if gamma {
-                r = inverse_gamma_correct(r);
-                g = inverse_gamma_correct(g);
-                b = inverse_gamma_correct(b);
-            }
+            r = encoding.to_linear(r);
+            g = encoding.to_linear(g);
+            b = encoding.to_linear(b);
 
             spcs[index] = RGBSpectrum::rgb_from_rgb(&[r, g, b]);
         }
@@ -188,12 +192,12 @@ fn convert_from_rgba8(img: &image::RgbaImage, gamma: bool) -> (Vec<RGBSpectrum>,
     return (spcs, Point2i::from((width as i32, height as i32)));
 }
 
-fn convert_raw_from_rgba8(img: &image::RgbaImage, gamma: bool) -> RawImage {
+fn convert_raw_from_rgba8(img: &image::RgbaImage, encoding: ColorEncoding) -> RawImage {
     let (width, height) = img.dimensions();
     RawImage {
         data: RawImageData::U8 {
             data: img.as_raw().clone(),
-            gamma,
+            encoding,
         },
         resolution: Point2i::from((width as i32, height as i32)),
         channels: 4,
@@ -309,7 +313,7 @@ fn convert_raw_from_rgba32f(img: &image::Rgba32FImage) -> RawImage {
 // use crate::image::*;
 pub fn read_image_common(
     path: &Path,
-    gamma: bool,
+    encoding: ColorEncoding,
 ) -> Result<(Vec<RGBSpectrum>, Point2i), PbrtError> {
     // The `image` crate only accepts 3-channel RGB for EXR and rejects
     // Y / RGBA / multi-layer files. Dispatch to the dedicated reader.
@@ -320,16 +324,16 @@ pub fn read_image_common(
     match r {
         Ok(dimg) => match dimg {
             DynamicImage::ImageLuma8(img) => {
-                return Ok(convert_from_luma8(&img, gamma));
+                return Ok(convert_from_luma8(&img, encoding));
             }
             DynamicImage::ImageLumaA8(img) => {
-                return Ok(convert_from_lumaa8(&img, gamma));
+                return Ok(convert_from_lumaa8(&img, encoding));
             }
             DynamicImage::ImageRgb8(img) => {
-                return Ok(convert_from_rgb8(&img, gamma));
+                return Ok(convert_from_rgb8(&img, encoding));
             }
             DynamicImage::ImageRgba8(img) => {
-                return Ok(convert_from_rgba8(&img, gamma));
+                return Ok(convert_from_rgba8(&img, encoding));
             }
             DynamicImage::ImageRgb16(img) => {
                 return Ok(convert_from_rgb16(&img));
@@ -355,9 +359,9 @@ fn has_extension(path: &Path, ext: &str) -> bool {
     return path.extension().unwrap_or_default() == ext;
 }
 
-pub fn read_image_gamma_correct(
+pub fn read_image_with_encoding(
     name: &str,
-    gamma: bool,
+    encoding: ColorEncoding,
 ) -> Result<(Vec<RGBSpectrum>, Point2i), PbrtError> {
     let path = Path::new(name);
     if !path.exists() {
@@ -366,11 +370,14 @@ pub fn read_image_gamma_correct(
     if has_extension(path, "pfm") {
         return read_image_pfm(name);
     } else {
-        return read_image_common(path, gamma);
+        return read_image_common(path, encoding);
     }
 }
 
-pub fn read_raw_image_gamma_correct(name: &str, gamma: bool) -> Result<RawImage, PbrtError> {
+pub fn read_raw_image_with_encoding(
+    name: &str,
+    encoding: ColorEncoding,
+) -> Result<RawImage, PbrtError> {
     let path = Path::new(name);
     if !path.exists() {
         return Err(PbrtError::from(format!("File not found: {}", name)));
@@ -396,10 +403,10 @@ pub fn read_raw_image_gamma_correct(name: &str, gamma: bool) -> Result<RawImage,
 
     let image = image::open(path)?;
     let raw = match image {
-        DynamicImage::ImageLuma8(img) => convert_raw_from_luma8(&img, gamma),
-        DynamicImage::ImageLumaA8(img) => convert_raw_from_lumaa8(&img, gamma),
-        DynamicImage::ImageRgb8(img) => convert_raw_from_rgb8(&img, gamma),
-        DynamicImage::ImageRgba8(img) => convert_raw_from_rgba8(&img, gamma),
+        DynamicImage::ImageLuma8(img) => convert_raw_from_luma8(&img, encoding),
+        DynamicImage::ImageLumaA8(img) => convert_raw_from_lumaa8(&img, encoding),
+        DynamicImage::ImageRgb8(img) => convert_raw_from_rgb8(&img, encoding),
+        DynamicImage::ImageRgba8(img) => convert_raw_from_rgba8(&img, encoding),
         DynamicImage::ImageRgb16(img) => convert_raw_from_rgb16(&img),
         DynamicImage::ImageRgb32F(img) => convert_raw_from_rgb32f(&img),
         DynamicImage::ImageRgba32F(img) => convert_raw_from_rgba32f(&img),
@@ -414,7 +421,7 @@ pub fn read_raw_image_gamma_correct(name: &str, gamma: bool) -> Result<RawImage,
 }
 
 pub fn read_image(name: &str) -> Result<(Vec<RGBSpectrum>, Point2i), PbrtError> {
-    return read_image_gamma_correct(name, false);
+    read_image_with_encoding(name, ColorEncoding::Linear)
 }
 
 fn convert_f32_from_rgba32f(img: &image::Rgb32FImage) -> (Vec<f32>, Point2i) {

--- a/tests/color_encoding.rs
+++ b/tests/color_encoding.rs
@@ -1,0 +1,57 @@
+use pbrt_r4::util::imageio::ColorEncoding;
+
+#[test]
+fn color_encoding_parses_linear_and_srgb() {
+    assert_eq!(
+        ColorEncoding::parse("linear").unwrap(),
+        ColorEncoding::Linear
+    );
+    assert_eq!(ColorEncoding::parse("sRGB").unwrap(), ColorEncoding::SRgb);
+}
+
+#[test]
+fn color_encoding_parses_gamma_value() {
+    assert_eq!(
+        ColorEncoding::parse("gamma 2.2").unwrap(),
+        ColorEncoding::Gamma(2.2)
+    );
+}
+
+#[test]
+fn color_encoding_rejects_invalid_gamma() {
+    assert!(ColorEncoding::parse("gamma").is_err());
+    assert!(ColorEncoding::parse("gamma 0").is_err());
+    assert!(ColorEncoding::parse("gamma -1").is_err());
+    assert!(ColorEncoding::parse("unknown").is_err());
+}
+
+#[test]
+fn color_encoding_legacy_bool_maps_to_linear_or_srgb() {
+    assert_eq!(
+        ColorEncoding::from_legacy_gamma(false),
+        ColorEncoding::Linear
+    );
+    assert_eq!(ColorEncoding::from_legacy_gamma(true), ColorEncoding::SRgb);
+}
+
+#[test]
+fn linear_encoding_round_trips_byte_values() {
+    let encoding = ColorEncoding::Linear;
+    for value in [0.0, 0.25, 0.5, 1.0] {
+        assert_eq!(encoding.to_linear(encoding.from_linear(value)), value);
+    }
+}
+
+#[test]
+fn srgb_encoding_is_not_linear_at_midpoint() {
+    let encoding = ColorEncoding::SRgb;
+    let encoded = encoding.from_linear(0.5);
+    assert!(encoded > 0.5);
+    assert!((encoding.to_linear(encoded) - 0.5).abs() < 1e-5);
+}
+
+#[test]
+fn gamma_encoding_does_not_clamp_float_input_before_power() {
+    let value = ColorEncoding::Gamma(2.2).to_linear(-0.5);
+    assert!(value.is_nan());
+}

--- a/tests/read_image.rs
+++ b/tests/read_image.rs
@@ -1,8 +1,9 @@
 use pbrt_r4::util::base::inverse_gamma_correct;
 use pbrt_r4::util::base::Point2i;
 use pbrt_r4::util::imageio::read_image::{
-    read_image_gamma_correct, read_raw_image_gamma_correct, RawImage, RawImageData,
+    read_image_with_encoding, read_raw_image_with_encoding, RawImage, RawImageData,
 };
+use pbrt_r4::util::imageio::ColorEncoding;
 
 fn write_rgba_png(bytes: &[u8], width: u32, height: u32) -> tempfile::NamedTempFile {
     let file = tempfile::Builder::new()
@@ -40,7 +41,8 @@ fn raw_image_exposes_luma_alpha_channel_names() {
 #[test]
 fn raw_rgba_read_preserves_alpha() {
     let file = write_rgba_png(&[10, 20, 30, 40, 50, 60, 70, 80], 2, 1);
-    let raw = read_raw_image_gamma_correct(file.path().to_str().unwrap(), false).unwrap();
+    let raw =
+        read_raw_image_with_encoding(file.path().to_str().unwrap(), ColorEncoding::Linear).unwrap();
 
     assert_eq!(raw.channels, 4);
     assert_eq!(raw.resolution, Point2i::new(2, 1));
@@ -63,7 +65,7 @@ fn raw_rgba_read_preserves_alpha() {
 fn rgba_spectrum_read_ignores_alpha() {
     let file = write_rgba_png(&[10, 20, 30, 40], 1, 1);
     let (spectra, resolution) =
-        read_image_gamma_correct(file.path().to_str().unwrap(), false).unwrap();
+        read_image_with_encoding(file.path().to_str().unwrap(), ColorEncoding::Linear).unwrap();
     let rgb = spectra[0].to_rgb();
 
     assert_eq!(resolution, Point2i::new(1, 1));
@@ -73,7 +75,8 @@ fn rgba_spectrum_read_ignores_alpha() {
 #[test]
 fn raw_rgba_gamma_correction_applies_to_alpha_as_v4_does() {
     let file = write_rgba_png(&[128, 128, 128, 128], 1, 1);
-    let raw = read_raw_image_gamma_correct(file.path().to_str().unwrap(), true).unwrap();
+    let raw =
+        read_raw_image_with_encoding(file.path().to_str().unwrap(), ColorEncoding::SRgb).unwrap();
     let expected = inverse_gamma_correct(128.0 / 255.0);
 
     assert!((raw.channel(0, 0) - expected).abs() < 1e-6);

--- a/tests/texture_create.rs
+++ b/tests/texture_create.rs
@@ -1,5 +1,6 @@
 use pbrt_r4::base::typed_spectrum_texture_name;
 use pbrt_r4::prelude::*;
+use pbrt_r4::util::imageio::ColorEncoding;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -277,7 +278,7 @@ fn imagemap_png_defaults_to_v4_filter_and_gamma() {
     assert_eq!(texinfo.filter, ImageFilter::Bilinear);
     assert_eq!(texinfo.swrap_mode, ImageWrap::Repeat);
     assert_eq!(texinfo.twrap_mode, ImageWrap::Repeat);
-    assert!(texinfo.gamma);
+    assert_eq!(texinfo.encoding, ColorEncoding::SRgb);
 }
 
 #[test]
@@ -321,7 +322,7 @@ fn imagemap_supports_v4_filter_and_encoding_parameters() {
         .expect("texinfo creation should succeed")
         .expect("filename should produce texinfo");
     assert_eq!(texinfo.filter, ImageFilter::EWA);
-    assert!(!texinfo.gamma);
+    assert_eq!(texinfo.encoding, ColorEncoding::Linear);
 }
 
 #[test]
@@ -336,7 +337,39 @@ fn imagemap_exr_defaults_to_linear_encoding_like_v4() {
     let texinfo = create_texinfo(&tp)
         .expect("texinfo creation should succeed")
         .expect("filename should produce texinfo");
-    assert!(!texinfo.gamma);
+    assert_eq!(texinfo.encoding, ColorEncoding::Linear);
+}
+
+#[test]
+fn imagemap_non_png_defaults_to_linear_encoding_like_v4() {
+    let _geom_params = ParameterDictionary::new();
+    let mut mat_params = ParameterDictionary::new();
+    mat_params.add_string("filename", "textures/example_bump.pfm");
+    let f_tex: HashMap<String, Arc<FloatTexture>> = HashMap::new();
+    let s_tex: HashMap<String, Arc<SpectrumTexture>> = HashMap::new();
+    let tp = TextureParameterDictionary::new(&mat_params, &f_tex, &s_tex);
+
+    let texinfo = create_texinfo(&tp)
+        .expect("texinfo creation should succeed")
+        .expect("filename should produce texinfo");
+    assert_eq!(texinfo.encoding, ColorEncoding::Linear);
+}
+
+#[test]
+fn imagemap_encoding_takes_precedence_over_legacy_gamma() {
+    let _geom_params = ParameterDictionary::new();
+    let mut mat_params = ParameterDictionary::new();
+    mat_params.add_string("filename", "textures/example_bump.png");
+    mat_params.add_string("encoding", "linear");
+    mat_params.add_bool("gamma", true);
+    let f_tex: HashMap<String, Arc<FloatTexture>> = HashMap::new();
+    let s_tex: HashMap<String, Arc<SpectrumTexture>> = HashMap::new();
+    let tp = TextureParameterDictionary::new(&mat_params, &f_tex, &s_tex);
+
+    let texinfo = create_texinfo(&tp)
+        .expect("texinfo creation should succeed")
+        .expect("filename should produce texinfo");
+    assert_eq!(texinfo.encoding, ColorEncoding::Linear);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add a v4-compatible ColorEncoding model for linear, sRGB, and gamma encodings.
- Propagate encoding through TexInfo, RawImage, image loading, and MIPMap byte storage.
- Use PNG=sRGB and other formats=linear defaults, while preserving legacy gamma input handling.
- Add focused ColorEncoding, image loading, and texture parameter tests.

## Validation
- cargo fmt --all
- cargo test --test color_encoding --test texture_create --test read_image
- cargo test --tests
- cargo build
- git diff --check

PR3 will handle byte MIPMap storage details and PR5 will handle disk cache redesign.