### PR TITLE
perf: align HLBVH SAH and avoid treelet clones

### DIFF
--- a/src/cpu/aggregates/bvh/build/hlbvh.rs
+++ b/src/cpu/aggregates/bvh/build/hlbvh.rs
@@ -248,9 +248,9 @@ struct BucketInfo {
     pub bounds: Bounds3f,
 }
 
-fn build_upper_sah(treelet_roots: &[Box<BVHBuildNode>]) -> Box<BVHBuildNode> {
-    if treelet_roots.len() <= 1 {
-        return treelet_roots[0].clone();
+fn build_upper_sah(treelet_roots: Vec<Box<BVHBuildNode>>) -> Box<BVHBuildNode> {
+    if treelet_roots.len() == 1 {
+        return treelet_roots.into_iter().next().unwrap();
     }
 
     let mut bounds = treelet_roots[0].bounds;
@@ -314,34 +314,23 @@ fn build_upper_sah(treelet_roots: &[Box<BVHBuildNode>]) -> Box<BVHBuildNode> {
     }
 
     // Split nodes and create interior HLBVH SAH node
-    let (c0, c1): (Vec<&Box<BVHBuildNode>>, Vec<&Box<BVHBuildNode>>) =
-        treelet_roots.iter().partition(|node| -> bool {
-            let c = (node.bounds.min[dim] + node.bounds.max[dim]) * 0.5;
-            let b = (N_BUCKETS as Float
-                * ((c - centroid_bounds.min[dim])
-                    / (centroid_bounds.max[dim] - centroid_bounds.min[dim])))
-                as usize;
-            let b = usize::min(b, N_BUCKETS - 1);
-            return b <= min_cost_split_bucket;
-        });
-
-    let node0;
-    {
-        let mut cc: Vec<Box<BVHBuildNode>> = Vec::new();
-        for c in c0.iter() {
-            cc.push((*c).clone());
+    let mut c0 = Vec::new();
+    let mut c1 = Vec::new();
+    for node in treelet_roots {
+        let c = (node.bounds.min[dim] + node.bounds.max[dim]) * 0.5;
+        let b = (N_BUCKETS as Float
+            * ((c - centroid_bounds.min[dim])
+                / (centroid_bounds.max[dim] - centroid_bounds.min[dim]))) as usize;
+        let b = usize::min(b, N_BUCKETS - 1);
+        if b <= min_cost_split_bucket {
+            c0.push(node);
+        } else {
+            c1.push(node);
         }
-        node0 = Some(build_upper_sah(&cc));
     }
 
-    let node1;
-    {
-        let mut cc: Vec<Box<BVHBuildNode>> = Vec::new();
-        for c in c1.iter() {
-            cc.push((*c).clone());
-        }
-        node1 = Some(build_upper_sah(&cc));
-    }
+    let node0 = Some(build_upper_sah(c0));
+    let node1 = Some(build_upper_sah(c1));
 
     let node = Box::new(BVHBuildNode::init_interior(dim, node0, node1));
     return node;
@@ -418,8 +407,8 @@ pub fn hlbvh_build(
     // Create and return SAH BVH from LBVH treelets
     let mut finished_treelets = Vec::with_capacity(treelets_to_build.len());
     for treelet in treelets_to_build {
-        finished_treelets.push(treelet.build_nodes.unwrap().clone());
+        finished_treelets.push(treelet.build_nodes.unwrap());
     }
-    let node = build_upper_sah(&finished_treelets);
+    let node = build_upper_sah(finished_treelets);
     return node;
 }

--- a/src/cpu/aggregates/bvh/build/hlbvh.rs
+++ b/src/cpu/aggregates/bvh/build/hlbvh.rs
@@ -329,6 +329,10 @@ fn build_upper_sah(treelet_roots: Vec<Box<BVHBuildNode>>) -> Box<BVHBuildNode> {
         }
     }
 
+    assert!(
+        !c0.is_empty() && !c1.is_empty(),
+        "HLBVH upper SAH split must produce two non-empty children"
+    );
     let node0 = Some(build_upper_sah(c0));
     let node1 = Some(build_upper_sah(c1));
 

--- a/src/cpu/aggregates/bvh/build/hlbvh.rs
+++ b/src/cpu/aggregates/bvh/build/hlbvh.rs
@@ -286,11 +286,11 @@ fn build_upper_sah(treelet_roots: &[Box<BVHBuildNode>]) -> Box<BVHBuildNode> {
     // Compute costs for splitting after each bucket
     let mut cost: [Float; N_BUCKETS - 1] = [0.0; N_BUCKETS - 1];
     for i in 0..(N_BUCKETS - 1) {
-        let mut b0 = buckets[i].bounds;
-        let mut b1 = buckets[i].bounds;
+        let mut b0 = Bounds3f::default();
+        let mut b1 = Bounds3f::default();
         let mut count0 = 0;
-        let mut count1 = 1;
-        for j in 0..i {
+        let mut count1 = 0;
+        for j in 0..=i {
             b0 = Bounds3f::union(&b0, &buckets[j].bounds);
             count0 += buckets[j].count;
         }

--- a/tests/bvh_build.rs
+++ b/tests/bvh_build.rs
@@ -1,3 +1,4 @@
+use pbrt_r4::cpu::bvh::build::hlbvh::hlbvh_build;
 use pbrt_r4::cpu::bvh::sah::split_sah;
 use pbrt_r4::cpu::bvh::{BVHBuildNode, BVHPrimitiveInfo, SplitMethod};
 use pbrt_r4::prelude::*;
@@ -52,4 +53,29 @@ fn sah_matches_v4_split_decision_even_below_max_primitives() {
     assert!(node.children[1].is_some());
     assert_eq!(node.primitive_count(), 3);
     assert_eq!(ordered_indices.len(), 3);
+}
+
+#[test]
+fn hlbvh_build_preserves_all_primitives_across_treelets() {
+    let bounds: Vec<_> = (0..32)
+        .map(|index| {
+            let x = index as Float * 2.0;
+            Bounds3f::from(((x, 0.0, 0.0), (x + 1.0, 1.0, 1.0)))
+        })
+        .collect();
+    let mut primitive_info: Vec<_> = bounds
+        .iter()
+        .enumerate()
+        .map(|(index, bound)| {
+            let centroid = (bound.min + bound.max) * 0.5;
+            BVHPrimitiveInfo::new(index, bound, &centroid)
+        })
+        .collect();
+    let mut ordered_indices = Vec::new();
+
+    let node = hlbvh_build(&mut primitive_info, &mut ordered_indices, 4);
+
+    ordered_indices.sort_unstable();
+    assert_eq!(ordered_indices, (0..bounds.len()).collect::<Vec<_>>());
+    assert_eq!(node.primitive_count(), bounds.len());
 }


### PR DESCRIPTION
## Summary
- Match pbrt-v4 HLBVH upper-SAH bucket cost calculation.
- Move treelet ownership instead of deep-cloning complete BVH subtrees.
- Assert that the upper-SAH partition produces two non-empty children.
- Add an external HLBVH regression test covering multiple treelets and primitive preservation.

## Validation
- cargo fmt
- cargo test --test bvh_build
- cargo build --release
- git diff --check
- Compared crown_tiny, villa_small, sportscar_regress, and bunny_cloud_tiny renders against pbrt-v4 at 16 spp; no new structural difference was observed.

Commits: d03893b, a33436c, 5283b1b