### PR TITLE
perf(parser): parse comments in nom whitespace

### DIFF
--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -11,11 +11,21 @@ use nom::IResult;
 use std::io::{Error, ErrorKind};
 
 pub fn space0(s: &str) -> IResult<&str, &str> {
-    return character::complete::multispace0(s);
+    return nom::combinator::recognize(multi::many0(space_or_comment))(s);
 }
 
 pub fn space1(s: &str) -> IResult<&str, &str> {
-    return character::complete::multispace1(s);
+    return nom::combinator::recognize(multi::many1(space_or_comment))(s);
+}
+
+fn space_or_comment(s: &str) -> IResult<&str, &str> {
+    return nom::branch::alt((
+        character::complete::multispace1,
+        sequence::preceded(
+            character::complete::char('#'),
+            bytes::complete::take_till(|c| c == '\n'),
+        ),
+    ))(s);
 }
 
 pub fn bool_literal(s: &str) -> IResult<&str, &str> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -85,8 +85,7 @@ pub fn parse_file(filename: &str, context: &mut dyn ParseTarget) -> Result<(), P
 }
 
 pub fn parse_string(s: &str, context: &mut dyn ParseTarget) -> Result<(), PbrtError> {
-    let ops = parse_opnodes(s)?;
-    return evaluate_opnodes(&ops, context);
+    return parse_string_core(s, context);
 }
 
 /// Parses a legacy scene and evaluates its v4-compatible upgraded operations.
@@ -690,12 +689,9 @@ fn parse_op_floats<'a>(s: &'a str, opname: &str) -> IResult<&'a str, OPNode> {
         sequence::delimited(
             character::complete::char('['),
             sequence::delimited(
-                character::complete::multispace0,
-                multi::separated_list1(
-                    character::complete::multispace1,
-                    number::complete::recognize_float,
-                ),
-                character::complete::multispace0,
+                space0,
+                multi::separated_list1(space1, number::complete::recognize_float),
+                space0,
             ),
             character::complete::char(']'),
         ),

--- a/tests/parser_comments.rs
+++ b/tests/parser_comments.rs
@@ -1,0 +1,61 @@
+use pbrt_r4::paramdict::ParameterDictionary;
+use pbrt_r4::parser::common::parse_params;
+use pbrt_r4::parser::{parse_string, DebugTarget};
+
+#[test]
+fn parse_string_accepts_comments_between_arguments_and_operations() {
+    let mut target = DebugTarget::new();
+    parse_string("Translate 1 # the first component\n 2 3\n", &mut target)
+        .expect("comments should be accepted by the nom parser");
+
+    let operations = target.operations.borrow();
+    let names: Vec<&str> = operations
+        .iter()
+        .map(|operation| operation.name.as_str())
+        .collect();
+    assert_eq!(names, ["Translate"]);
+}
+
+#[test]
+fn parse_params_accepts_comments_inside_arrays() {
+    let (_, params): (&str, ParameterDictionary) =
+        parse_params("\"float values\" [1 # between values\n 2 3]").unwrap();
+
+    assert_eq!(params.get_floats("values"), vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn parse_params_accepts_comments_between_name_and_value() {
+    let (_, params): (&str, ParameterDictionary) =
+        parse_params("\"float value\" # before the value\n [1]").unwrap();
+
+    assert_eq!(params.get_floats("value"), vec![1.0]);
+}
+
+#[test]
+fn parse_string_accepts_comment_only_lines() {
+    let mut target = DebugTarget::new();
+    parse_string("# a comment-only line\nIdentity\n", &mut target)
+        .expect("comment-only lines should be ignored");
+
+    let operations = target.operations.borrow();
+    assert_eq!(operations.len(), 1);
+}
+
+#[test]
+fn hash_inside_string_is_not_a_comment() {
+    let (_, params): (&str, ParameterDictionary) =
+        parse_params("\"string label\" [\"# not a comment\"]").unwrap();
+
+    assert_eq!(params.get_strings("label"), vec!["# not a comment"]);
+}
+
+#[test]
+fn parse_string_accepts_comment_at_eof() {
+    let mut target = DebugTarget::new();
+    parse_string("Identity # no trailing newline", &mut target)
+        .expect("a comment at EOF should be accepted");
+
+    let operations = target.operations.borrow();
+    assert_eq!(operations.len(), 1);
+}


### PR DESCRIPTION
## Summary
- Treat pbrt-v4-style `#` comments as whitespace in the nom parser.
- Preserve `#` inside string literals and support comments in arrays, between parameter names and values, comment-only lines, and EOF comments.
- Add external regression tests in `tests/parser_comments.rs`.

## Validation
- cargo fmt --all
- cargo test --test parser_comments
- cargo test --test parser_common
- cargo test --test parser_upgrade
- cargo build --release
- git diff --check

This PR is the first change in the parser optimization trunk `perf/parser-streaming`. Include expansion and full streaming remain follow-up PRs.