### PR TITLE
perf(parser): evaluate operations incrementally

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -112,8 +112,18 @@ pub fn parse_file_upgraded(filename: &str, context: &mut dyn ParseTarget) -> Res
 //-----------------------------------
 
 pub fn parse_string_core(s: &str, context: &mut dyn ParseTarget) -> Result<(), PbrtError> {
-    let ops = parse_opnodes_core(s)?;
-    return evaluate_opnodes(&ops, context);
+    let mut input = s;
+    loop {
+        let (remaining, _) = space0(input).map_err(|e| PbrtError::from(e.to_string()))?;
+        if remaining.is_empty() {
+            return Ok(());
+        }
+
+        let (remaining, op) =
+            parse_operation(remaining).map_err(|e| PbrtError::from(e.to_string()))?;
+        evaluate_opnodes(std::slice::from_ref(&op), context)?;
+        input = remaining;
+    }
 }
 
 fn parse_opnodes(s: &str) -> Result<Vec<OPNode>, PbrtError> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -111,17 +111,55 @@ pub fn parse_file_upgraded(filename: &str, context: &mut dyn ParseTarget) -> Res
 }
 //-----------------------------------
 
+fn parser_error(source: &str, input: &str, operation: &str, message: &str) -> PbrtError {
+    let offset = source.len().saturating_sub(input.len());
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
+    let column = prefix
+        .rsplit('\n')
+        .next()
+        .map_or(1, |line| line.chars().count() + 1);
+    let message = format!(
+        "parser error at byte {offset}, line {line}, column {column}, operation `{operation}`: {message}"
+    );
+    PbrtError::error(&message)
+}
+
+fn operation_name(input: &str) -> &str {
+    input.split_whitespace().next().unwrap_or("<end-of-input>")
+}
+
+fn parse_next_operation<'a>(
+    source: &str,
+    input: &'a str,
+) -> Result<Option<(&'a str, &'a str, OPNode)>, PbrtError> {
+    let (remaining, _) = space0(input)
+        .map_err(|error| parser_error(source, input, "<whitespace>", &error.to_string()))?;
+    if remaining.is_empty() {
+        return Ok(None);
+    }
+
+    let operation_input = remaining;
+    let name = operation_name(operation_input);
+    let (remaining, operation) = parse_operation(operation_input)
+        .map_err(|error| parser_error(source, operation_input, name, &error.to_string()))?;
+    Ok(Some((remaining, operation_input, operation)))
+}
+
 pub fn parse_string_core(s: &str, context: &mut dyn ParseTarget) -> Result<(), PbrtError> {
     let mut input = s;
     loop {
-        let (remaining, _) = space0(input).map_err(|e| PbrtError::from(e.to_string()))?;
-        if remaining.is_empty() {
+        let Some((remaining, operation_input, operation)) = parse_next_operation(s, input)? else {
             return Ok(());
+        };
+        if let Err(error) = evaluate_opnodes(std::slice::from_ref(&operation), context) {
+            return Err(parser_error(
+                s,
+                operation_input,
+                &operation.name,
+                &error.to_string(),
+            ));
         }
-
-        let (remaining, op) =
-            parse_operation(remaining).map_err(|e| PbrtError::from(e.to_string()))?;
-        evaluate_opnodes(std::slice::from_ref(&op), context)?;
         input = remaining;
     }
 }

--- a/tests/parser_comments.rs
+++ b/tests/parser_comments.rs
@@ -17,6 +17,28 @@ fn parse_string_accepts_comments_between_arguments_and_operations() {
 }
 
 #[test]
+fn parse_string_evaluates_operations_in_order() {
+    let mut target = DebugTarget::new();
+    parse_string("Identity\nTranslate 1 2 3\nScale 2 2 2\n", &mut target)
+        .expect("operations should be evaluated in order");
+
+    let operations = target.operations.borrow();
+    let names: Vec<&str> = operations
+        .iter()
+        .map(|operation| operation.name.as_str())
+        .collect();
+    assert_eq!(names, ["Identitiy", "Translate", "Scale"]);
+}
+
+#[test]
+fn parse_string_rejects_an_invalid_operation_after_valid_input() {
+    let mut target = DebugTarget::new();
+    let result = parse_string("Identity\nNotAParserOperation\n", &mut target);
+
+    assert!(result.is_err());
+}
+
+#[test]
 fn parse_params_accepts_comments_inside_arrays() {
     let (_, params): (&str, ParameterDictionary) =
         parse_params("\"float values\" [1 # between values\n 2 3]").unwrap();

--- a/tests/parser_comments.rs
+++ b/tests/parser_comments.rs
@@ -1,6 +1,15 @@
 use pbrt_r4::paramdict::ParameterDictionary;
 use pbrt_r4::parser::common::parse_params;
-use pbrt_r4::parser::{parse_string, DebugTarget};
+use pbrt_r4::parser::{parse_string, parse_string_upgraded, DebugTarget, SceneBuilder};
+
+fn debug_operations(target: &DebugTarget) -> Vec<(String, Vec<String>)> {
+    target
+        .operations
+        .borrow()
+        .iter()
+        .map(|operation| (operation.name.clone(), operation.args.clone()))
+        .collect()
+}
 
 #[test]
 fn parse_string_accepts_comments_between_arguments_and_operations() {
@@ -18,16 +27,16 @@ fn parse_string_accepts_comments_between_arguments_and_operations() {
 
 #[test]
 fn parse_string_evaluates_operations_in_order() {
-    let mut target = DebugTarget::new();
-    parse_string("Identity\nTranslate 1 2 3\nScale 2 2 2\n", &mut target)
-        .expect("operations should be evaluated in order");
+    let scene = "Identity\nTranslate 1 2 3\nScale 2 2 2\n";
+    let mut streaming_target = DebugTarget::new();
+    let mut ast_target = DebugTarget::new();
+    parse_string(scene, &mut streaming_target).expect("streaming parse should succeed");
+    parse_string_upgraded(scene, &mut ast_target).expect("AST parse should succeed");
 
-    let operations = target.operations.borrow();
-    let names: Vec<&str> = operations
-        .iter()
-        .map(|operation| operation.name.as_str())
-        .collect();
-    assert_eq!(names, ["Identitiy", "Translate", "Scale"]);
+    assert_eq!(
+        debug_operations(&streaming_target),
+        debug_operations(&ast_target)
+    );
 }
 
 #[test]
@@ -35,7 +44,28 @@ fn parse_string_rejects_an_invalid_operation_after_valid_input() {
     let mut target = DebugTarget::new();
     let result = parse_string("Identity\nNotAParserOperation\n", &mut target);
 
-    assert!(result.is_err());
+    let error = result.expect_err("invalid operation should be rejected");
+    assert!(error.msg.contains("line 2"));
+    assert!(error.msg.contains("operation `NotAParserOperation`"));
+    assert_eq!(debug_operations(&target).len(), 1);
+}
+
+#[test]
+fn streaming_and_ast_paths_keep_large_shape_counts() {
+    const SHAPE_COUNT: usize = 1024;
+    let mut scene = String::from("WorldBegin\n");
+    for _ in 0..SHAPE_COUNT {
+        scene.push_str("Shape \"sphere\" \"float radius\" [1]\n");
+    }
+    scene.push_str("WorldEnd\n");
+
+    let mut streaming_builder = SceneBuilder::new();
+    let mut ast_builder = SceneBuilder::new();
+    parse_string(&scene, &mut streaming_builder).expect("streaming parse should succeed");
+    parse_string_upgraded(&scene, &mut ast_builder).expect("AST parse should succeed");
+
+    assert_eq!(streaming_builder.shapes.len(), SHAPE_COUNT);
+    assert_eq!(streaming_builder.shapes.len(), ast_builder.shapes.len());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Parse and evaluate one operation at a time in the normal `parse_string` path.
- Avoid retaining the full `Vec<OPNode>` for ordinary input.
- Keep the AST path for the legacy upgrade flow unchanged.
- Add regression coverage for operation order and errors after a valid prefix.

## Validation
- cargo fmt --all
- cargo test --test parser_comments
- cargo test --test parser_common
- cargo test --test parser_upgrade
- cargo build --release
- git diff --check

Target trunk: `perf/parser-streaming`.