### PR TITLE
feat(curves): share common state across curve groups

### DIFF
--- a/src/base/shape.rs
+++ b/src/base/shape.rs
@@ -125,6 +125,28 @@ pub enum Shape {
 }
 
 impl Shape {
+    pub fn create_curves(
+        render_from_object: &Transform,
+        object_from_render: &Transform,
+        reverse_orientation: bool,
+        shape_params: &[ParameterDictionary],
+        float_textures: &HashMap<String, Arc<FloatTexture>>,
+    ) -> Result<Vec<Vec<Shape>>, PbrtError> {
+        let curve_sets = create_curves_shape(
+            render_from_object,
+            object_from_render,
+            reverse_orientation,
+            shape_params,
+        )?;
+        let mut shape_sets = Vec::with_capacity(curve_sets.len());
+        debug_assert_eq!(curve_sets.len(), shape_params.len());
+        for (curves, params) in curve_sets.into_iter().zip(shape_params) {
+            let curve_shapes = curves.into_iter().map(Shape::Curve).collect();
+            shape_sets.push(wrap_alpha_masks(curve_shapes, params, float_textures)?);
+        }
+        Ok(shape_sets)
+    }
+
     /// Create shapes from shape name and parameters
     ///
     /// Corresponds to pbrt-v4's Shape::Create

--- a/src/parser/scene_builder/build.rs
+++ b/src/parser/scene_builder/build.rs
@@ -34,7 +34,7 @@ use super::scene_entity::{
     InstanceDefinitionSceneEntity, InstanceSceneEntity, MediumInterfaceNames, RenderFromObject,
     ShapeSceneEntity,
 };
-use super::SceneBuilder;
+use super::{SceneBuilder, CURVES_SHAPE_NAME};
 use crate::base::camera::Camera;
 use crate::base::filter::Filter;
 use crate::base::light::Light;
@@ -596,9 +596,9 @@ impl SceneBuilder {
             let mut area_lights: Vec<Arc<Light>> = Vec::new();
 
             if build_parallel {
-                let realize_static_shape = |shape| {
-                    self.realize_shape_owned(
-                        shape,
+                let realize_static_shape = |entry| {
+                    self.realize_shape_entry_owned(
+                        entry,
                         float_tex,
                         spectrum_tex,
                         materials,
@@ -610,9 +610,9 @@ impl SceneBuilder {
                 };
                 let static_results: Vec<Result<(Vec<Arc<Primitive>>, Vec<Arc<Light>>), PbrtError>> =
                     def.shapes.par_iter().map(realize_static_shape).collect();
-                let realize_animated_shape = |shape| {
-                    self.realize_shape_owned(
-                        shape,
+                let realize_animated_shape = |entry| {
+                    self.realize_shape_entry_owned(
+                        entry,
                         float_tex,
                         spectrum_tex,
                         materials,
@@ -642,9 +642,9 @@ impl SceneBuilder {
                     area_lights.extend(l);
                 }
             } else {
-                for shape in &def.shapes {
-                    if let Err(e) = self.realize_shape(
-                        shape,
+                for entry in &def.shapes {
+                    if let Err(e) = self.realize_shape_entry(
+                        entry,
                         float_tex,
                         spectrum_tex,
                         materials,
@@ -658,9 +658,9 @@ impl SceneBuilder {
                         return ((*name).clone(), Err(e));
                     }
                 }
-                for shape in &def.animated_shapes {
-                    if let Err(e) = self.realize_shape(
-                        shape,
+                for entry in &def.animated_shapes {
+                    if let Err(e) = self.realize_shape_entry(
+                        entry,
                         float_tex,
                         spectrum_tex,
                         materials,
@@ -748,9 +748,9 @@ impl SceneBuilder {
         if build_parallel {
             // Process static and animated shape entities in declaration order.
             // The parallel path uses par_iter, whose collect preserves order.
-            let realize_static_shape = |shape| {
-                self.realize_shape_owned(
-                    shape,
+            let realize_static_shape = |entry| {
+                self.realize_shape_entry_owned(
+                    entry,
                     float_tex,
                     spectrum_tex,
                     materials,
@@ -760,9 +760,9 @@ impl SceneBuilder {
                     render_from_world,
                 )
             };
-            let realize_animated_shape = |shape| {
-                self.realize_shape_owned(
-                    shape,
+            let realize_animated_shape = |entry| {
+                self.realize_shape_entry_owned(
+                    entry,
                     float_tex,
                     spectrum_tex,
                     materials,
@@ -801,9 +801,9 @@ impl SceneBuilder {
                 area_lights.extend(l);
             }
         } else {
-            for shape in &self.shapes {
-                self.realize_shape(
-                    shape,
+            for entry in &self.shapes {
+                self.realize_shape_entry(
+                    entry,
                     float_tex,
                     spectrum_tex,
                     materials,
@@ -815,9 +815,9 @@ impl SceneBuilder {
                     &mut area_lights,
                 )?;
             }
-            for shape in &self.animated_shapes {
-                self.realize_shape(
-                    shape,
+            for entry in &self.animated_shapes {
+                self.realize_shape_entry(
+                    entry,
                     float_tex,
                     spectrum_tex,
                     materials,
@@ -834,12 +834,12 @@ impl SceneBuilder {
         Ok((prims, area_lights))
     }
 
-    /// Owned-output variant of `realize_shape` for parallel collection. Each
+    /// Owned-output variant of `realize_shape_entry` for parallel collection. Each
     /// parallel task gets its own buffers.
     #[allow(clippy::too_many_arguments)]
-    fn realize_shape_owned(
+    fn realize_shape_entry_owned(
         &self,
-        shape: &ShapeSceneEntity,
+        entry: &ShapeSceneEntity,
         float_tex: &FloatTextureMap,
         spectrum_tex: &SpectrumTextureMap,
         materials: &[Arc<Material>],
@@ -850,8 +850,8 @@ impl SceneBuilder {
     ) -> Result<(Vec<Arc<Primitive>>, Vec<Arc<Light>>), PbrtError> {
         let mut prims = Vec::new();
         let mut area_lights = Vec::new();
-        self.realize_shape(
-            shape,
+        self.realize_shape_entry(
+            entry,
             float_tex,
             spectrum_tex,
             materials,
@@ -863,6 +863,105 @@ impl SceneBuilder {
             &mut area_lights,
         )?;
         Ok((prims, area_lights))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn realize_shape_entry(
+        &self,
+        entry: &ShapeSceneEntity,
+        float_tex: &FloatTextureMap,
+        spectrum_tex: &SpectrumTextureMap,
+        materials: &[Arc<Material>],
+        named_materials: &HashMap<String, Arc<Material>>,
+        default_material: &Arc<Material>,
+        named_media: &MediumMap,
+        render_from_world: &Transform,
+        out_prims: &mut Vec<Arc<Primitive>>,
+        out_area_lights: &mut Vec<Arc<Light>>,
+    ) -> Result<(), PbrtError> {
+        if entry.base.name == CURVES_SHAPE_NAME && entry.child_params.is_empty() {
+            return Err(PbrtError::error(
+                "Shape \"curves\" is reserved for SceneBuilder's internal representation.",
+            ));
+        }
+
+        if entry.base.name == CURVES_SHAPE_NAME {
+            self.realize_curves(
+                entry,
+                float_tex,
+                spectrum_tex,
+                materials,
+                named_materials,
+                default_material,
+                named_media,
+                render_from_world,
+                out_prims,
+                out_area_lights,
+            )
+        } else {
+            self.realize_shape(
+                entry,
+                float_tex,
+                spectrum_tex,
+                materials,
+                named_materials,
+                default_material,
+                named_media,
+                render_from_world,
+                out_prims,
+                out_area_lights,
+            )
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn realize_curves(
+        &self,
+        shape: &ShapeSceneEntity,
+        float_tex: &FloatTextureMap,
+        _spectrum_tex: &SpectrumTextureMap,
+        materials: &[Arc<Material>],
+        named_materials: &HashMap<String, Arc<Material>>,
+        default_material: &Arc<Material>,
+        named_media: &MediumMap,
+        render_from_world: &Transform,
+        out_prims: &mut Vec<Arc<Primitive>>,
+        out_area_lights: &mut Vec<Arc<Light>>,
+    ) -> Result<(), PbrtError> {
+        let rfo = compose_with_render_from_world(&shape.render_from_object, render_from_world);
+        let animated = matches!(rfo, RenderFromObject::Animated { .. });
+        let object_to_world = match &rfo {
+            RenderFromObject::Static(t) => *t,
+            RenderFromObject::Animated { from, .. } => *from,
+        };
+        let shape_object_to_world = if animated {
+            Transform::identity()
+        } else {
+            object_to_world
+        };
+        let shape_sets = Shape::create_curves(
+            &shape_object_to_world,
+            &shape_object_to_world.inverse(),
+            shape.reverse_orientation,
+            &shape.child_params,
+            float_tex,
+        )?;
+        for shapes in shape_sets {
+            self.emit_shape_primitives(
+                shape,
+                rfo.clone(),
+                object_to_world,
+                shapes,
+                false,
+                materials,
+                named_materials,
+                default_material,
+                named_media,
+                out_prims,
+                out_area_lights,
+            )?;
+        }
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -884,9 +983,9 @@ impl SceneBuilder {
         // collapses to identity (the helper short-circuits).
         let rfo = compose_with_render_from_world(&shape.render_from_object, render_from_world);
         let animated = matches!(rfo, RenderFromObject::Animated { .. });
-        let object_to_world = match rfo {
-            RenderFromObject::Static(t) => t,
-            RenderFromObject::Animated { from, .. } => from,
+        let object_to_world = match &rfo {
+            RenderFromObject::Static(t) => *t,
+            RenderFromObject::Animated { from, .. } => *from,
         };
         let shape_object_to_world = if animated {
             Transform::identity()
@@ -923,14 +1022,15 @@ impl SceneBuilder {
                 .get_textures_ref("displacement")
                 .is_some();
 
-        let shapes = match Shape::create(
+        let created_shapes = Shape::create(
             &shape.base.name,
             &shape_object_to_world,
             &shape_object_to_world.inverse(),
             shape.reverse_orientation,
             shape_params_for_create,
             float_tex,
-        ) {
+        );
+        let shapes = match created_shapes {
             Ok(s) => s,
             Err(e) => {
                 return Err(e);
@@ -942,6 +1042,41 @@ impl SceneBuilder {
         let use_dedicated_mesh_accelerator = shape.base.name == "plymesh"
             && shape.area_light_index.is_none()
             && (has_displacement || shapes.len() >= DEDICATED_MESH_BVH_THRESHOLD);
+
+        self.emit_shape_primitives(
+            shape,
+            rfo,
+            object_to_world,
+            shapes,
+            use_dedicated_mesh_accelerator,
+            materials,
+            named_materials,
+            default_material,
+            named_media,
+            out_prims,
+            out_area_lights,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn emit_shape_primitives(
+        &self,
+        shape: &ShapeSceneEntity,
+        rfo: RenderFromObject,
+        object_to_world: Transform,
+        shapes: Vec<Shape>,
+        use_dedicated_mesh_accelerator: bool,
+        materials: &[Arc<Material>],
+        named_materials: &HashMap<String, Arc<Material>>,
+        default_material: &Arc<Material>,
+        named_media: &MediumMap,
+        out_prims: &mut Vec<Arc<Primitive>>,
+        out_area_lights: &mut Vec<Arc<Light>>,
+    ) -> Result<(), PbrtError> {
+        if shapes.is_empty() {
+            return Ok(());
+        }
+        let animated = matches!(rfo, RenderFromObject::Animated { .. });
 
         let material = if shape.material_is_default
             && shape.material_index == usize::MAX

--- a/src/parser/scene_builder/build.rs
+++ b/src/parser/scene_builder/build.rs
@@ -597,7 +597,7 @@ impl SceneBuilder {
 
             if build_parallel {
                 let realize_static_shape = |shape| {
-                    self.realize_shape_entry_owned(
+                    self.realize_shape_owned(
                         shape,
                         float_tex,
                         spectrum_tex,
@@ -611,7 +611,7 @@ impl SceneBuilder {
                 let static_results: Vec<Result<(Vec<Arc<Primitive>>, Vec<Arc<Light>>), PbrtError>> =
                     def.shapes.par_iter().map(realize_static_shape).collect();
                 let realize_animated_shape = |shape| {
-                    self.realize_shape_entry_owned(
+                    self.realize_shape_owned(
                         shape,
                         float_tex,
                         spectrum_tex,
@@ -643,7 +643,7 @@ impl SceneBuilder {
                 }
             } else {
                 for shape in &def.shapes {
-                    if let Err(e) = self.realize_shape_entry(
+                    if let Err(e) = self.realize_shape(
                         shape,
                         float_tex,
                         spectrum_tex,
@@ -659,7 +659,7 @@ impl SceneBuilder {
                     }
                 }
                 for shape in &def.animated_shapes {
-                    if let Err(e) = self.realize_shape_entry(
+                    if let Err(e) = self.realize_shape(
                         shape,
                         float_tex,
                         spectrum_tex,
@@ -749,7 +749,7 @@ impl SceneBuilder {
             // Process static and animated shape entities in declaration order.
             // The parallel path uses par_iter, whose collect preserves order.
             let realize_static_shape = |shape| {
-                self.realize_shape_entry_owned(
+                self.realize_shape_owned(
                     shape,
                     float_tex,
                     spectrum_tex,
@@ -761,7 +761,7 @@ impl SceneBuilder {
                 )
             };
             let realize_animated_shape = |shape| {
-                self.realize_shape_entry_owned(
+                self.realize_shape_owned(
                     shape,
                     float_tex,
                     spectrum_tex,
@@ -802,7 +802,7 @@ impl SceneBuilder {
             }
         } else {
             for shape in &self.shapes {
-                self.realize_shape_entry(
+                self.realize_shape(
                     shape,
                     float_tex,
                     spectrum_tex,
@@ -816,7 +816,7 @@ impl SceneBuilder {
                 )?;
             }
             for shape in &self.animated_shapes {
-                self.realize_shape_entry(
+                self.realize_shape(
                     shape,
                     float_tex,
                     spectrum_tex,
@@ -834,10 +834,10 @@ impl SceneBuilder {
         Ok((prims, area_lights))
     }
 
-    /// Owned-output variant of `realize_shape_entry` for parallel collection. Each
+    /// Owned-output variant of `realize_shape` for parallel collection. Each
     /// parallel task gets its own buffers.
     #[allow(clippy::too_many_arguments)]
-    fn realize_shape_entry_owned(
+    fn realize_shape_owned(
         &self,
         shape: &ShapeSceneEntity,
         float_tex: &FloatTextureMap,
@@ -850,7 +850,7 @@ impl SceneBuilder {
     ) -> Result<(Vec<Arc<Primitive>>, Vec<Arc<Light>>), PbrtError> {
         let mut prims = Vec::new();
         let mut area_lights = Vec::new();
-        self.realize_shape_entry(
+        self.realize_shape(
             shape,
             float_tex,
             spectrum_tex,
@@ -863,55 +863,6 @@ impl SceneBuilder {
             &mut area_lights,
         )?;
         Ok((prims, area_lights))
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn realize_shape_entry(
-        &self,
-        shape: &ShapeSceneEntity,
-        float_tex: &FloatTextureMap,
-        spectrum_tex: &SpectrumTextureMap,
-        materials: &[Arc<Material>],
-        named_materials: &HashMap<String, Arc<Material>>,
-        default_material: &Arc<Material>,
-        named_media: &MediumMap,
-        render_from_world: &Transform,
-        out_prims: &mut Vec<Arc<Primitive>>,
-        out_area_lights: &mut Vec<Arc<Light>>,
-    ) -> Result<(), PbrtError> {
-        if shape.base.name == CURVES_SHAPE_NAME && shape.child_params.is_empty() {
-            return Err(PbrtError::error(
-                "Shape \"curves\" is reserved for SceneBuilder's internal representation.",
-            ));
-        }
-
-        if shape.base.name == CURVES_SHAPE_NAME {
-            self.realize_curves(
-                shape,
-                float_tex,
-                spectrum_tex,
-                materials,
-                named_materials,
-                default_material,
-                named_media,
-                render_from_world,
-                out_prims,
-                out_area_lights,
-            )
-        } else {
-            self.realize_shape(
-                shape,
-                float_tex,
-                spectrum_tex,
-                materials,
-                named_materials,
-                default_material,
-                named_media,
-                render_from_world,
-                out_prims,
-                out_area_lights,
-            )
-        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -969,7 +920,7 @@ impl SceneBuilder {
         &self,
         shape: &ShapeSceneEntity,
         float_tex: &FloatTextureMap,
-        _spectrum_tex: &SpectrumTextureMap,
+        spectrum_tex: &SpectrumTextureMap,
         materials: &[Arc<Material>],
         named_materials: &HashMap<String, Arc<Material>>,
         default_material: &Arc<Material>,
@@ -978,6 +929,27 @@ impl SceneBuilder {
         out_prims: &mut Vec<Arc<Primitive>>,
         out_area_lights: &mut Vec<Arc<Light>>,
     ) -> Result<(), PbrtError> {
+        if shape.base.name == CURVES_SHAPE_NAME && shape.child_params.is_empty() {
+            return Err(PbrtError::error(
+                "Shape \"curves\" is reserved for SceneBuilder's internal representation.",
+            ));
+        }
+
+        if shape.base.name == CURVES_SHAPE_NAME {
+            return self.realize_curves(
+                shape,
+                float_tex,
+                spectrum_tex,
+                materials,
+                named_materials,
+                default_material,
+                named_media,
+                render_from_world,
+                out_prims,
+                out_area_lights,
+            );
+        }
+
         // pbrt-v4 pre-composes shape transforms with `renderFromWorld`
         // before handing them to the shape ctor; for World mode this
         // collapses to identity (the helper short-circuits).

--- a/src/parser/scene_builder/build.rs
+++ b/src/parser/scene_builder/build.rs
@@ -596,9 +596,9 @@ impl SceneBuilder {
             let mut area_lights: Vec<Arc<Light>> = Vec::new();
 
             if build_parallel {
-                let realize_static_shape = |entry| {
+                let realize_static_shape = |shape| {
                     self.realize_shape_entry_owned(
-                        entry,
+                        shape,
                         float_tex,
                         spectrum_tex,
                         materials,
@@ -610,9 +610,9 @@ impl SceneBuilder {
                 };
                 let static_results: Vec<Result<(Vec<Arc<Primitive>>, Vec<Arc<Light>>), PbrtError>> =
                     def.shapes.par_iter().map(realize_static_shape).collect();
-                let realize_animated_shape = |entry| {
+                let realize_animated_shape = |shape| {
                     self.realize_shape_entry_owned(
-                        entry,
+                        shape,
                         float_tex,
                         spectrum_tex,
                         materials,
@@ -642,9 +642,9 @@ impl SceneBuilder {
                     area_lights.extend(l);
                 }
             } else {
-                for entry in &def.shapes {
+                for shape in &def.shapes {
                     if let Err(e) = self.realize_shape_entry(
-                        entry,
+                        shape,
                         float_tex,
                         spectrum_tex,
                         materials,
@@ -658,9 +658,9 @@ impl SceneBuilder {
                         return ((*name).clone(), Err(e));
                     }
                 }
-                for entry in &def.animated_shapes {
+                for shape in &def.animated_shapes {
                     if let Err(e) = self.realize_shape_entry(
-                        entry,
+                        shape,
                         float_tex,
                         spectrum_tex,
                         materials,
@@ -748,9 +748,9 @@ impl SceneBuilder {
         if build_parallel {
             // Process static and animated shape entities in declaration order.
             // The parallel path uses par_iter, whose collect preserves order.
-            let realize_static_shape = |entry| {
+            let realize_static_shape = |shape| {
                 self.realize_shape_entry_owned(
-                    entry,
+                    shape,
                     float_tex,
                     spectrum_tex,
                     materials,
@@ -760,9 +760,9 @@ impl SceneBuilder {
                     render_from_world,
                 )
             };
-            let realize_animated_shape = |entry| {
+            let realize_animated_shape = |shape| {
                 self.realize_shape_entry_owned(
-                    entry,
+                    shape,
                     float_tex,
                     spectrum_tex,
                     materials,
@@ -801,9 +801,9 @@ impl SceneBuilder {
                 area_lights.extend(l);
             }
         } else {
-            for entry in &self.shapes {
+            for shape in &self.shapes {
                 self.realize_shape_entry(
-                    entry,
+                    shape,
                     float_tex,
                     spectrum_tex,
                     materials,
@@ -815,9 +815,9 @@ impl SceneBuilder {
                     &mut area_lights,
                 )?;
             }
-            for entry in &self.animated_shapes {
+            for shape in &self.animated_shapes {
                 self.realize_shape_entry(
-                    entry,
+                    shape,
                     float_tex,
                     spectrum_tex,
                     materials,
@@ -839,7 +839,7 @@ impl SceneBuilder {
     #[allow(clippy::too_many_arguments)]
     fn realize_shape_entry_owned(
         &self,
-        entry: &ShapeSceneEntity,
+        shape: &ShapeSceneEntity,
         float_tex: &FloatTextureMap,
         spectrum_tex: &SpectrumTextureMap,
         materials: &[Arc<Material>],
@@ -851,7 +851,7 @@ impl SceneBuilder {
         let mut prims = Vec::new();
         let mut area_lights = Vec::new();
         self.realize_shape_entry(
-            entry,
+            shape,
             float_tex,
             spectrum_tex,
             materials,
@@ -868,7 +868,7 @@ impl SceneBuilder {
     #[allow(clippy::too_many_arguments)]
     fn realize_shape_entry(
         &self,
-        entry: &ShapeSceneEntity,
+        shape: &ShapeSceneEntity,
         float_tex: &FloatTextureMap,
         spectrum_tex: &SpectrumTextureMap,
         materials: &[Arc<Material>],
@@ -879,15 +879,15 @@ impl SceneBuilder {
         out_prims: &mut Vec<Arc<Primitive>>,
         out_area_lights: &mut Vec<Arc<Light>>,
     ) -> Result<(), PbrtError> {
-        if entry.base.name == CURVES_SHAPE_NAME && entry.child_params.is_empty() {
+        if shape.base.name == CURVES_SHAPE_NAME && shape.child_params.is_empty() {
             return Err(PbrtError::error(
                 "Shape \"curves\" is reserved for SceneBuilder's internal representation.",
             ));
         }
 
-        if entry.base.name == CURVES_SHAPE_NAME {
+        if shape.base.name == CURVES_SHAPE_NAME {
             self.realize_curves(
-                entry,
+                shape,
                 float_tex,
                 spectrum_tex,
                 materials,
@@ -900,7 +900,7 @@ impl SceneBuilder {
             )
         } else {
             self.realize_shape(
-                entry,
+                shape,
                 float_tex,
                 spectrum_tex,
                 materials,

--- a/src/parser/scene_builder/mod.rs
+++ b/src/parser/scene_builder/mod.rs
@@ -36,6 +36,8 @@ use crate::util::transform::transform_set::{TransformSet, ALL_TRANSFORM_BITS};
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
+const CURVES_SHAPE_NAME: &str = "curves";
+
 /// Parse-time state for the SceneBuilder loader, equivalent to the
 /// `BasicScene` + `BasicSceneBuilder` pair in pbrt-v4. The entity
 /// vectors accumulate immutably until `build()`; the other fields

--- a/src/parser/scene_builder/parse_target_impl.rs
+++ b/src/parser/scene_builder/parse_target_impl.rs
@@ -13,7 +13,7 @@ use super::scene_entity::{
     TextureSceneEntity, TransformedSceneEntity,
 };
 use super::state::{ApiState, PushKind};
-use super::SceneBuilder;
+use super::{SceneBuilder, CURVES_SHAPE_NAME};
 use crate::options::PbrtOptions;
 use crate::paramdict::ParameterDictionary;
 use crate::parser::{parse_file, parse_target::ParseTarget};
@@ -28,6 +28,73 @@ use log::{error, info, warn};
 use std::path::Path;
 
 impl SceneBuilder {
+    fn append_shape(shapes: &mut Vec<ShapeSceneEntity>, mut shape: ShapeSceneEntity) {
+        if let Some(parent) = shapes.last_mut() {
+            if Self::can_group_shapes(parent, &shape) {
+                parent.child_params.push(shape.base.params);
+                return;
+            }
+        }
+
+        if shape.base.name == "curve" && shape.area_light_index.is_none() {
+            shape.base.name = CURVES_SHAPE_NAME.to_owned();
+            shape
+                .child_params
+                .push(std::mem::take(&mut shape.base.params));
+        }
+        shapes.push(shape);
+    }
+
+    fn can_group_shapes(parent: &ShapeSceneEntity, child: &ShapeSceneEntity) -> bool {
+        if parent.base.name != CURVES_SHAPE_NAME
+            || child.base.name != "curve"
+            || parent.area_light_index.is_some()
+            || child.area_light_index.is_some()
+        {
+            return false;
+        }
+
+        if parent.render_from_object != child.render_from_object
+            || parent.reverse_orientation != child.reverse_orientation
+            || parent.material_index != child.material_index
+            || parent.material_name != child.material_name
+            || parent.material_is_default != child.material_is_default
+            || parent.medium_interface != child.medium_interface
+            || parent.instance_name != child.instance_name
+        {
+            return false;
+        }
+
+        let Some(parent_params) = parent.child_params.last() else {
+            return false;
+        };
+        Self::curve_params_share_group(parent_params, &child.base.params)
+    }
+
+    fn curve_params_share_group(a: &ParameterDictionary, b: &ParameterDictionary) -> bool {
+        a.get_one_string("type", "flat") == b.get_one_string("type", "flat")
+            && Self::same_curve_parameter(a, b, "alpha")
+            && Self::same_curve_parameter(a, b, "shadowalpha")
+    }
+
+    fn same_curve_parameter(a: &ParameterDictionary, b: &ParameterDictionary, name: &str) -> bool {
+        let a_textures = a.get_textures_ref(name);
+        let b_textures = b.get_textures_ref(name);
+        match (a_textures.as_ref(), b_textures.as_ref()) {
+            (Some(a), Some(b)) => return a.as_slice() == b.as_slice(),
+            (Some(_), None) | (None, Some(_)) => return false,
+            (None, None) => {}
+        }
+
+        let a_values = a.get_floats_ref(name);
+        let b_values = b.get_floats_ref(name);
+        match (a_values.as_ref(), b_values.as_ref()) {
+            (Some(a), Some(b)) => a.as_slice() == b.as_slice(),
+            (Some(_), None) | (None, Some(_)) => false,
+            (None, None) => true,
+        }
+    }
+
     fn verify_options(&self, fun: &str) {
         if self.api_state != ApiState::OptionsBlock {
             error!(
@@ -507,6 +574,7 @@ impl ParseTarget for SceneBuilder {
         let gs = self.top_graphics_state();
         let entity = ShapeSceneEntity {
             base: SceneEntity::new(name, params, self.current_file_loc()),
+            child_params: Vec::new(),
             render_from_object: render_from_object.clone(),
             reverse_orientation: gs.reverse_orientation,
             material_index: gs.current_material_index.unwrap_or(usize::MAX),
@@ -529,14 +597,14 @@ impl ParseTarget for SceneBuilder {
                     animated_shapes: Vec::new(),
                 });
             if animated {
-                def.animated_shapes.push(entity);
+                Self::append_shape(&mut def.animated_shapes, entity);
             } else {
-                def.shapes.push(entity);
+                Self::append_shape(&mut def.shapes, entity);
             }
         } else if animated {
-            self.animated_shapes.push(entity);
+            Self::append_shape(&mut self.animated_shapes, entity);
         } else {
-            self.shapes.push(entity);
+            Self::append_shape(&mut self.shapes, entity);
         }
     }
 

--- a/src/parser/scene_builder/scene_entity.rs
+++ b/src/parser/scene_builder/scene_entity.rs
@@ -73,7 +73,7 @@ pub struct TransformedSceneEntity {
 /// time, but for the deferred-build intermediate it is safer to hold
 /// only the names (Medium itself becomes an entity in SceneBuilder
 /// too).
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct MediumInterfaceNames {
     pub inside_medium: String,
     pub outside_medium: String,
@@ -96,7 +96,7 @@ impl MediumInterfaceNames {
 /// a single matrix; `Animated` holds the two-matrix interpolation
 /// pair plus the time interval. This is the source data for building
 /// v4's `AnimatedTransform` equivalent in the end.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum RenderFromObject {
     Static(Transform),
     Animated {
@@ -142,6 +142,9 @@ impl RenderFromObject {
 #[derive(Clone)]
 pub struct ShapeSceneEntity {
     pub base: SceneEntity,
+    /// Parameters for consecutive child shapes that share this entity's
+    /// transform and shading state. Empty for shapes that are not grouped.
+    pub child_params: Vec<ParameterDictionary>,
     pub render_from_object: RenderFromObject,
     pub reverse_orientation: bool,
     /// Resolved later as `materials[material_index]`. `usize::MAX`

--- a/src/shapes/curve.rs
+++ b/src/shapes/curve.rs
@@ -23,6 +23,17 @@ pub enum CurveType {
     Ribbon,
 }
 
+impl CurveType {
+    fn parse(s: &str) -> Result<Self, PbrtError> {
+        match s {
+            "flat" => Ok(Self::Flat),
+            "ribbon" => Ok(Self::Ribbon),
+            "cylinder" => Ok(Self::Cylinder),
+            _ => Err(PbrtError::error(&format!("Unknown curve type \"{}\".", s))),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct CurveNormal {
     pub n: [Normal3f; 2],
@@ -30,11 +41,16 @@ pub struct CurveNormal {
     pub inv_sin_normal_angle: Float,
 }
 
+#[derive(Debug)]
+struct CurvesCommon {
+    base: BaseShape,
+    curve_type: CurveType,
+}
+
 // CurveCommon Declarations
 #[derive(Debug, Clone)]
 pub struct CurveCommon {
-    pub base: BaseShape,
-    pub t: CurveType,
+    curves: Arc<CurvesCommon>,
     pub cp_obj: [Point3f; 4],
     pub width: [Float; 2],
     pub normals: Option<CurveNormal>,
@@ -112,6 +128,20 @@ fn transform_lookat(e: &Point3f, l: &Point3f, u: &Vector3f) -> Transform {
     return Transform::look_at(e.x, e.y, e.z, l.x, l.y, l.z, u.x, u.y, u.z);
 }
 
+impl CurvesCommon {
+    fn new(
+        o2w: &Transform,
+        w2o: &Transform,
+        reverse_orientation: bool,
+        curve_type: CurveType,
+    ) -> Self {
+        Self {
+            base: BaseShape::new(o2w, w2o, reverse_orientation),
+            curve_type,
+        }
+    }
+}
+
 impl CurveCommon {
     pub fn new(
         o2w: &Transform,
@@ -120,7 +150,18 @@ impl CurveCommon {
         c: &[Point3f],
         w0: Float,
         w1: Float,
-        t: CurveType,
+        curve_type: CurveType,
+        norm: &Option<Vec<Normal3f>>,
+    ) -> Self {
+        let curves = Arc::new(CurvesCommon::new(o2w, w2o, reverse_orientation, curve_type));
+        Self::new_with_common(&curves, c, w0, w1, norm)
+    }
+
+    fn new_with_common(
+        curves: &Arc<CurvesCommon>,
+        c: &[Point3f],
+        w0: Float,
+        w1: Float,
         norm: &Option<Vec<Normal3f>>,
     ) -> Self {
         let cp_obj: Vec<Point3f> = c.to_vec();
@@ -141,8 +182,7 @@ impl CurveCommon {
             None => None,
         };
         CurveCommon {
-            base: BaseShape::new(o2w, w2o, reverse_orientation),
-            t,
+            curves: Arc::clone(curves),
             cp_obj,
             width,
             normals,
@@ -181,7 +221,7 @@ fn recursive_intersect(
 ) -> Option<(Float, Option<SurfaceInteraction>)> {
     let mut t_max = t_max;
     let width = &common.width;
-    let t = common.t;
+    let t = common.curves.curve_type;
     let normals = &common.normals;
     let ray_length = ray.d.length();
 
@@ -362,7 +402,7 @@ fn recursive_intersect(
             let p = ray.o + t_hit * ray.d;
             let uv = Point2f::new(u, v); //u, v
             let wo = -ray.d;
-            let mut n = common.base.calc_normal(&dpdu, &dpdv);
+            let mut n = common.curves.base.calc_normal(&dpdu, &dpdv);
             if Vector3f::dot(&ray.d, &n) > 0.0 {
                 n *= -1.0;
             }
@@ -380,6 +420,7 @@ fn recursive_intersect(
                 0,
             );
             let si = common
+                .curves
                 .base
                 .object_to_world
                 .transform_surface_interaction(&si);
@@ -426,7 +467,7 @@ impl Curve {
         let u_max = self.u_max;
         let common = self.common.as_ref();
         // Transform _Ray_ to object space
-        let (ray, _o_err, _d_err) = common.base.world_to_object.transform_ray(r);
+        let (ray, _o_err, _d_err) = common.curves.base.world_to_object.transform_ray(r);
         // Compute object-space control points for curve segment, _cpObj_
         let cp_obj = [
             blossom_bezier(&common.cp_obj, u_min, u_min, u_min),
@@ -562,7 +603,7 @@ impl Curve {
     pub fn world_bound(&self) -> Bounds3f {
         let common = self.common.as_ref();
         let b = self.object_bound();
-        let b = common.base.object_to_world.transform_bounds(&b);
+        let b = common.curves.base.object_to_world.transform_bounds(&b);
         return b;
     }
 
@@ -628,7 +669,7 @@ impl Curve {
         let tangent = dpdu_obj.normalize();
         let (sx, sy) = coordinate_system(&tangent);
         let mut dpdv_obj = sx * width;
-        let n_obj = match common.t {
+        let n_obj = match common.curves.curve_type {
             CurveType::Ribbon => {
                 if let Some(n) = &common.normals {
                     let sin0 =
@@ -638,7 +679,7 @@ impl Curve {
                     dpdv_obj = Vector3f::cross(&n_hit, &tangent).normalize() * width;
                     n_hit
                 } else {
-                    common.base.calc_normal(&dpdu_obj, &dpdv_obj)
+                    common.curves.base.calc_normal(&dpdu_obj, &dpdv_obj)
                 }
             }
             CurveType::Cylinder => {
@@ -646,18 +687,20 @@ impl Curve {
                 let theta = radians(lerp(v_curve, -90.0, 90.0));
                 let around = Float::cos(theta) * sx + Float::sin(theta) * sy;
                 dpdv_obj = around.normalize() * width;
-                common.base.calc_normal(&dpdu_obj, &dpdv_obj)
+                common.curves.base.calc_normal(&dpdu_obj, &dpdv_obj)
             }
-            CurveType::Flat => common.base.calc_normal(&dpdu_obj, &dpdv_obj),
+            CurveType::Flat => common.curves.base.calc_normal(&dpdu_obj, &dpdv_obj),
         };
 
         let p_obj = p_center + (v_curve - 0.5) * dpdv_obj;
         let p_obj_error = GAMMA3 * Vector3f::new(p_obj.x, p_obj.y, p_obj.z).abs();
         let (p, p_error) = common
+            .curves
             .base
             .object_to_world
             .transform_point_with_abs_error(&p_obj, &p_obj_error);
         let n_world = common
+            .curves
             .base
             .object_to_world
             .transform_normal(&n_obj)
@@ -730,27 +773,15 @@ impl Curve {
 }
 
 fn create_curve(
-    o2w: &Transform,
-    w2o: &Transform,
-    reverse_orientation: bool,
+    curves_common: &Arc<CurvesCommon>,
     c: &[Point3f],
     w0: Float,
     w1: Float,
-    t: CurveType,
     norm: &Option<Vec<Normal3f>>,
     split_depth: i32,
 ) -> Result<Vec<Curve>, PbrtError> {
     let mut segments: Vec<Curve> = Vec::new();
-    let common = Arc::new(CurveCommon::new(
-        o2w,
-        w2o,
-        reverse_orientation,
-        c,
-        w0,
-        w1,
-        t,
-        norm,
-    ));
+    let common = Arc::new(CurveCommon::new_with_common(curves_common, c, w0, w1, norm));
     let n_segments = (1 << split_depth) as usize;
     segments.reserve(n_segments);
     for i in 0..n_segments {
@@ -760,18 +791,6 @@ fn create_curve(
         segments.push(curve);
     }
     return Ok(segments);
-}
-
-fn get_curve_type(s: &str) -> Result<CurveType, PbrtError> {
-    return match s {
-        "flat" => Ok(CurveType::Flat),
-        "ribbon" => Ok(CurveType::Ribbon),
-        "cylinder" => Ok(CurveType::Cylinder),
-        _ => {
-            let msg = format!("Unknown curve type \"{}\".", s);
-            return Err(PbrtError::error(&msg));
-        }
-    };
 }
 
 fn convert_to_point(f: &[Float]) -> Vec<Point3f> {
@@ -789,6 +808,51 @@ pub fn create_curve_shape(
     reverse_orientation: bool,
     params: &ParameterDictionary,
 ) -> Result<Vec<Curve>, PbrtError> {
+    create_curve_shape_impl(params, |curve_type| {
+        Ok(Arc::new(CurvesCommon::new(
+            o2w,
+            w2o,
+            reverse_orientation,
+            curve_type,
+        )))
+    })
+}
+
+pub fn create_curves_shape(
+    o2w: &Transform,
+    w2o: &Transform,
+    reverse_orientation: bool,
+    shape_params: &[ParameterDictionary],
+) -> Result<Vec<Vec<Curve>>, PbrtError> {
+    let Some(first) = shape_params.first() else {
+        return Err(PbrtError::error(
+            "create_curves_shape requires at least one curve parameter dictionary.",
+        ));
+    };
+    let curve_type = CurveType::parse(&first.get_one_string("type", "flat"))?;
+    let common = Arc::new(CurvesCommon::new(o2w, w2o, reverse_orientation, curve_type));
+    let mut curve_sets = Vec::with_capacity(shape_params.len());
+    for params in shape_params {
+        let curves = create_curve_shape_impl(params, |curve_type| {
+            if common.curve_type != curve_type {
+                return Err(PbrtError::error(
+                    "Curve types in one curves shape must match.",
+                ));
+            }
+            Ok(Arc::clone(&common))
+        })?;
+        curve_sets.push(curves);
+    }
+    Ok(curve_sets)
+}
+
+fn create_curve_shape_impl<F>(
+    params: &ParameterDictionary,
+    make_common: F,
+) -> Result<Vec<Curve>, PbrtError>
+where
+    F: FnOnce(CurveType) -> Result<Arc<CurvesCommon>, PbrtError>,
+{
     let width = params.get_one_float("width", 1.0);
     let width0 = params.get_one_float("width0", width);
     let width1 = params.get_one_float("width1", width);
@@ -855,8 +919,8 @@ pub fn create_curve_shape(
         }
     };
 
-    let curve_type = params.get_one_string("type", "flat");
-    let curve_type = get_curve_type(&curve_type)?;
+    let curve_type = CurveType::parse(&params.get_one_string("type", "flat"))?;
+    let curves_common = make_common(curve_type)?;
 
     let n = params.get_points_ref("N");
     let mut n = n.as_ref().map(|nn| convert_to_point(nn));
@@ -951,17 +1015,7 @@ pub fn create_curve_shape(
         }
         let w0 = lerp((seg as Float) / (n_segments as Float), width0, width1);
         let w1 = lerp(((seg + 1) as Float) / (n_segments as Float), width0, width1);
-        let mut c = create_curve(
-            o2w,
-            w2o,
-            reverse_orientation,
-            &seg_cp_bezier,
-            w0,
-            w1,
-            curve_type,
-            &n,
-            sd,
-        )?;
+        let mut c = create_curve(&curves_common, &seg_cp_bezier, w0, w1, &n, sd)?;
         curves.append(&mut c);
     }
 

--- a/tests/curve_shape.rs
+++ b/tests/curve_shape.rs
@@ -1,5 +1,52 @@
 use pbrt_r4::prelude::*;
-use pbrt_r4::shapes::create_curve_shape;
+
+use pbrt_r4::shapes::{create_curve_shape, create_curves_shape};
+
+fn assert_close(a: Float, b: Float) {
+    assert!((a - b).abs() < 1e-4, "{a} != {b}");
+}
+
+fn assert_vector_close(a: &Vector3f, b: &Vector3f) {
+    assert_close(a.x, b.x);
+    assert_close(a.y, b.y);
+    assert_close(a.z, b.z);
+}
+
+fn curve_params(curve_type: &str) -> ParameterDictionary {
+    let mut params = ParameterDictionary::new();
+    params.add_string("type", curve_type);
+    params.add_int("splitdepth", 0);
+    params.add_point(
+        "P",
+        &[
+            0.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, //
+            1.0, 0.0, 1.0, //
+            1.0, 0.0, 2.0,
+        ],
+    );
+    params
+}
+
+fn intersectable_curve_params(curve_type: &str, split_depth: i32) -> ParameterDictionary {
+    let mut params = ParameterDictionary::new();
+    params.add_string("type", curve_type);
+    params.add_int("splitdepth", split_depth);
+    params.add_float("width", 0.2);
+    params.add_point(
+        "P",
+        &[
+            0.0, 0.0, 0.0, //
+            0.3, 0.0, 0.0, //
+            0.7, 0.0, 0.0, //
+            1.0, 0.0, 0.0,
+        ],
+    );
+    if curve_type == "ribbon" {
+        params.add_point("N", &[0.0, -0.2, 0.98, 0.0, 0.2, 0.98]);
+    }
+    params
+}
 
 #[test]
 fn create_curve_shape_rejects_unknown_basis() {
@@ -36,4 +83,116 @@ fn create_curve_shape_rejects_too_few_control_points() {
         &params,
     );
     assert!(result.is_err());
+}
+
+#[test]
+fn create_curves_shape_preserves_input_shape_groups() {
+    let transform = Transform::identity();
+    let params = [curve_params("flat"), curve_params("flat")];
+
+    let curve_sets = create_curves_shape(&transform, &transform, false, &params).unwrap();
+
+    assert_eq!(curve_sets.len(), 2);
+    assert_eq!(curve_sets[0].len(), 1);
+    assert_eq!(curve_sets[1].len(), 1);
+}
+
+#[test]
+fn shape_create_curves_accepts_multiple_parameter_dictionaries() {
+    let transform = Transform::identity();
+    let shape_params = [curve_params("flat"), curve_params("flat")];
+
+    let shape_sets = Shape::create_curves(
+        &transform,
+        &transform,
+        false,
+        &shape_params,
+        &Default::default(),
+    )
+    .unwrap();
+
+    assert_eq!(shape_sets.len(), 2);
+    assert!(shape_sets
+        .iter()
+        .all(|shapes| matches!(shapes.as_slice(), [Shape::Curve(_)])));
+}
+
+#[test]
+fn create_curves_shape_rejects_mixed_curve_types() {
+    let transform = Transform::identity();
+    let params = [curve_params("flat"), curve_params("cylinder")];
+
+    assert!(create_curves_shape(&transform, &transform, false, &params).is_err());
+}
+
+#[test]
+fn grouped_curves_match_standalone_intersections_for_types_and_transforms() {
+    let transforms = [
+        Transform::identity(),
+        Transform::translate(1.5, -0.5, 2.0),
+        Transform::rotate_y(35.0),
+        Transform::scale(1.5, 0.75, 2.0),
+    ];
+
+    for curve_type in ["flat", "ribbon", "cylinder"] {
+        let params = intersectable_curve_params(curve_type, 0);
+        for render_from_object in transforms {
+            let object_from_render = render_from_object.inverse();
+            let standalone =
+                create_curve_shape(&render_from_object, &object_from_render, false, &params)
+                    .unwrap();
+            let grouped = Shape::create_curves(
+                &render_from_object,
+                &object_from_render,
+                false,
+                std::slice::from_ref(&params),
+                &Default::default(),
+            )
+            .unwrap();
+
+            let ray = Ray::new(
+                &render_from_object.transform_point(&Point3f::new(0.5, 0.0, -1.0)),
+                &render_from_object.transform_vector(&Vector3f::new(0.0, 0.0, 1.0)),
+                Float::INFINITY,
+                0.0,
+            );
+            let expected = standalone[0]
+                .intersect(&ray, Float::INFINITY)
+                .unwrap_or_else(|| panic!("standalone {curve_type} curve should intersect"));
+            let actual = grouped[0][0]
+                .intersect(&ray, Float::INFINITY)
+                .unwrap_or_else(|| panic!("grouped {curve_type} curve should intersect"));
+
+            assert_close(actual.t_hit, expected.t_hit);
+            assert_vector_close(&actual.intr.p, &expected.intr.p);
+            assert_vector_close(&actual.intr.n, &expected.intr.n);
+            assert_vector_close(&actual.intr.wo, &expected.intr.wo);
+        }
+    }
+}
+
+#[test]
+fn splitdepth_preserves_grouped_curve_intersections() {
+    let transform = Transform::identity();
+    let params = intersectable_curve_params("flat", 2);
+    let standalone = create_curve_shape(&transform, &transform, false, &params).unwrap();
+    let grouped =
+        create_curves_shape(&transform, &transform, false, std::slice::from_ref(&params)).unwrap();
+
+    assert_eq!(standalone.len(), 4);
+    assert_eq!(grouped[0].len(), 4);
+    let ray = Ray::new(
+        &Point3f::new(0.125, 0.0, -1.0),
+        &Vector3f::new(0.0, 0.0, 1.0),
+        Float::INFINITY,
+        0.0,
+    );
+    assert_eq!(
+        standalone
+            .iter()
+            .any(|curve| curve.intersect_p(&ray, Float::INFINITY)),
+        grouped[0]
+            .iter()
+            .any(|curve| curve.intersect_p(&ray, Float::INFINITY))
+    );
 }

--- a/tests/curves_scene_build.rs
+++ b/tests/curves_scene_build.rs
@@ -1,0 +1,96 @@
+use pbrt_r4::util::imageio::read_image::read_image;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn write_scene(path: &Path, output: &Path) {
+    let scene = format!(
+        r#"Integrator "diagnostic" "string mode" "normal" "string filename" "{}"
+Film "rgb" "integer xresolution" 16 "integer yresolution" 16
+Sampler "independent" "integer pixelsamples" 1
+LookAt 0 0 -3  0 0 0  0 1 0
+Camera "perspective" "float fov" 40
+WorldBegin
+Material "diffuse" "rgb reflectance" [ 0.5 0.5 0.5 ]
+Shape "curve" "float width" 0.25
+    "point3 P" [ -0.8 0 0  -0.3 0 0  0.3 0 0  0.8 0 0 ]
+Shape "curve" "float width" 0.25
+    "point3 P" [ -0.8 0.4 0  -0.3 0.4 0  0.3 0.4 0  0.8 0.4 0 ]
+"#,
+        output.display()
+    );
+    fs::write(path, scene).unwrap();
+}
+
+fn render(scene: &Path, mode: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_pbrt-r4"))
+        .args([
+            "--quiet",
+            "--nthreads",
+            "1",
+            "--scene-build",
+            mode,
+            "--scene-build-jobs",
+            "2",
+        ])
+        .arg(scene)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{mode} scene build failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn serial_and_parallel_curve_scene_builds_match() {
+    let dir = tempfile::tempdir().unwrap();
+    let serial_scene = dir.path().join("serial.pbrt");
+    let parallel_scene = dir.path().join("parallel.pbrt");
+    let serial_output = dir.path().join("serial.exr");
+    let parallel_output = dir.path().join("parallel.exr");
+    write_scene(&serial_scene, &serial_output);
+    write_scene(&parallel_scene, &parallel_output);
+
+    render(&serial_scene, "serial");
+    render(&parallel_scene, "parallel");
+
+    let (serial_pixels, serial_resolution) = read_image(serial_output.to_str().unwrap()).unwrap();
+    let (parallel_pixels, parallel_resolution) =
+        read_image(parallel_output.to_str().unwrap()).unwrap();
+    assert_eq!(serial_resolution, parallel_resolution);
+    assert_eq!(serial_pixels.len(), parallel_pixels.len());
+    for (serial, parallel) in serial_pixels.iter().zip(&parallel_pixels) {
+        assert_eq!(serial, parallel);
+    }
+}
+
+#[test]
+fn curves_shape_input_is_rejected_without_panicking() {
+    let dir = tempfile::tempdir().unwrap();
+    let scene = dir.path().join("reserved-curves.pbrt");
+    fs::write(
+        &scene,
+        r#"WorldBegin
+Shape "curves"
+Shape "curve"
+    "point3 P" [ 0 0 0  0 0 1  1 0 1  1 0 2 ]
+WorldEnd
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pbrt-r4"))
+        .args(["--quiet", "--scene-build", "serial"])
+        .arg(scene)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Shape \"curves\" is reserved"),
+        "unexpected error: {stderr}"
+    );
+}

--- a/tests/curves_scene_entity.rs
+++ b/tests/curves_scene_entity.rs
@@ -1,0 +1,178 @@
+use pbrt_r4::parser::{parse_string, SceneBuilder};
+
+const CURVE: &str = r#"Shape "curve"
+    "point3 P" [ 0 0 0  0 0 1  1 0 1  1 0 2 ]"#;
+
+#[test]
+fn consecutive_curve_directives_form_one_shape_scene_entity() {
+    let mut builder = SceneBuilder::new();
+    let scene = format!("WorldBegin\n{CURVE}\n{CURVE}\nWorldEnd\n");
+
+    parse_string(&scene, &mut builder).expect("scene should parse");
+
+    assert_eq!(builder.shapes.len(), 1);
+    assert_eq!(builder.shapes[0].base.name, "curves");
+    assert!(builder.shapes[0].base.params.get_points_ref("P").is_none());
+    assert_eq!(builder.shapes[0].child_params.len(), 2);
+}
+
+#[test]
+fn non_curve_shape_ends_a_curves_group() {
+    let mut builder = SceneBuilder::new();
+    let scene = format!("WorldBegin\n{CURVE}\nShape \"sphere\"\n{CURVE}\nWorldEnd\n");
+
+    parse_string(&scene, &mut builder).expect("scene should parse");
+
+    assert_eq!(builder.shapes.len(), 3);
+    assert_eq!(builder.shapes[0].base.name, "curves");
+    assert_eq!(builder.shapes[1].base.name, "sphere");
+    assert_eq!(builder.shapes[2].base.name, "curves");
+    assert_eq!(builder.shapes[0].child_params.len(), 1);
+    assert!(builder.shapes[1].child_params.is_empty());
+    assert_eq!(builder.shapes[2].child_params.len(), 1);
+}
+
+#[test]
+fn transform_type_and_orientation_changes_end_curves_groups() {
+    let mut builder = SceneBuilder::new();
+    let scene = format!(
+        r#"WorldBegin
+{CURVE}
+Translate 1 0 0
+{CURVE}
+Shape "curve" "string type" "cylinder"
+    "point3 P" [ 0 0 0  0 0 1  1 0 1  1 0 2 ]
+ReverseOrientation
+Shape "curve" "string type" "cylinder"
+    "point3 P" [ 0 0 0  0 0 1  1 0 1  1 0 2 ]
+WorldEnd
+"#
+    );
+
+    parse_string(&scene, &mut builder).expect("scene should parse");
+
+    assert_eq!(builder.shapes.len(), 4);
+    assert!(builder
+        .shapes
+        .iter()
+        .all(|shape| shape.base.name == "curves" && shape.child_params.len() == 1));
+}
+
+#[test]
+fn area_light_curves_remain_individual_shape_entries() {
+    let mut builder = SceneBuilder::new();
+    let scene = format!(
+        "WorldBegin\nAreaLightSource \"diffuse\" \"rgb L\" [ 1 1 1 ]\n{CURVE}\n{CURVE}\nWorldEnd\n"
+    );
+
+    parse_string(&scene, &mut builder).expect("scene should parse");
+
+    assert_eq!(builder.area_lights.len(), 2);
+    assert_eq!(builder.shapes.len(), 2);
+    assert!(builder
+        .shapes
+        .iter()
+        .all(|shape| shape.base.name == "curve" && shape.child_params.is_empty()));
+}
+
+#[test]
+fn material_and_alpha_changes_end_curves_groups() {
+    let mut builder = SceneBuilder::new();
+    let scene = format!(
+        r#"WorldBegin
+{CURVE}
+Material "diffuse"
+{CURVE}
+Shape "curve"
+    "point3 P" [ 0 0 0  0 0 1  1 0 1  1 0 2 ]
+    "float alpha" [ 0.5 ]
+WorldEnd
+"#
+    );
+
+    parse_string(&scene, &mut builder).expect("scene should parse");
+
+    assert_eq!(builder.shapes.len(), 3);
+    assert!(builder
+        .shapes
+        .iter()
+        .all(|shape| shape.base.name == "curves" && shape.child_params.len() == 1));
+}
+
+#[test]
+fn twosided_does_not_end_a_curves_group() {
+    let mut builder = SceneBuilder::new();
+    let scene = format!(
+        r#"WorldBegin
+{CURVE}
+Shape "curve"
+    "bool twosided" [ true ]
+    "point3 P" [ 0 0 0  0 0 1  1 0 1  1 0 2 ]
+WorldEnd
+"#
+    );
+
+    parse_string(&scene, &mut builder).expect("scene should parse");
+
+    assert_eq!(builder.shapes.len(), 1);
+    assert_eq!(builder.shapes[0].child_params.len(), 2);
+}
+
+#[test]
+fn medium_interface_change_ends_a_curves_group() {
+    let mut builder = SceneBuilder::new();
+    let scene = format!(
+        r#"WorldBegin
+{CURVE}
+MediumInterface "fog" ""
+{CURVE}
+WorldEnd
+"#
+    );
+
+    parse_string(&scene, &mut builder).expect("scene should parse");
+
+    assert_eq!(builder.shapes.len(), 2);
+    assert!(builder
+        .shapes
+        .iter()
+        .all(|shape| shape.base.name == "curves" && shape.child_params.len() == 1));
+}
+
+#[test]
+fn consecutive_animated_curves_form_one_group() {
+    let mut builder = SceneBuilder::new();
+    let scene = format!(
+        r#"WorldBegin
+ActiveTransform StartTime
+Translate 1 0 0
+ActiveTransform EndTime
+Translate 2 0 0
+ActiveTransform All
+{CURVE}
+{CURVE}
+WorldEnd
+"#
+    );
+
+    parse_string(&scene, &mut builder).expect("scene should parse");
+
+    assert!(builder.shapes.is_empty());
+    assert_eq!(builder.animated_shapes.len(), 1);
+    assert_eq!(builder.animated_shapes[0].child_params.len(), 2);
+}
+
+#[test]
+fn curves_inside_an_object_definition_are_grouped_locally() {
+    let mut builder = SceneBuilder::new();
+    let scene = format!(
+        "WorldBegin\nObjectBegin \"hair\"\n{CURVE}\n{CURVE}\nObjectEnd\nObjectInstance \"hair\"\nWorldEnd\n"
+    );
+
+    parse_string(&scene, &mut builder).expect("scene should parse");
+
+    assert!(builder.shapes.is_empty());
+    let definition = &builder.instance_definitions["hair"];
+    assert_eq!(definition.shapes.len(), 1);
+    assert_eq!(definition.shapes[0].child_params.len(), 2);
+}


### PR DESCRIPTION
Summary:

- Group consecutive compatible Curve directives in SceneBuilder while preserving material, medium, transform, orientation, alpha, instance, and area-light boundaries.
- Share CurvesCommon state across logical curves and retain per-segment CurveCommon sharing.
- Reject the internal-only `Shape "curves"` input without panicking.
- Add grouping, geometry-equivalence, serial/parallel build, and reserved-name regression tests.

Validation:

- `cargo fmt -- --check`
- `cargo test --test curve_shape --test curves_scene_entity --test curves_scene_build`
- `cargo test -q`
- `git diff --check`
- hair-eumel-2 quick render: peak RSS reduced from 6,649,032 KiB to 5,818,832 KiB (~12.5%); rendered image hash unchanged