### PR TITLE
fix(texture): evaluate image-map Y flip like v4

### DIFF
--- a/src/base/texture.rs
+++ b/src/base/texture.rs
@@ -38,7 +38,6 @@ pub struct TexInfo {
     pub twrap_mode: ImageWrap,
     pub scale: Float,
     pub encoding: ColorEncoding,
-    pub flip_y: bool,
 }
 
 impl Display for TexInfo {

--- a/src/textures/imagemap.rs
+++ b/src/textures/imagemap.rs
@@ -107,7 +107,8 @@ impl ImageTexture<Float, Float> {
     }
 
     pub fn evaluate(&self, ctx: &TextureEvalContext) -> Float {
-        let (st, dstdx, dstdy) = self.mapping.map(ctx);
+        let (mut st, dstdx, dstdy) = self.mapping.map(ctx);
+        st[1] = 1.0 - st[1];
         let v = self.scale * self.mipmap.lookup_delta(&st, &dstdx, &dstdy);
         // pbrt-v4 textures.h FloatImageTexture::Evaluate: `invert ? max(0, 1-v) : v`.
         if self.invert {
@@ -183,10 +184,7 @@ impl ImageTexture<Float, Float> {
 
         let _p = ProfilePhase::new(Prof::TextureLoading);
         let raw = read_raw_image_with_encoding(&texinfo.filename, encoding)?;
-        let (mut data, channels) = normalize_raw_image_for_float(&raw)?;
-        if texinfo.flip_y {
-            flip_y(&mut data, &raw.resolution, channels);
-        }
+        let (data, channels) = normalize_raw_image_for_float(&raw)?;
         let mipmap = MIPMap::<Float>::new_with_raw_channels(
             &raw.resolution,
             &data,
@@ -288,7 +286,8 @@ impl ImageTexture<RGBSpectrum, Spectrum> {
         ctx: &TextureEvalContext,
         lambda: &SampledWavelengths,
     ) -> SampledSpectrum {
-        let (st, dstdx, dstdy) = self.mapping.map(ctx);
+        let (mut st, dstdx, dstdy) = self.mapping.map(ctx);
+        st[1] = 1.0 - st[1];
         let mut rgb = self.mipmap.lookup_delta(&st, &dstdx, &dstdy).to_rgb();
         for c in rgb.iter_mut() {
             *c *= self.scale;
@@ -384,10 +383,7 @@ impl ImageTexture<RGBSpectrum, Spectrum> {
         };
 
         let _p = ProfilePhase::new(Prof::TextureLoading);
-        let (mut data, resolution) = read_image_with_encoding(&texinfo.filename, encoding)?;
-        if texinfo.flip_y {
-            flip_y(&mut data, &resolution, 1);
-        }
+        let (data, resolution) = read_image_with_encoding(&texinfo.filename, encoding)?;
         let mipmap = MIPMap::<RGBSpectrum>::new_with_storage(
             &resolution,
             &data,
@@ -555,7 +551,6 @@ pub fn create_texinfo(
         twrap_mode,
         scale,
         encoding,
-        flip_y: true,
     }))
 }
 
@@ -598,22 +593,6 @@ fn normalize_raw_image_for_float(raw: &RawImage) -> Result<(Vec<Float>, usize), 
         }
     };
     Ok(normalized)
-}
-
-fn flip_y<T: Copy>(data: &mut [T], resolution: &Vector2i, channels: usize) {
-    // Flip image in y; texture coordinate space has (0,0) at the lower
-    // left corner.
-    let w = resolution.x;
-    let h = resolution.y;
-    for y in 0..(h / 2) {
-        for x in 0..w {
-            let o1 = channels * (y * w + x) as usize;
-            let o2 = channels * ((h - 1 - y) * w + x) as usize;
-            for channel in 0..channels {
-                data.swap(o1 + channel, o2 + channel);
-            }
-        }
-    }
 }
 
 pub type FloatImageTexture = ImageTexture<Float, Float>;

--- a/tests/imagemap_behavior.rs
+++ b/tests/imagemap_behavior.rs
@@ -1,8 +1,9 @@
 use pbrt_r4::textures::{
-    FloatImageTexture, ImageFilter, ImageWrap, MIPMap, TextureEvalContext, TextureMapping2D,
-    UVMapping,
+    FloatImageTexture, ImageFilter, ImageWrap, MIPMap, SpectrumImageTexture, TextureEvalContext,
+    TextureMapping2D, UVMapping,
 };
 use pbrt_r4::util::base::{Float, Point2f, Point2i};
+use pbrt_r4::util::spectrum::{RGBSpectrum, SampledWavelengths, SpectrumType};
 
 #[test]
 fn float_imagemap_applies_scale_after_filtering() {
@@ -23,4 +24,59 @@ fn float_imagemap_applies_scale_after_filtering() {
     let mut ctx = TextureEvalContext::default();
     ctx.uv = Point2f::new(0.5, 0.5);
     assert!((texture.evaluate(&ctx) + 1.0).abs() < 1e-4);
+}
+
+#[test]
+fn float_imagemap_flips_t_at_evaluation_like_v4() {
+    let mipmap = MIPMap::<Float>::new(
+        &Point2i::new(1, 2),
+        &vec![0.0, 1.0],
+        ImageFilter::Point,
+        8.0,
+        ImageWrap::Clamp,
+        ImageWrap::Clamp,
+    );
+    let texture = FloatImageTexture::new(
+        TextureMapping2D::UV(UVMapping::new(1.0, 1.0, 0.0, 0.0)),
+        mipmap,
+        1.0,
+        false,
+    );
+    let mut ctx = TextureEvalContext::default();
+    ctx.uv = Point2f::new(0.5, 0.25);
+    let lower = texture.evaluate(&ctx);
+    ctx.uv[1] = 0.75;
+    let upper = texture.evaluate(&ctx);
+
+    assert!(lower > upper);
+}
+
+#[test]
+fn spectrum_imagemap_flips_t_at_evaluation_like_v4() {
+    let mipmap = MIPMap::<RGBSpectrum>::new(
+        &Point2i::new(1, 2),
+        &vec![
+            RGBSpectrum::new(0.0, 0.0, 0.0),
+            RGBSpectrum::new(1.0, 1.0, 1.0),
+        ],
+        ImageFilter::Point,
+        8.0,
+        ImageWrap::Clamp,
+        ImageWrap::Clamp,
+    );
+    let texture = SpectrumImageTexture::new_shared(
+        TextureMapping2D::UV(UVMapping::new(1.0, 1.0, 0.0, 0.0)),
+        std::sync::Arc::new(mipmap),
+        SpectrumType::Albedo,
+        1.0,
+        false,
+    );
+    let lambda = SampledWavelengths::sample_visible(0.5);
+    let mut ctx = TextureEvalContext::default();
+    ctx.uv = Point2f::new(0.5, 0.25);
+    let lower = texture.evaluate(&ctx, &lambda).max_component_value();
+    ctx.uv[1] = 0.75;
+    let upper = texture.evaluate(&ctx, &lambda).max_component_value();
+
+    assert!(lower > upper);
 }


### PR DESCRIPTION
## Summary
- Move image-map Y flipping from image loading to texture evaluation.
- Match pbrt-v4 by applying `st[1] = 1 - st[1]` for Float and Spectrum image maps without changing texture differentials.
- Remove the obsolete `TexInfo.flip_y` field and add Float/Spectrum regression tests.

## Validation
- cargo fmt --all
- cargo test --test imagemap_behavior --test texture_create --test read_image
- cargo build
- git diff --check