### PR TITLE
feat(texture): preserve source format in mipmap storage

### DIFF
--- a/src/textures/imagemap.rs
+++ b/src/textures/imagemap.rs
@@ -184,16 +184,27 @@ impl ImageTexture<Float, Float> {
 
         let _p = ProfilePhase::new(Prof::TextureLoading);
         let raw = read_raw_image_with_encoding(&texinfo.filename, encoding)?;
-        let (data, channels) = normalize_raw_image_for_float(&raw)?;
-        let mipmap = MIPMap::<Float>::new_with_raw_channels(
-            &raw.resolution,
-            &data,
-            channels,
-            texinfo.filter,
-            texinfo.max_aniso,
-            texinfo.swrap_mode,
-            texinfo.twrap_mode,
-        );
+        let mipmap = if matches!(raw.channels, 1 | 3) {
+            MIPMap::<Float>::new_from_raw_image(
+                &raw,
+                texinfo.filter,
+                texinfo.max_aniso,
+                texinfo.swrap_mode,
+                texinfo.twrap_mode,
+            )
+        } else {
+            let (data, channels) = normalize_raw_image_for_float(&raw)?;
+            MIPMap::<Float>::new_with_raw_channels_and_storage(
+                &raw.resolution,
+                &data,
+                channels,
+                texinfo.filter,
+                texinfo.max_aniso,
+                texinfo.swrap_mode,
+                texinfo.twrap_mode,
+                MIPMapStorageKind::from_raw_image(&raw),
+            )
+        };
         if let Some((cache_path, file_hash)) = cache_entry {
             let _ = save_float_mipmap_cache(&cache_path, &mipmap_texinfo, &file_hash, &mipmap);
         }
@@ -383,7 +394,8 @@ impl ImageTexture<RGBSpectrum, Spectrum> {
         };
 
         let _p = ProfilePhase::new(Prof::TextureLoading);
-        let (data, resolution) = read_image_with_encoding(&texinfo.filename, encoding)?;
+        let raw = read_raw_image_with_encoding(&texinfo.filename, encoding)?;
+        let (data, resolution) = normalize_raw_image_for_spectrum(&raw)?;
         let mipmap = MIPMap::<RGBSpectrum>::new_with_storage(
             &resolution,
             &data,
@@ -391,7 +403,7 @@ impl ImageTexture<RGBSpectrum, Spectrum> {
             texinfo.max_aniso,
             texinfo.swrap_mode,
             texinfo.twrap_mode,
-            spectrum_mipmap_storage(&texinfo, &resolution),
+            MIPMapStorageKind::from_raw_image(&raw),
         );
         if let Some((cache_path, file_hash)) = cache_entry {
             let _ = save_spectrum_mipmap_cache(&cache_path, &mipmap_texinfo, &file_hash, &mipmap);
@@ -417,37 +429,6 @@ fn has_extension(path: &str, ext: &str) -> bool {
         }
     }
     return false;
-}
-
-fn spectrum_mipmap_storage(texinfo: &TexInfo, resolution: &Point2i) -> MIPMapStorageKind {
-    if has_extension(&texinfo.filename, "exr")
-        || has_extension(&texinfo.filename, "pfm")
-        || is_16bit_image_file(&texinfo.filename, resolution)
-    {
-        MIPMapStorageKind::F16
-    } else {
-        MIPMapStorageKind::U8 {
-            encoding: texinfo.encoding,
-        }
-    }
-}
-
-fn is_16bit_image_file(filename: &str, resolution: &Point2i) -> bool {
-    if !has_extension(filename, "png") {
-        return false;
-    }
-    use std::io::Read;
-
-    let Ok(mut file) = std::fs::File::open(filename) else {
-        return false;
-    };
-    let mut header = [0u8; 25];
-    if file.read_exact(&mut header).is_err() || &header[0..8] != b"\x89PNG\r\n\x1a\n" {
-        return false;
-    }
-    let width = u32::from_be_bytes([header[16], header[17], header[18], header[19]]) as i32;
-    let height = u32::from_be_bytes([header[20], header[21], header[22], header[23]]) as i32;
-    width == resolution.x && height == resolution.y && header[24] == 16
 }
 
 fn get_wrap_mode(mode: &str) -> Result<ImageWrap, PbrtError> {
@@ -593,6 +574,37 @@ fn normalize_raw_image_for_float(raw: &RawImage) -> Result<(Vec<Float>, usize), 
         }
     };
     Ok(normalized)
+}
+
+fn normalize_raw_image_for_spectrum(
+    raw: &RawImage,
+) -> Result<(Vec<RGBSpectrum>, Point2i), PbrtError> {
+    let pixels = (raw.resolution.x * raw.resolution.y) as usize;
+    let mut data = Vec::with_capacity(pixels);
+    for pixel in 0..pixels {
+        match raw.channels {
+            1 => {
+                let value = raw.channel(pixel, 0);
+                data.push(RGBSpectrum::new(value, value, value));
+            }
+            2 => {
+                let value = raw.channel(pixel, 0);
+                data.push(RGBSpectrum::new(value, value, value));
+            }
+            3 | 4 => data.push(RGBSpectrum::new(
+                raw.channel(pixel, 0),
+                raw.channel(pixel, 1),
+                raw.channel(pixel, 2),
+            )),
+            _ => {
+                return Err(PbrtError::error(&format!(
+                    "Unsupported image channel count for Spectrum imagemap: {}",
+                    raw.channels
+                )));
+            }
+        }
+    }
+    Ok((data, raw.resolution))
 }
 
 pub type FloatImageTexture = ImageTexture<Float, Float>;

--- a/src/textures/mipmap.rs
+++ b/src/textures/mipmap.rs
@@ -26,6 +26,18 @@ pub enum MIPMapStorageKind {
     U8 { encoding: ColorEncoding },
 }
 
+impl MIPMapStorageKind {
+    pub fn from_raw_image(raw: &RawImage) -> Self {
+        match &raw.data {
+            RawImageData::F32(_) => Self::F32,
+            RawImageData::F16(_) => Self::F16,
+            RawImageData::U8 { encoding, .. } => Self::U8 {
+                encoding: *encoding,
+            },
+        }
+    }
+}
+
 pub enum MIPMapLevelStorage {
     F32(Vec<f32>),
     F16(Vec<half::f16>),
@@ -815,6 +827,48 @@ where
         swrap_mode: ImageWrap,
         twrap_mode: ImageWrap,
     ) -> Self {
+        Self::new_with_raw_channels_and_storage(
+            resolution,
+            data,
+            channels,
+            filter,
+            max_anisotropy,
+            swrap_mode,
+            twrap_mode,
+            MIPMapStorageKind::F32,
+        )
+    }
+
+    pub fn new_from_raw_image(
+        raw: &RawImage,
+        filter: ImageFilter,
+        max_anisotropy: Float,
+        swrap_mode: ImageWrap,
+        twrap_mode: ImageWrap,
+    ) -> Self {
+        let data = raw.data_f32();
+        Self::new_with_raw_channels_and_storage(
+            &raw.resolution,
+            &data,
+            raw.channels,
+            filter,
+            max_anisotropy,
+            swrap_mode,
+            twrap_mode,
+            MIPMapStorageKind::from_raw_image(raw),
+        )
+    }
+
+    pub fn new_with_raw_channels_and_storage(
+        resolution: &Point2i,
+        data: &[f32],
+        channels: usize,
+        filter: ImageFilter,
+        max_anisotropy: Float,
+        swrap_mode: ImageWrap,
+        twrap_mode: ImageWrap,
+        storage: MIPMapStorageKind,
+    ) -> Self {
         assert!((1..=4).contains(&channels));
         let _p = ProfilePhase::new(Prof::MIPMapCreation);
         let resolution = (resolution.x as usize, resolution.y as usize);
@@ -824,7 +878,7 @@ where
             resolution,
             swrap_mode,
             twrap_mode,
-            MIPMapStorageKind::F32,
+            storage,
         );
         Self::make_from_pyramid(pyramid, filter, max_anisotropy, swrap_mode, twrap_mode)
     }

--- a/tests/float_imagemap_channels.rs
+++ b/tests/float_imagemap_channels.rs
@@ -86,3 +86,36 @@ fn two_channel_float_imagemap_is_rejected() {
 
     assert!(FloatTexture::create("imagemap", &Transform::identity(), &tp).is_err());
 }
+
+#[test]
+fn two_channel_spectrum_imagemap_uses_luma_and_ignores_alpha() {
+    let file = tempfile::Builder::new()
+        .prefix("pbrt-r4-two-channel-spectrum-imagemap-")
+        .suffix(".png")
+        .tempfile()
+        .unwrap();
+    let image = image::GrayAlphaImage::from_raw(1, 1, vec![51, 255]).unwrap();
+    image.save(file.path()).unwrap();
+
+    let mut geom_params = ParameterDictionary::new();
+    geom_params.add_string("filename", file.path().to_str().unwrap());
+    geom_params.add_string("encoding", "linear");
+    let f_tex: HashMap<String, Arc<FloatTexture>> = HashMap::new();
+    let s_tex: HashMap<String, Arc<SpectrumTexture>> = HashMap::new();
+    let tp = TextureParameterDictionary::new(&geom_params, &f_tex, &s_tex);
+
+    let texture = SpectrumTexture::create(
+        "imagemap",
+        &Transform::identity(),
+        &tp,
+        SpectrumType::Albedo,
+    )
+    .unwrap();
+    let value = texture
+        .evaluate(
+            &TextureEvalContext::default(),
+            &SampledWavelengths::sample_visible(0.5),
+        )
+        .max_component_value();
+    assert!((value - 51.0 / 255.0).abs() < 1e-5);
+}

--- a/tests/mipmap_raw_storage.rs
+++ b/tests/mipmap_raw_storage.rs
@@ -1,0 +1,72 @@
+use pbrt_r4::textures::{ImageFilter, ImageWrap, MIPMap, MIPMapLevelStorage};
+use pbrt_r4::util::base::{Float, Point2i};
+use pbrt_r4::util::imageio::{ColorEncoding, RawImage, RawImageData};
+
+fn storage_for(raw: RawImage) -> MIPMap<Float> {
+    MIPMap::new_from_raw_image(
+        &raw,
+        ImageFilter::Point,
+        8.0,
+        ImageWrap::Clamp,
+        ImageWrap::Clamp,
+    )
+}
+
+#[test]
+fn raw_u8_image_selects_u8_mipmap_storage_and_round_trips_encoding() {
+    let mipmap = storage_for(RawImage {
+        data: RawImageData::U8 {
+            data: vec![128],
+            encoding: ColorEncoding::SRgb,
+        },
+        resolution: Point2i::new(1, 1),
+        channels: 1,
+    });
+
+    match &mipmap.storage.pyramid[0].data {
+        MIPMapLevelStorage::U8 { data, encoding } => {
+            assert_eq!(data, &[128]);
+            assert_eq!(*encoding, ColorEncoding::SRgb);
+        }
+        _ => panic!("expected U8 MIPMap storage"),
+    }
+    assert!((mipmap.texel(0, 0, 0) - 0.2158605).abs() < 1e-5);
+}
+
+#[test]
+fn raw_f16_and_f32_images_select_matching_mipmap_storage() {
+    let f16 = storage_for(RawImage {
+        data: RawImageData::F16(vec![half::f16::from_f32(0.5)]),
+        resolution: Point2i::new(1, 1),
+        channels: 1,
+    });
+    assert!(matches!(
+        f16.storage.pyramid[0].data,
+        MIPMapLevelStorage::F16(_)
+    ));
+
+    let f32 = storage_for(RawImage {
+        data: RawImageData::F32(vec![0.5]),
+        resolution: Point2i::new(1, 1),
+        channels: 1,
+    });
+    assert!(matches!(
+        f32.storage.pyramid[0].data,
+        MIPMapLevelStorage::F32(_)
+    ));
+}
+
+#[test]
+fn u8_mipmap_downsamples_in_linear_space_before_reencoding() {
+    let mipmap = storage_for(RawImage {
+        data: RawImageData::U8 {
+            data: vec![0, 255],
+            encoding: ColorEncoding::SRgb,
+        },
+        resolution: Point2i::new(2, 1),
+        channels: 1,
+    });
+
+    let averaged = mipmap.texel(1, 0, 0);
+    assert!((averaged - 0.5).abs() < 0.01);
+}


### PR DESCRIPTION
## Summary
- Add `MIPMap::new_from_raw_image` and storage selection from `RawImageData`.
- Build mip levels from linear Float working data and preserve F32/F16/U8 storage formats.
- Route Float and Spectrum image maps through the source-format-aware storage path.
- Preserve grayscale/alpha Spectrum behavior and add storage, quantization, and linear-downsampling tests.

## Validation
- cargo fmt --all
- cargo test --tests --quiet
- cargo test --test float_imagemap_channels --test mipmap_raw_storage --test imagemap_behavior --test read_image
- cargo build
- git diff --check

This PR is based on the merged PR2 image-map Y flip change.