### PR TITLE
feat(textures): preserve mipmap evaluation views

### DIFF
--- a/src/textures/imagemap.rs
+++ b/src/textures/imagemap.rs
@@ -80,6 +80,12 @@ pub struct ImageTexture<Tmemory, Treturn> {
     phantom: PhantomData<Treturn>, //non allocate
 }
 
+impl<Tmemory, Treturn> ImageTexture<Tmemory, Treturn> {
+    pub fn mipmap_channel_count(&self) -> usize {
+        self.mipmap.channel_count()
+    }
+}
+
 impl ImageTexture<Float, Float> {
     pub fn new(
         mapping: TextureMapping2D,
@@ -395,10 +401,11 @@ impl ImageTexture<RGBSpectrum, Spectrum> {
 
         let _p = ProfilePhase::new(Prof::TextureLoading);
         let raw = read_raw_image_with_encoding(&texinfo.filename, encoding)?;
-        let (data, resolution) = normalize_raw_image_for_spectrum(&raw)?;
-        let mipmap = MIPMap::<RGBSpectrum>::new_with_storage(
+        let (data, channels, resolution) = normalize_raw_image_for_spectrum(&raw)?;
+        let mipmap = MIPMap::<RGBSpectrum>::new_with_raw_channels_and_storage(
             &resolution,
             &data,
+            channels,
             texinfo.filter,
             texinfo.max_aniso,
             texinfo.swrap_mode,
@@ -538,7 +545,7 @@ pub fn create_texinfo(
 fn alpha_all_one(raw: &RawImage) -> bool {
     let alpha_offset = raw.channels - 1;
     let pixels = (raw.resolution.x * raw.resolution.y) as usize;
-    (0..pixels).all(|i| raw.channel(i, alpha_offset) >= 1.0 - 1e-6)
+    (0..pixels).all(|i| raw.channel(i, alpha_offset) == 1.0)
 }
 
 fn normalize_raw_image_for_float(raw: &RawImage) -> Result<(Vec<Float>, usize), PbrtError> {
@@ -578,33 +585,39 @@ fn normalize_raw_image_for_float(raw: &RawImage) -> Result<(Vec<Float>, usize), 
 
 fn normalize_raw_image_for_spectrum(
     raw: &RawImage,
-) -> Result<(Vec<RGBSpectrum>, Point2i), PbrtError> {
+) -> Result<(Vec<Float>, usize, Point2i), PbrtError> {
     let pixels = (raw.resolution.x * raw.resolution.y) as usize;
-    let mut data = Vec::with_capacity(pixels);
-    for pixel in 0..pixels {
-        match raw.channels {
-            1 => {
+    match raw.channels {
+        1 => Ok((raw.data_f32(), 1, raw.resolution)),
+        2 => {
+            let mut data = Vec::with_capacity(3 * pixels);
+            for pixel in 0..pixels {
                 let value = raw.channel(pixel, 0);
-                data.push(RGBSpectrum::new(value, value, value));
+                data.extend_from_slice(&[value, value, value]);
             }
-            2 => {
-                let value = raw.channel(pixel, 0);
-                data.push(RGBSpectrum::new(value, value, value));
-            }
-            3 | 4 => data.push(RGBSpectrum::new(
-                raw.channel(pixel, 0),
-                raw.channel(pixel, 1),
-                raw.channel(pixel, 2),
-            )),
-            _ => {
-                return Err(PbrtError::error(&format!(
-                    "Unsupported image channel count for Spectrum imagemap: {}",
-                    raw.channels
-                )));
+            Ok((data, 3, raw.resolution))
+        }
+        3 => Ok((raw.data_f32(), 3, raw.resolution)),
+        4 => {
+            if alpha_all_one(raw) {
+                let mut data = Vec::with_capacity(3 * pixels);
+                for pixel in 0..pixels {
+                    data.extend_from_slice(&[
+                        raw.channel(pixel, 0),
+                        raw.channel(pixel, 1),
+                        raw.channel(pixel, 2),
+                    ]);
+                }
+                Ok((data, 3, raw.resolution))
+            } else {
+                Ok((raw.data_f32(), 4, raw.resolution))
             }
         }
+        _ => Err(PbrtError::error(&format!(
+            "Unsupported image channel count for Spectrum imagemap: {}",
+            raw.channels
+        ))),
     }
-    Ok((data, raw.resolution))
 }
 
 pub type FloatImageTexture = ImageTexture<Float, Float>;

--- a/src/textures/mipmap.rs
+++ b/src/textures/mipmap.rs
@@ -721,6 +721,12 @@ pub struct MIPMap<T> {
 pub type MIPMapFloatView = MIPMap<Float>;
 pub type MIPMapSpectrumView = MIPMap<RGBSpectrum>;
 
+impl<T> MIPMap<T> {
+    pub fn channel_count(&self) -> usize {
+        self.storage.pyramid[0].channels
+    }
+}
+
 impl<
         T: Default + Debug + Copy + std::ops::Add<T, Output = T> + std::ops::Mul<Float, Output = T>,
     > MIPMap<T>

--- a/tests/mipmap_evaluation_views.rs
+++ b/tests/mipmap_evaluation_views.rs
@@ -1,0 +1,47 @@
+use pbrt_r4::prelude::*;
+use pbrt_r4::textures::{MIPMap, MIPMapStorageKind};
+
+fn rgba_mipmap(filter: ImageFilter) -> MIPMap<Float> {
+    MIPMap::new_with_raw_channels_and_storage(
+        &Point2i::new(2, 2),
+        &[
+            0.1, 0.0, 0.0, 0.2, 0.1, 0.0, 0.0, 0.4, 0.1, 0.0, 0.0, 0.6, 0.1, 0.0, 0.0, 0.8,
+        ],
+        4,
+        filter,
+        8.0,
+        ImageWrap::Clamp,
+        ImageWrap::Clamp,
+        MIPMapStorageKind::F32,
+    )
+}
+
+#[test]
+fn float_point_lookup_uses_r_while_bilinear_uses_alpha() {
+    let point = rgba_mipmap(ImageFilter::Point);
+    let bilinear = rgba_mipmap(ImageFilter::Bilinear);
+    let st = Point2f::new(0.5, 0.5);
+    let zero = Vector2f::new(0.0, 0.0);
+
+    assert!((point.lookup_delta(&st, &zero, &zero) - 0.1).abs() < 1e-6);
+    assert!((bilinear.lookup_delta(&st, &zero, &zero) - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn float_trilinear_lookup_uses_alpha() {
+    let mipmap = rgba_mipmap(ImageFilter::Trilinear);
+    let st = Point2f::new(0.5, 0.5);
+    let zero = Vector2f::new(0.0, 0.0);
+
+    assert!((mipmap.lookup_delta(&st, &zero, &zero) - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn float_ewa_lookup_uses_r() {
+    let mipmap = rgba_mipmap(ImageFilter::EWA);
+    let st = Point2f::new(0.5, 0.5);
+    let dst0 = Vector2f::new(0.5, 0.0);
+    let dst1 = Vector2f::new(0.0, 0.5);
+
+    assert!((mipmap.lookup_delta(&st, &dst0, &dst1) - 0.1).abs() < 1e-6);
+}

--- a/tests/spectrum_imagemap_channels.rs
+++ b/tests/spectrum_imagemap_channels.rs
@@ -1,0 +1,59 @@
+use pbrt_r4::prelude::*;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn write_rgba_png(bytes: &[u8]) -> tempfile::NamedTempFile {
+    let file = tempfile::Builder::new()
+        .prefix("pbrt-r4-spectrum-imagemap-")
+        .suffix(".png")
+        .tempfile()
+        .unwrap();
+    let image = image::RgbaImage::from_raw(2, 2, bytes.to_vec()).unwrap();
+    image.save(file.path()).unwrap();
+    file
+}
+
+fn create_spectrum_imagemap(file: &tempfile::NamedTempFile) -> SpectrumTexture {
+    let mut parameters = ParameterDictionary::new();
+    parameters.add_string("filename", file.path().to_str().unwrap());
+    parameters.add_string("encoding", "linear");
+    let float_textures = HashMap::<String, Arc<FloatTexture>>::new();
+    let spectrum_textures = HashMap::<String, Arc<SpectrumTexture>>::new();
+    let texture_parameters =
+        TextureParameterDictionary::new(&parameters, &float_textures, &spectrum_textures);
+    SpectrumTexture::create(
+        "imagemap",
+        &Transform::identity(),
+        &texture_parameters,
+        SpectrumType::Albedo,
+    )
+    .unwrap()
+}
+
+fn channel_count(texture: &SpectrumTexture) -> usize {
+    match texture {
+        SpectrumTexture::ImageMap(texture) => texture.mipmap_channel_count(),
+        _ => panic!("expected an imagemap texture"),
+    }
+}
+
+#[test]
+fn spectrum_opaque_rgba_imagemap_shrinks_to_rgb() {
+    let file = write_rgba_png(&[
+        26, 51, 77, 255, 26, 51, 77, 255, 26, 51, 77, 255, 26, 51, 77, 255,
+    ]);
+    let texture = create_spectrum_imagemap(&file);
+
+    assert_eq!(channel_count(&texture), 3);
+}
+
+#[test]
+fn spectrum_nonopaque_rgba_imagemap_preserves_alpha() {
+    let file = write_rgba_png(&[
+        26, 51, 77, 255, 26, 51, 77, 254, 26, 51, 77, 255, 26, 51, 77, 255,
+    ]);
+    let texture = create_spectrum_imagemap(&file);
+
+    assert_eq!(channel_count(&texture), 4);
+}


### PR DESCRIPTION
## Summary
- Preserve RGBA channel layout for Spectrum imagemaps unless alpha is uniformly one.
- Keep Float and Spectrum evaluation channel rules aligned with pbrt-v4.
- Add read-only channel-count inspection APIs and external regression tests for Point/Bilinear/Trilinear/EWA and RGBA reduction.

## Validation
- cargo fmt --all
- cargo test --test spectrum_imagemap_channels --test mipmap_evaluation_views --test mipmap_channels --test float_imagemap_channels
- cargo build
- git diff --check