### PR TITLE
Release v4.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbrt-r4"
-version = "4.1.0"
+version = "4.2.0"
 edition = "2021"
 build = "build/main.rs"
 default-run = "pbrt-r4"


### PR DESCRIPTION
## Summary
- Bump the crate version to `4.2.0`.
- Prepare the release containing v4-compatible MIPMap storage/evaluation and disk caching.
- Include the CPU CLI utilities and removal of legacy v3 stats/profile functionality already merged into develop.

## Validation
- `cargo fmt --all --check`
- `cargo test --all-targets --quiet`
- `cargo build --release --bins --quiet` (release binaries generated)
- `cargo package --allow-dirty --no-verify`
- `git diff --check`

After merge: create tag `v4.2.0`, publish `pbrt-r4` to crates.io, and create the GitHub release.