### PR TITLE
perf(parser): evaluate include sources sequentially

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,7 +15,9 @@ pub use scene_builder::SceneBuilder;
 pub use to_ply_target::ToPlyTarget;
 
 use self::common::*;
-use self::read_file::{read_file_with_include, read_file_without_include};
+use self::read_file::{
+    read_file_with_include, read_file_with_include_sources, read_file_without_include,
+};
 use self::remove_comment::remove_comment;
 use crate::paramdict::ParameterDictionary;
 use crate::util::base::Float;
@@ -66,8 +68,11 @@ fn parse_targz(filename: &str, context: &mut dyn ParseTarget) -> Result<(), Pbrt
         let path = entry.path();
         if let Some(path) = search_pbrt_file(&path) {
             let path = path.to_string_lossy();
-            let s = read_file_with_include(&path)?;
-            return parse_string_core(&s, context);
+            let sources = read_file_with_include_sources(&path)?;
+            for source in sources {
+                parse_string_core(&source, context)?;
+            }
+            return Ok(());
         }
     }
     return Err(PbrtError::from(std::io::Error::from(
@@ -79,8 +84,11 @@ pub fn parse_file(filename: &str, context: &mut dyn ParseTarget) -> Result<(), P
     if filename.ends_with(".tar.gz") {
         return parse_targz(filename, context);
     } else {
-        let s = read_file_with_include(filename)?;
-        return parse_string_core(&s, context);
+        let sources = read_file_with_include_sources(filename)?;
+        for source in sources {
+            parse_string_core(&source, context)?;
+        }
+        return Ok(());
     }
 }
 

--- a/src/parser/read_file.rs
+++ b/src/parser/read_file.rs
@@ -12,17 +12,21 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 pub fn read_file_with_include(path: &str) -> Result<String, Error> {
+    Ok(read_file_with_include_sources(path)?.concat())
+}
+
+pub fn read_file_with_include_sources(path: &str) -> Result<Vec<String>, Error> {
     let path = Path::new(path);
     if path.exists() {
         let path = path.canonicalize()?;
         let mut dirs = Vec::<PathBuf>::new();
         let parent = path.parent().ok_or(Error::from(ErrorKind::InvalidInput))?;
         dirs.push(PathBuf::from(parent));
-        let mut ss = String::new();
-        ss += &print_work_dir_begin(&dirs);
-        ss += &read_file_with_include_core(path.as_path(), &mut dirs)?;
-        ss += &print_work_dir_end();
-        return Ok(ss);
+        let mut sources = Vec::new();
+        sources.push(print_work_dir_begin(&dirs));
+        sources.extend(read_file_with_include_core(path.as_path(), &mut dirs)?);
+        sources.push(print_work_dir_end());
+        return Ok(sources);
     } else {
         return Err(Error::from(ErrorKind::NotFound));
     }
@@ -55,7 +59,7 @@ fn read_to_string(path: &Path) -> Result<String, Error> {
     }
 }
 
-fn read_file_with_include_core(path: &Path, dirs: &mut Vec<PathBuf>) -> Result<String, Error> {
+fn read_file_with_include_core(path: &Path, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Error> {
     let s = read_to_string(path)?;
     return evaluate_include(&s, dirs);
 }
@@ -110,11 +114,12 @@ fn parse_tokens(s: &str) -> Result<Vec<String>, Error> {
     }
 }
 
-fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<String, Error> {
+fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Error> {
     let s = remove_comment_result(s)?;
     let vs = parse_tokens(&s)?;
 
-    let mut ss = String::new();
+    let mut sources = Vec::new();
+    let mut source = String::new();
     //ss += &print_work_dir_begin(dirs);
     for s in vs {
         if s.starts_with("Include") {
@@ -127,28 +132,36 @@ fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<String, Error> {
                 let Some(parent) = next_path.parent() else {
                     return Err(Error::from(ErrorKind::InvalidInput));
                 };
+                if !source.is_empty() {
+                    sources.push(std::mem::take(&mut source));
+                }
                 dirs.push(PathBuf::from(parent));
-                ss += &print_work_dir_begin(dirs);
+                sources.push(print_work_dir_begin(dirs));
 
-                let rss = read_file_with_include_core(next_path.as_path(), dirs)?;
-                ss += &rss;
+                sources.extend(read_file_with_include_core(next_path.as_path(), dirs)?);
                 if vv.len() > 2 {
                     for i in 2..vv.len() {
-                        ss += &format!(" {}", vv[i]);
+                        source += &format!(" {}", vv[i]);
                     }
-                    ss += "\n";
+                    source += "\n";
+                }
+                if !source.is_empty() {
+                    sources.push(std::mem::take(&mut source));
                 }
                 dirs.pop();
-                ss += &print_work_dir_end();
+                sources.push(print_work_dir_end());
             } else {
                 return Err(Error::from(ErrorKind::NotFound));
             }
         } else {
-            ss += &s;
+            source += &s;
         }
     }
     //ss += &print_work_dir_end();
-    return Ok(ss);
+    if !source.is_empty() {
+        sources.push(source);
+    }
+    return Ok(sources);
 }
 
 fn parse_one(s: &str) -> IResult<&str, String> {

--- a/src/parser/read_file.rs
+++ b/src/parser/read_file.rs
@@ -22,9 +22,14 @@ pub fn read_file_with_include_sources(path: &str) -> Result<Vec<String>, Error> 
         let mut dirs = Vec::<PathBuf>::new();
         let parent = path.parent().ok_or(Error::from(ErrorKind::InvalidInput))?;
         dirs.push(PathBuf::from(parent));
+        let mut files = vec![path.clone()];
         let mut sources = Vec::new();
         sources.push(print_work_dir_begin(&dirs));
-        sources.extend(read_file_with_include_core(path.as_path(), &mut dirs)?);
+        sources.extend(read_file_with_include_core(
+            path.as_path(),
+            &mut dirs,
+            &mut files,
+        )?);
         sources.push(print_work_dir_end());
         return Ok(sources);
     } else {
@@ -59,9 +64,13 @@ fn read_to_string(path: &Path) -> Result<String, Error> {
     }
 }
 
-fn read_file_with_include_core(path: &Path, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Error> {
+fn read_file_with_include_core(
+    path: &Path,
+    dirs: &mut Vec<PathBuf>,
+    files: &mut Vec<PathBuf>,
+) -> Result<Vec<String>, Error> {
     let s = read_to_string(path)?;
-    return evaluate_include(&s, dirs);
+    return evaluate_include(&s, dirs, files);
 }
 
 pub fn read_file_without_include_core(path: &Path) -> Result<String, Error> {
@@ -114,7 +123,11 @@ fn parse_tokens(s: &str) -> Result<Vec<String>, Error> {
     }
 }
 
-fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Error> {
+fn evaluate_include(
+    s: &str,
+    dirs: &mut Vec<PathBuf>,
+    files: &mut Vec<PathBuf>,
+) -> Result<Vec<String>, Error> {
     let s = remove_comment_result(s)?;
     let vs = parse_tokens(&s)?;
 
@@ -129,6 +142,13 @@ fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Err
             };
             let filename = Path::new(filename_str);
             if let Some(next_path) = get_next_path(filename, dirs) {
+                let next_path = next_path.canonicalize()?;
+                if files.iter().any(|file| file == &next_path) {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        format!("Include cycle detected at {}", next_path.display()),
+                    ));
+                }
                 let Some(parent) = next_path.parent() else {
                     return Err(Error::from(ErrorKind::InvalidInput));
                 };
@@ -136,9 +156,14 @@ fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Err
                     sources.push(std::mem::take(&mut source));
                 }
                 dirs.push(PathBuf::from(parent));
+                files.push(next_path.clone());
                 sources.push(print_work_dir_begin(dirs));
 
-                sources.extend(read_file_with_include_core(next_path.as_path(), dirs)?);
+                sources.extend(read_file_with_include_core(
+                    next_path.as_path(),
+                    dirs,
+                    files,
+                )?);
                 if vv.len() > 2 {
                     for i in 2..vv.len() {
                         source += &format!(" {}", vv[i]);
@@ -148,6 +173,7 @@ fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Err
                 if !source.is_empty() {
                     sources.push(std::mem::take(&mut source));
                 }
+                files.pop();
                 dirs.pop();
                 sources.push(print_work_dir_end());
             } else {

--- a/tests/parser_include_sources.rs
+++ b/tests/parser_include_sources.rs
@@ -1,6 +1,25 @@
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use pbrt_r4::parser::read_file::read_file_with_include_sources;
-use pbrt_r4::parser::{parse_file, DebugTarget};
+use pbrt_r4::parser::{parse_file, parse_string, DebugTarget, PrintTarget, SceneBuilder};
+use std::cell::RefCell;
 use std::fs;
+use std::io::{Result as IoResult, Write};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedWriter {
+    fn write(&mut self, bytes: &[u8]) -> IoResult<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        Ok(())
+    }
+}
 
 fn operation_names(target: &DebugTarget) -> Vec<String> {
     target
@@ -16,27 +35,125 @@ fn include_sources_preserve_directive_order_and_work_directories() {
     let directory = tempfile::tempdir().expect("temporary directory should be created");
     let root = directory.path().join("root.pbrt");
     let child = directory.path().join("child.pbrt");
-    fs::write(&child, "Translate 1 2 3\n").expect("child scene should be written");
+    let grandchild = directory.path().join("grandchild.pbrt");
+    fs::write(&grandchild, "Rotate 90 0 1 0\n").expect("grandchild scene should be written");
+    fs::write(&child, "Include \"grandchild.pbrt\"\nTranslate 1 2 3\n")
+        .expect("child scene should be written");
     fs::write(&root, "Identity\nInclude \"child.pbrt\"\nScale 2 2 2\n")
         .expect("root scene should be written");
 
     let sources = read_file_with_include_sources(root.to_str().unwrap())
         .expect("include expansion should succeed");
-    assert!(sources.len() >= 7);
+    assert!(sources.len() >= 10);
     assert!(sources.iter().all(|source| !source.is_empty()));
 
     let mut target = DebugTarget::new();
     parse_file(root.to_str().unwrap(), &mut target).expect("scene should parse");
+    let mut identity_target = DebugTarget::new();
+    parse_string("Identity", &mut identity_target).expect("identity should parse");
+    let identity_name = operation_names(&identity_target)
+        .into_iter()
+        .next()
+        .expect("identity should be recorded");
     assert_eq!(
         operation_names(&target),
         [
             "WorkDirBegin",
-            "Identitiy",
+            identity_name.as_str(),
             "WorkDirBegin",
+            "WorkDirBegin",
+            "Rotate",
+            "WorkDirEnd",
             "Translate",
             "WorkDirEnd",
             "Scale",
             "WorkDirEnd",
         ]
     );
+}
+
+#[test]
+fn gzipped_include_is_parsed_in_order() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt.gz");
+    let child = directory.path().join("child.pbrt");
+    fs::write(&child, "Translate 1 2 3\n").expect("child scene should be written");
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(b"Identity\nInclude \"child.pbrt\"\nScale 2 2 2\n")
+        .expect("gzipped scene should be written");
+    fs::write(&root, encoder.finish().expect("gzip should finish"))
+        .expect("compressed root scene should be written");
+
+    let mut target = DebugTarget::new();
+    parse_file(root.to_str().unwrap(), &mut target).expect("gzipped scene should parse");
+    let names = operation_names(&target);
+    assert!(names.contains(&"Translate".to_string()));
+    assert!(names.contains(&"Scale".to_string()));
+}
+
+#[test]
+fn include_cycle_is_reported_as_an_error() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let first = directory.path().join("first.pbrt");
+    let second = directory.path().join("second.pbrt");
+    fs::write(&first, "Include \"second.pbrt\"\n").expect("first scene should be written");
+    fs::write(&second, "Include \"first.pbrt\"\n").expect("second scene should be written");
+
+    let error = read_file_with_include_sources(first.to_str().unwrap())
+        .expect_err("include cycle should be rejected");
+    assert!(error.to_string().contains("Include cycle detected"));
+}
+
+#[test]
+fn include_parse_errors_report_the_current_source_chunk() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt");
+    fs::write(&child, "NotAParserOperation\n").expect("child scene should be written");
+    fs::write(&root, "Identity\nInclude \"child.pbrt\"\n").expect("root scene should be written");
+
+    let mut target = DebugTarget::new();
+    let error = parse_file(root.to_str().unwrap(), &mut target)
+        .expect_err("invalid child operation should be rejected");
+    assert!(error.msg.contains("line 1"));
+    assert!(error.msg.contains("operation `NotAParserOperation`"));
+}
+
+#[test]
+fn include_result_reaches_scene_builder() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt");
+    fs::write(
+        &child,
+        "Material \"diffuse\" \"rgb reflectance\" [.5 .5 .5]\n\
+         Shape \"sphere\" \"float radius\" [1]\n",
+    )
+    .expect("child scene should be written");
+    fs::write(&root, "WorldBegin\nInclude \"child.pbrt\"\nWorldEnd\n")
+        .expect("root scene should be written");
+
+    let mut builder = SceneBuilder::new();
+    parse_file(root.to_str().unwrap(), &mut builder).expect("scene should parse");
+    assert_eq!(builder.materials.len(), 1);
+    assert_eq!(builder.shapes.len(), 1);
+}
+
+#[test]
+fn include_result_reaches_print_target() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt");
+    fs::write(&child, "Translate 1 2 3\n").expect("child scene should be written");
+    fs::write(&root, "Identity\nInclude \"child.pbrt\"\n").expect("root scene should be written");
+
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let writer = Arc::new(RefCell::new(SharedWriter(bytes.clone())));
+    let mut target = PrintTarget::new(writer);
+    parse_file(root.to_str().unwrap(), &mut target).expect("scene should parse");
+    let output = String::from_utf8(bytes.lock().unwrap().clone()).expect("output should be UTF-8");
+    assert!(output.contains("Identity"));
+    assert!(output.contains("Translate 1 2 3"));
 }

--- a/tests/parser_include_sources.rs
+++ b/tests/parser_include_sources.rs
@@ -1,0 +1,42 @@
+use pbrt_r4::parser::read_file::read_file_with_include_sources;
+use pbrt_r4::parser::{parse_file, DebugTarget};
+use std::fs;
+
+fn operation_names(target: &DebugTarget) -> Vec<String> {
+    target
+        .operations
+        .borrow()
+        .iter()
+        .map(|operation| operation.name.clone())
+        .collect()
+}
+
+#[test]
+fn include_sources_preserve_directive_order_and_work_directories() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt");
+    fs::write(&child, "Translate 1 2 3\n").expect("child scene should be written");
+    fs::write(&root, "Identity\nInclude \"child.pbrt\"\nScale 2 2 2\n")
+        .expect("root scene should be written");
+
+    let sources = read_file_with_include_sources(root.to_str().unwrap())
+        .expect("include expansion should succeed");
+    assert!(sources.len() >= 7);
+    assert!(sources.iter().all(|source| !source.is_empty()));
+
+    let mut target = DebugTarget::new();
+    parse_file(root.to_str().unwrap(), &mut target).expect("scene should parse");
+    assert_eq!(
+        operation_names(&target),
+        [
+            "WorkDirBegin",
+            "Identitiy",
+            "WorkDirBegin",
+            "Translate",
+            "WorkDirEnd",
+            "Scale",
+            "WorkDirEnd",
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- Evaluate expanded Include sources sequentially while preserving WorkDir boundaries and directive order.
- Detect recursive Include cycles and report them as input errors.
- Add regression coverage for nested and gzip Includes, cycle detection, source-chunk parse errors, SceneBuilder, and PrintTarget integration.

## Validation
- cargo fmt --all
- cargo test --all
- cargo build --release
- git diff --check

## Note
- PR3 intentionally reports parse positions relative to the current source chunk. Original-file/global position tracking is deferred to the parser-session work in PR4.