### PR TITLE
fix(parser): address Include session review findings

### DIFF
--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -11,11 +11,21 @@ use nom::IResult;
 use std::io::{Error, ErrorKind};
 
 pub fn space0(s: &str) -> IResult<&str, &str> {
-    return character::complete::multispace0(s);
+    return nom::combinator::recognize(multi::many0(space_or_comment))(s);
 }
 
 pub fn space1(s: &str) -> IResult<&str, &str> {
-    return character::complete::multispace1(s);
+    return nom::combinator::recognize(multi::many1(space_or_comment))(s);
+}
+
+fn space_or_comment(s: &str) -> IResult<&str, &str> {
+    return nom::branch::alt((
+        character::complete::multispace1,
+        sequence::preceded(
+            character::complete::char('#'),
+            bytes::complete::take_till(|c| c == '\n'),
+        ),
+    ))(s);
 }
 
 pub fn bool_literal(s: &str) -> IResult<&str, &str> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -112,8 +112,18 @@ pub fn parse_file_upgraded(filename: &str, context: &mut dyn ParseTarget) -> Res
 //-----------------------------------
 
 pub fn parse_string_core(s: &str, context: &mut dyn ParseTarget) -> Result<(), PbrtError> {
-    let ops = parse_opnodes_core(s)?;
-    return evaluate_opnodes(&ops, context);
+    let mut input = s;
+    loop {
+        let (remaining, _) = space0(input).map_err(|e| PbrtError::from(e.to_string()))?;
+        if remaining.is_empty() {
+            return Ok(());
+        }
+
+        let (remaining, op) =
+            parse_operation(remaining).map_err(|e| PbrtError::from(e.to_string()))?;
+        evaluate_opnodes(std::slice::from_ref(&op), context)?;
+        input = remaining;
+    }
 }
 
 fn parse_opnodes(s: &str) -> Result<Vec<OPNode>, PbrtError> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,7 +15,9 @@ pub use scene_builder::SceneBuilder;
 pub use to_ply_target::ToPlyTarget;
 
 use self::common::*;
-use self::read_file::{read_file_with_include, read_file_without_include};
+use self::read_file::{
+    read_file_with_include, read_file_with_include_sources, read_file_without_include,
+};
 use self::remove_comment::remove_comment;
 use crate::paramdict::ParameterDictionary;
 use crate::util::base::Float;
@@ -66,8 +68,11 @@ fn parse_targz(filename: &str, context: &mut dyn ParseTarget) -> Result<(), Pbrt
         let path = entry.path();
         if let Some(path) = search_pbrt_file(&path) {
             let path = path.to_string_lossy();
-            let s = read_file_with_include(&path)?;
-            return parse_string_core(&s, context);
+            let sources = read_file_with_include_sources(&path)?;
+            for source in sources {
+                parse_string_core(&source, context)?;
+            }
+            return Ok(());
         }
     }
     return Err(PbrtError::from(std::io::Error::from(
@@ -79,8 +84,11 @@ pub fn parse_file(filename: &str, context: &mut dyn ParseTarget) -> Result<(), P
     if filename.ends_with(".tar.gz") {
         return parse_targz(filename, context);
     } else {
-        let s = read_file_with_include(filename)?;
-        return parse_string_core(&s, context);
+        let sources = read_file_with_include_sources(filename)?;
+        for source in sources {
+            parse_string_core(&source, context)?;
+        }
+        return Ok(());
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -85,8 +85,7 @@ pub fn parse_file(filename: &str, context: &mut dyn ParseTarget) -> Result<(), P
 }
 
 pub fn parse_string(s: &str, context: &mut dyn ParseTarget) -> Result<(), PbrtError> {
-    let ops = parse_opnodes(s)?;
-    return evaluate_opnodes(&ops, context);
+    return parse_string_core(s, context);
 }
 
 /// Parses a legacy scene and evaluates its v4-compatible upgraded operations.
@@ -690,12 +689,9 @@ fn parse_op_floats<'a>(s: &'a str, opname: &str) -> IResult<&'a str, OPNode> {
         sequence::delimited(
             character::complete::char('['),
             sequence::delimited(
-                character::complete::multispace0,
-                multi::separated_list1(
-                    character::complete::multispace1,
-                    number::complete::recognize_float,
-                ),
-                character::complete::multispace0,
+                space0,
+                multi::separated_list1(space1, number::complete::recognize_float),
+                space0,
             ),
             character::complete::char(']'),
         ),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -111,17 +111,55 @@ pub fn parse_file_upgraded(filename: &str, context: &mut dyn ParseTarget) -> Res
 }
 //-----------------------------------
 
+fn parser_error(source: &str, input: &str, operation: &str, message: &str) -> PbrtError {
+    let offset = source.len().saturating_sub(input.len());
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
+    let column = prefix
+        .rsplit('\n')
+        .next()
+        .map_or(1, |line| line.chars().count() + 1);
+    let message = format!(
+        "parser error at byte {offset}, line {line}, column {column}, operation `{operation}`: {message}"
+    );
+    PbrtError::error(&message)
+}
+
+fn operation_name(input: &str) -> &str {
+    input.split_whitespace().next().unwrap_or("<end-of-input>")
+}
+
+fn parse_next_operation<'a>(
+    source: &str,
+    input: &'a str,
+) -> Result<Option<(&'a str, &'a str, OPNode)>, PbrtError> {
+    let (remaining, _) = space0(input)
+        .map_err(|error| parser_error(source, input, "<whitespace>", &error.to_string()))?;
+    if remaining.is_empty() {
+        return Ok(None);
+    }
+
+    let operation_input = remaining;
+    let name = operation_name(operation_input);
+    let (remaining, operation) = parse_operation(operation_input)
+        .map_err(|error| parser_error(source, operation_input, name, &error.to_string()))?;
+    Ok(Some((remaining, operation_input, operation)))
+}
+
 pub fn parse_string_core(s: &str, context: &mut dyn ParseTarget) -> Result<(), PbrtError> {
     let mut input = s;
     loop {
-        let (remaining, _) = space0(input).map_err(|e| PbrtError::from(e.to_string()))?;
-        if remaining.is_empty() {
+        let Some((remaining, operation_input, operation)) = parse_next_operation(s, input)? else {
             return Ok(());
+        };
+        if let Err(error) = evaluate_opnodes(std::slice::from_ref(&operation), context) {
+            return Err(parser_error(
+                s,
+                operation_input,
+                &operation.name,
+                &error.to_string(),
+            ));
         }
-
-        let (remaining, op) =
-            parse_operation(remaining).map_err(|e| PbrtError::from(e.to_string()))?;
-        evaluate_opnodes(std::slice::from_ref(&op), context)?;
         input = remaining;
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,6 +5,7 @@ pub mod print_target;
 pub mod read_file;
 pub mod remove_comment;
 pub mod scene_builder;
+mod session;
 pub mod to_ply_target;
 pub mod upgrade;
 
@@ -15,10 +16,9 @@ pub use scene_builder::SceneBuilder;
 pub use to_ply_target::ToPlyTarget;
 
 use self::common::*;
-use self::read_file::{
-    read_file_with_include, read_file_with_include_sources, read_file_without_include,
-};
+use self::read_file::{read_file_with_include, read_file_without_include};
 use self::remove_comment::remove_comment;
+use self::session::ParserSession;
 use crate::paramdict::ParameterDictionary;
 use crate::util::base::Float;
 use crate::util::error::*;
@@ -68,11 +68,7 @@ fn parse_targz(filename: &str, context: &mut dyn ParseTarget) -> Result<(), Pbrt
         let path = entry.path();
         if let Some(path) = search_pbrt_file(&path) {
             let path = path.to_string_lossy();
-            let sources = read_file_with_include_sources(&path)?;
-            for source in sources {
-                parse_string_core(&source, context)?;
-            }
-            return Ok(());
+            return ParserSession::new(&path, context)?.parse();
         }
     }
     return Err(PbrtError::from(std::io::Error::from(
@@ -84,11 +80,7 @@ pub fn parse_file(filename: &str, context: &mut dyn ParseTarget) -> Result<(), P
     if filename.ends_with(".tar.gz") {
         return parse_targz(filename, context);
     } else {
-        let sources = read_file_with_include_sources(filename)?;
-        for source in sources {
-            parse_string_core(&source, context)?;
-        }
-        return Ok(());
+        return ParserSession::new(filename, context)?.parse();
     }
 }
 
@@ -121,6 +113,10 @@ pub fn parse_file_upgraded(filename: &str, context: &mut dyn ParseTarget) -> Res
 
 fn parser_error(source: &str, input: &str, operation: &str, message: &str) -> PbrtError {
     let offset = source.len().saturating_sub(input.len());
+    parser_error_at(source, offset, operation, message)
+}
+
+fn parser_error_at(source: &str, offset: usize, operation: &str, message: &str) -> PbrtError {
     let prefix = &source[..offset];
     let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
     let column = prefix

--- a/src/parser/read_file.rs
+++ b/src/parser/read_file.rs
@@ -64,6 +64,10 @@ fn read_to_string(path: &Path) -> Result<String, Error> {
     }
 }
 
+pub fn read_file_source(path: &Path) -> Result<String, Error> {
+    read_to_string(path)
+}
+
 fn read_file_with_include_core(
     path: &Path,
     dirs: &mut Vec<PathBuf>,

--- a/src/parser/read_file.rs
+++ b/src/parser/read_file.rs
@@ -12,17 +12,21 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 pub fn read_file_with_include(path: &str) -> Result<String, Error> {
+    Ok(read_file_with_include_sources(path)?.concat())
+}
+
+pub fn read_file_with_include_sources(path: &str) -> Result<Vec<String>, Error> {
     let path = Path::new(path);
     if path.exists() {
         let path = path.canonicalize()?;
         let mut dirs = Vec::<PathBuf>::new();
         let parent = path.parent().ok_or(Error::from(ErrorKind::InvalidInput))?;
         dirs.push(PathBuf::from(parent));
-        let mut ss = String::new();
-        ss += &print_work_dir_begin(&dirs);
-        ss += &read_file_with_include_core(path.as_path(), &mut dirs)?;
-        ss += &print_work_dir_end();
-        return Ok(ss);
+        let mut sources = Vec::new();
+        sources.push(print_work_dir_begin(&dirs));
+        sources.extend(read_file_with_include_core(path.as_path(), &mut dirs)?);
+        sources.push(print_work_dir_end());
+        return Ok(sources);
     } else {
         return Err(Error::from(ErrorKind::NotFound));
     }
@@ -55,7 +59,7 @@ fn read_to_string(path: &Path) -> Result<String, Error> {
     }
 }
 
-fn read_file_with_include_core(path: &Path, dirs: &mut Vec<PathBuf>) -> Result<String, Error> {
+fn read_file_with_include_core(path: &Path, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Error> {
     let s = read_to_string(path)?;
     return evaluate_include(&s, dirs);
 }
@@ -110,11 +114,12 @@ fn parse_tokens(s: &str) -> Result<Vec<String>, Error> {
     }
 }
 
-fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<String, Error> {
+fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Error> {
     let s = remove_comment_result(s)?;
     let vs = parse_tokens(&s)?;
 
-    let mut ss = String::new();
+    let mut sources = Vec::new();
+    let mut source = String::new();
     //ss += &print_work_dir_begin(dirs);
     for s in vs {
         if s.starts_with("Include") {
@@ -127,28 +132,36 @@ fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<String, Error> {
                 let Some(parent) = next_path.parent() else {
                     return Err(Error::from(ErrorKind::InvalidInput));
                 };
+                if !source.is_empty() {
+                    sources.push(std::mem::take(&mut source));
+                }
                 dirs.push(PathBuf::from(parent));
-                ss += &print_work_dir_begin(dirs);
+                sources.push(print_work_dir_begin(dirs));
 
-                let rss = read_file_with_include_core(next_path.as_path(), dirs)?;
-                ss += &rss;
+                sources.extend(read_file_with_include_core(next_path.as_path(), dirs)?);
                 if vv.len() > 2 {
                     for i in 2..vv.len() {
-                        ss += &format!(" {}", vv[i]);
+                        source += &format!(" {}", vv[i]);
                     }
-                    ss += "\n";
+                    source += "\n";
+                }
+                if !source.is_empty() {
+                    sources.push(std::mem::take(&mut source));
                 }
                 dirs.pop();
-                ss += &print_work_dir_end();
+                sources.push(print_work_dir_end());
             } else {
                 return Err(Error::from(ErrorKind::NotFound));
             }
         } else {
-            ss += &s;
+            source += &s;
         }
     }
     //ss += &print_work_dir_end();
-    return Ok(ss);
+    if !source.is_empty() {
+        sources.push(source);
+    }
+    return Ok(sources);
 }
 
 fn parse_one(s: &str) -> IResult<&str, String> {

--- a/src/parser/read_file.rs
+++ b/src/parser/read_file.rs
@@ -22,9 +22,14 @@ pub fn read_file_with_include_sources(path: &str) -> Result<Vec<String>, Error> 
         let mut dirs = Vec::<PathBuf>::new();
         let parent = path.parent().ok_or(Error::from(ErrorKind::InvalidInput))?;
         dirs.push(PathBuf::from(parent));
+        let mut files = vec![path.clone()];
         let mut sources = Vec::new();
         sources.push(print_work_dir_begin(&dirs));
-        sources.extend(read_file_with_include_core(path.as_path(), &mut dirs)?);
+        sources.extend(read_file_with_include_core(
+            path.as_path(),
+            &mut dirs,
+            &mut files,
+        )?);
         sources.push(print_work_dir_end());
         return Ok(sources);
     } else {
@@ -59,9 +64,13 @@ fn read_to_string(path: &Path) -> Result<String, Error> {
     }
 }
 
-fn read_file_with_include_core(path: &Path, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Error> {
+fn read_file_with_include_core(
+    path: &Path,
+    dirs: &mut Vec<PathBuf>,
+    files: &mut Vec<PathBuf>,
+) -> Result<Vec<String>, Error> {
     let s = read_to_string(path)?;
-    return evaluate_include(&s, dirs);
+    return evaluate_include(&s, dirs, files);
 }
 
 pub fn read_file_without_include_core(path: &Path) -> Result<String, Error> {
@@ -114,7 +123,11 @@ fn parse_tokens(s: &str) -> Result<Vec<String>, Error> {
     }
 }
 
-fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Error> {
+fn evaluate_include(
+    s: &str,
+    dirs: &mut Vec<PathBuf>,
+    files: &mut Vec<PathBuf>,
+) -> Result<Vec<String>, Error> {
     let s = remove_comment_result(s)?;
     let vs = parse_tokens(&s)?;
 
@@ -129,6 +142,13 @@ fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Err
             };
             let filename = Path::new(filename_str);
             if let Some(next_path) = get_next_path(filename, dirs) {
+                let next_path = next_path.canonicalize()?;
+                if files.iter().any(|file| file == &next_path) {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        format!("Include cycle detected at {}", next_path.display()),
+                    ));
+                }
                 let Some(parent) = next_path.parent() else {
                     return Err(Error::from(ErrorKind::InvalidInput));
                 };
@@ -136,9 +156,14 @@ fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Err
                     sources.push(std::mem::take(&mut source));
                 }
                 dirs.push(PathBuf::from(parent));
+                files.push(next_path.clone());
                 sources.push(print_work_dir_begin(dirs));
 
-                sources.extend(read_file_with_include_core(next_path.as_path(), dirs)?);
+                sources.extend(read_file_with_include_core(
+                    next_path.as_path(),
+                    dirs,
+                    files,
+                )?);
                 if vv.len() > 2 {
                     for i in 2..vv.len() {
                         source += &format!(" {}", vv[i]);
@@ -148,6 +173,7 @@ fn evaluate_include(s: &str, dirs: &mut Vec<PathBuf>) -> Result<Vec<String>, Err
                 if !source.is_empty() {
                     sources.push(std::mem::take(&mut source));
                 }
+                files.pop();
                 dirs.pop();
                 sources.push(print_work_dir_end());
             } else {

--- a/src/parser/session.rs
+++ b/src/parser/session.rs
@@ -1,0 +1,206 @@
+use super::parse_target::ParseTarget;
+use super::read_file::read_file_source;
+use super::{evaluate_opnodes, parse_next_operation, parser_error_at, OPNode};
+use crate::util::error::PbrtError;
+use std::path::{Path, PathBuf};
+
+struct InputFrame {
+    path: PathBuf,
+    source: String,
+    offset: usize,
+}
+
+pub struct ParserSession<'a> {
+    context: &'a mut dyn ParseTarget,
+    frames: Vec<InputFrame>,
+}
+
+impl<'a> ParserSession<'a> {
+    pub fn new(filename: &str, context: &'a mut dyn ParseTarget) -> Result<Self, PbrtError> {
+        let path = Path::new(filename)
+            .canonicalize()
+            .map_err(|error| PbrtError::from(error).with_file(Path::new(filename)))?;
+        let source =
+            read_file_source(&path).map_err(|error| PbrtError::from(error).with_file(&path))?;
+        let parent = path
+            .parent()
+            .ok_or_else(|| PbrtError::from("scene file has no parent directory"))?;
+        context.work_dir_begin(&parent.to_string_lossy());
+
+        Ok(Self {
+            context,
+            frames: vec![InputFrame {
+                path,
+                source,
+                offset: 0,
+            }],
+        })
+    }
+
+    pub fn parse(mut self) -> Result<(), PbrtError> {
+        let result = self.parse_frames();
+        if result.is_err() {
+            self.close_work_dirs();
+        }
+        result
+    }
+
+    fn parse_frames(&mut self) -> Result<(), PbrtError> {
+        loop {
+            let Some(frame) = self.frames.last() else {
+                return Ok(());
+            };
+            if frame.offset == frame.source.len() {
+                self.pop_frame();
+                continue;
+            }
+
+            let parsed = {
+                let Some(frame) = self.frames.last() else {
+                    return Err(Self::stack_empty_error());
+                };
+                let input = &frame.source[frame.offset..];
+                parse_next_operation(&frame.source, input).map(|result| {
+                    result.map(|(remaining, operation_input, operation)| {
+                        (
+                            frame.source.len() - remaining.len(),
+                            frame.source.len() - operation_input.len(),
+                            operation,
+                        )
+                    })
+                })
+            };
+
+            let parsed = match parsed {
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    return Err(self.add_current_file_context(error));
+                }
+            };
+            let Some((next_offset, operation_offset, operation)) = parsed else {
+                self.pop_frame();
+                continue;
+            };
+
+            let Some(frame) = self.frames.last_mut() else {
+                return Err(Self::stack_empty_error());
+            };
+            frame.offset = next_offset;
+
+            if operation.name == "Include" {
+                let filename = Self::include_filename(&operation).map_err(|error| {
+                    self.operation_error(operation_offset, &operation.name, error)
+                })?;
+                if operation.params.is_none() {
+                    return Err(self.operation_error(
+                        operation_offset,
+                        &operation.name,
+                        PbrtError::error("Include requires parameters."),
+                    ));
+                }
+                self.push_include(&filename).map_err(|error| {
+                    self.operation_error(operation_offset, &operation.name, error)
+                })?;
+                continue;
+            }
+
+            if let Err(error) = evaluate_opnodes(std::slice::from_ref(&operation), self.context) {
+                let Some(frame) = self.frames.last() else {
+                    return Err(Self::stack_empty_error());
+                };
+                return Err(parser_error_at(
+                    &frame.source,
+                    operation_offset,
+                    &operation.name,
+                    &error.to_string(),
+                )
+                .with_file(&frame.path));
+            }
+        }
+    }
+
+    fn include_filename(operation: &OPNode) -> Result<String, PbrtError> {
+        let args = operation
+            .args
+            .as_ref()
+            .ok_or_else(|| PbrtError::error("Include requires arguments."))?;
+        args.get_strings("arg1")
+            .into_iter()
+            .next()
+            .ok_or_else(|| PbrtError::error("Include requires a filename."))
+    }
+
+    fn push_include(&mut self, filename: &str) -> Result<(), PbrtError> {
+        if self.frames.last().is_none() {
+            return Err(Self::stack_empty_error());
+        }
+
+        let path = self
+            .resolve_path(filename)
+            .ok_or_else(|| PbrtError::from(format!("Include file not found: {filename}")))?;
+        let path = path.canonicalize().map_err(PbrtError::from)?;
+        if self.frames.iter().any(|frame| frame.path == path) {
+            return Err(PbrtError::from(format!(
+                "Include cycle detected at {}",
+                path.display()
+            )));
+        }
+
+        let source =
+            read_file_source(&path).map_err(|error| PbrtError::from(error).with_file(&path))?;
+        let parent = path
+            .parent()
+            .ok_or_else(|| PbrtError::from("included file has no parent directory"))
+            .map_err(|error| error.with_file(&path))?;
+        self.context.work_dir_begin(&parent.to_string_lossy());
+        self.frames.push(InputFrame {
+            path,
+            source,
+            offset: 0,
+        });
+        Ok(())
+    }
+
+    fn resolve_path(&self, filename: &str) -> Option<PathBuf> {
+        let filename = Path::new(filename);
+        if filename.is_absolute() && filename.exists() {
+            return Some(filename.to_path_buf());
+        }
+        self.frames.iter().rev().find_map(|frame| {
+            let parent = frame.path.parent()?;
+            let path = parent.join(filename);
+            path.exists().then_some(path)
+        })
+    }
+
+    fn pop_frame(&mut self) {
+        if self.frames.pop().is_some() {
+            self.context.work_dir_end();
+        }
+    }
+
+    fn close_work_dirs(&mut self) {
+        while !self.frames.is_empty() {
+            self.pop_frame();
+        }
+    }
+
+    fn add_current_file_context(&self, error: PbrtError) -> PbrtError {
+        match self.frames.last() {
+            Some(frame) => error.with_file(&frame.path),
+            None => error,
+        }
+    }
+
+    fn operation_error(&self, offset: usize, operation: &str, error: PbrtError) -> PbrtError {
+        match self.frames.last() {
+            Some(frame) => parser_error_at(&frame.source, offset, operation, &error.to_string())
+                .with_file(&frame.path),
+            None => error,
+        }
+    }
+
+    fn stack_empty_error() -> PbrtError {
+        PbrtError::error("parser input stack unexpectedly empty")
+    }
+}

--- a/src/util/error/error.rs
+++ b/src/util/error/error.rs
@@ -25,6 +25,10 @@ impl PbrtError {
     pub fn error(msg: &str) -> Self {
         PbrtError::new(PbrtErrorKind::Error, msg)
     }
+
+    pub fn with_file(self, path: &std::path::Path) -> Self {
+        PbrtError::new(self.kind, &format!("{}: {}", path.display(), self.msg))
+    }
 }
 
 impl std::error::Error for PbrtError {}

--- a/tests/parser_comments.rs
+++ b/tests/parser_comments.rs
@@ -17,6 +17,28 @@ fn parse_string_accepts_comments_between_arguments_and_operations() {
 }
 
 #[test]
+fn parse_string_evaluates_operations_in_order() {
+    let mut target = DebugTarget::new();
+    parse_string("Identity\nTranslate 1 2 3\nScale 2 2 2\n", &mut target)
+        .expect("operations should be evaluated in order");
+
+    let operations = target.operations.borrow();
+    let names: Vec<&str> = operations
+        .iter()
+        .map(|operation| operation.name.as_str())
+        .collect();
+    assert_eq!(names, ["Identitiy", "Translate", "Scale"]);
+}
+
+#[test]
+fn parse_string_rejects_an_invalid_operation_after_valid_input() {
+    let mut target = DebugTarget::new();
+    let result = parse_string("Identity\nNotAParserOperation\n", &mut target);
+
+    assert!(result.is_err());
+}
+
+#[test]
 fn parse_params_accepts_comments_inside_arrays() {
     let (_, params): (&str, ParameterDictionary) =
         parse_params("\"float values\" [1 # between values\n 2 3]").unwrap();

--- a/tests/parser_comments.rs
+++ b/tests/parser_comments.rs
@@ -1,0 +1,61 @@
+use pbrt_r4::paramdict::ParameterDictionary;
+use pbrt_r4::parser::common::parse_params;
+use pbrt_r4::parser::{parse_string, DebugTarget};
+
+#[test]
+fn parse_string_accepts_comments_between_arguments_and_operations() {
+    let mut target = DebugTarget::new();
+    parse_string("Translate 1 # the first component\n 2 3\n", &mut target)
+        .expect("comments should be accepted by the nom parser");
+
+    let operations = target.operations.borrow();
+    let names: Vec<&str> = operations
+        .iter()
+        .map(|operation| operation.name.as_str())
+        .collect();
+    assert_eq!(names, ["Translate"]);
+}
+
+#[test]
+fn parse_params_accepts_comments_inside_arrays() {
+    let (_, params): (&str, ParameterDictionary) =
+        parse_params("\"float values\" [1 # between values\n 2 3]").unwrap();
+
+    assert_eq!(params.get_floats("values"), vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn parse_params_accepts_comments_between_name_and_value() {
+    let (_, params): (&str, ParameterDictionary) =
+        parse_params("\"float value\" # before the value\n [1]").unwrap();
+
+    assert_eq!(params.get_floats("value"), vec![1.0]);
+}
+
+#[test]
+fn parse_string_accepts_comment_only_lines() {
+    let mut target = DebugTarget::new();
+    parse_string("# a comment-only line\nIdentity\n", &mut target)
+        .expect("comment-only lines should be ignored");
+
+    let operations = target.operations.borrow();
+    assert_eq!(operations.len(), 1);
+}
+
+#[test]
+fn hash_inside_string_is_not_a_comment() {
+    let (_, params): (&str, ParameterDictionary) =
+        parse_params("\"string label\" [\"# not a comment\"]").unwrap();
+
+    assert_eq!(params.get_strings("label"), vec!["# not a comment"]);
+}
+
+#[test]
+fn parse_string_accepts_comment_at_eof() {
+    let mut target = DebugTarget::new();
+    parse_string("Identity # no trailing newline", &mut target)
+        .expect("a comment at EOF should be accepted");
+
+    let operations = target.operations.borrow();
+    assert_eq!(operations.len(), 1);
+}

--- a/tests/parser_comments.rs
+++ b/tests/parser_comments.rs
@@ -1,6 +1,15 @@
 use pbrt_r4::paramdict::ParameterDictionary;
 use pbrt_r4::parser::common::parse_params;
-use pbrt_r4::parser::{parse_string, DebugTarget};
+use pbrt_r4::parser::{parse_string, parse_string_upgraded, DebugTarget, SceneBuilder};
+
+fn debug_operations(target: &DebugTarget) -> Vec<(String, Vec<String>)> {
+    target
+        .operations
+        .borrow()
+        .iter()
+        .map(|operation| (operation.name.clone(), operation.args.clone()))
+        .collect()
+}
 
 #[test]
 fn parse_string_accepts_comments_between_arguments_and_operations() {
@@ -18,16 +27,16 @@ fn parse_string_accepts_comments_between_arguments_and_operations() {
 
 #[test]
 fn parse_string_evaluates_operations_in_order() {
-    let mut target = DebugTarget::new();
-    parse_string("Identity\nTranslate 1 2 3\nScale 2 2 2\n", &mut target)
-        .expect("operations should be evaluated in order");
+    let scene = "Identity\nTranslate 1 2 3\nScale 2 2 2\n";
+    let mut streaming_target = DebugTarget::new();
+    let mut ast_target = DebugTarget::new();
+    parse_string(scene, &mut streaming_target).expect("streaming parse should succeed");
+    parse_string_upgraded(scene, &mut ast_target).expect("AST parse should succeed");
 
-    let operations = target.operations.borrow();
-    let names: Vec<&str> = operations
-        .iter()
-        .map(|operation| operation.name.as_str())
-        .collect();
-    assert_eq!(names, ["Identitiy", "Translate", "Scale"]);
+    assert_eq!(
+        debug_operations(&streaming_target),
+        debug_operations(&ast_target)
+    );
 }
 
 #[test]
@@ -35,7 +44,28 @@ fn parse_string_rejects_an_invalid_operation_after_valid_input() {
     let mut target = DebugTarget::new();
     let result = parse_string("Identity\nNotAParserOperation\n", &mut target);
 
-    assert!(result.is_err());
+    let error = result.expect_err("invalid operation should be rejected");
+    assert!(error.msg.contains("line 2"));
+    assert!(error.msg.contains("operation `NotAParserOperation`"));
+    assert_eq!(debug_operations(&target).len(), 1);
+}
+
+#[test]
+fn streaming_and_ast_paths_keep_large_shape_counts() {
+    const SHAPE_COUNT: usize = 1024;
+    let mut scene = String::from("WorldBegin\n");
+    for _ in 0..SHAPE_COUNT {
+        scene.push_str("Shape \"sphere\" \"float radius\" [1]\n");
+    }
+    scene.push_str("WorldEnd\n");
+
+    let mut streaming_builder = SceneBuilder::new();
+    let mut ast_builder = SceneBuilder::new();
+    parse_string(&scene, &mut streaming_builder).expect("streaming parse should succeed");
+    parse_string_upgraded(&scene, &mut ast_builder).expect("AST parse should succeed");
+
+    assert_eq!(streaming_builder.shapes.len(), SHAPE_COUNT);
+    assert_eq!(streaming_builder.shapes.len(), ast_builder.shapes.len());
 }
 
 #[test]

--- a/tests/parser_include_sources.rs
+++ b/tests/parser_include_sources.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 use std::fs;
 use std::io::{Result as IoResult, Write};
 use std::sync::{Arc, Mutex};
+use tar::Builder;
 
 #[derive(Clone)]
 struct SharedWriter(Arc<Mutex<Vec<u8>>>);
@@ -73,7 +74,7 @@ fn include_sources_preserve_directive_order_and_work_directories() {
 }
 
 #[test]
-fn gzipped_include_is_parsed_in_order() {
+fn gzipped_root_is_parsed_in_order() {
     let directory = tempfile::tempdir().expect("temporary directory should be created");
     let root = directory.path().join("root.pbrt.gz");
     let child = directory.path().join("child.pbrt");
@@ -94,6 +95,62 @@ fn gzipped_include_is_parsed_in_order() {
 }
 
 #[test]
+fn pbrt_file_can_include_gzipped_source() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt.gz");
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(b"Translate 1 2 3\n")
+        .expect("gzipped child should be written");
+    fs::write(&child, encoder.finish().expect("gzip should finish"))
+        .expect("compressed child scene should be written");
+    fs::write(&root, "Identity\nInclude \"child.pbrt.gz\"\nScale 2 2 2\n")
+        .expect("root scene should be written");
+
+    let mut target = DebugTarget::new();
+    parse_file(root.to_str().unwrap(), &mut target).expect("scene should parse");
+    let names = operation_names(&target);
+    assert!(names.contains(&"Translate".to_string()));
+    assert!(names.contains(&"Scale".to_string()));
+}
+
+#[test]
+fn tar_gz_scene_uses_streaming_include_parser() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let archive_path = directory.path().join("scene.tar.gz");
+    let archive_file = fs::File::create(&archive_path).expect("archive should be created");
+    let encoder = GzEncoder::new(archive_file, Compression::default());
+    let mut archive = Builder::new(encoder);
+    let root = b"Identity\nInclude \"child.pbrt\"\nScale 2 2 2\n";
+    let child = b"Translate 1 2 3\n";
+
+    let mut root_header = tar::Header::new_gnu();
+    root_header.set_size(root.len() as u64);
+    root_header.set_mode(0o644);
+    root_header.set_cksum();
+    archive
+        .append_data(&mut root_header, "scene/root.pbrt", &root[..])
+        .expect("root should be added to archive");
+
+    let mut child_header = tar::Header::new_gnu();
+    child_header.set_size(child.len() as u64);
+    child_header.set_mode(0o644);
+    child_header.set_cksum();
+    archive
+        .append_data(&mut child_header, "scene/child.pbrt", &child[..])
+        .expect("child should be added to archive");
+    let encoder = archive.into_inner().expect("tar should finish");
+    encoder.finish().expect("gzip should finish");
+
+    let mut target = DebugTarget::new();
+    parse_file(archive_path.to_str().unwrap(), &mut target).expect("archive scene should parse");
+    let names = operation_names(&target);
+    assert!(names.contains(&"Translate".to_string()));
+    assert!(names.contains(&"Scale".to_string()));
+}
+
+#[test]
 fn include_cycle_is_reported_as_an_error() {
     let directory = tempfile::tempdir().expect("temporary directory should be created");
     let first = directory.path().join("first.pbrt");
@@ -104,6 +161,20 @@ fn include_cycle_is_reported_as_an_error() {
     let error = read_file_with_include_sources(first.to_str().unwrap())
         .expect_err("include cycle should be rejected");
     assert!(error.to_string().contains("Include cycle detected"));
+}
+
+#[test]
+fn include_cycle_is_reported_by_streaming_parser() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let first = directory.path().join("first.pbrt");
+    let second = directory.path().join("second.pbrt");
+    fs::write(&first, "Include \"second.pbrt\"\n").expect("first scene should be written");
+    fs::write(&second, "Include \"first.pbrt\"\n").expect("second scene should be written");
+
+    let mut target = DebugTarget::new();
+    let error = parse_file(first.to_str().unwrap(), &mut target)
+        .expect_err("include cycle should be rejected by the parser session");
+    assert!(error.msg.contains("Include cycle detected"));
 }
 
 #[test]
@@ -119,6 +190,39 @@ fn include_parse_errors_report_the_current_source_chunk() {
         .expect_err("invalid child operation should be rejected");
     assert!(error.msg.contains("line 1"));
     assert!(error.msg.contains("operation `NotAParserOperation`"));
+    assert!(error.msg.contains(child.to_str().unwrap()));
+}
+
+#[test]
+fn include_read_errors_name_the_child_file() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt");
+    fs::write(&child, [0xff, 0xfe]).expect("invalid child scene should be written");
+    fs::write(&root, "Include \"child.pbrt\"\n").expect("root scene should be written");
+
+    let mut target = DebugTarget::new();
+    let error = parse_file(root.to_str().unwrap(), &mut target)
+        .expect_err("invalid child encoding should be rejected");
+    assert!(error.msg.contains(child.to_str().unwrap()));
+    assert!(error.msg.contains("line 1"));
+    assert!(error.msg.contains("operation `Include`"));
+}
+
+#[test]
+fn missing_include_error_reports_directive_location() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    fs::write(&root, "# comment\nInclude \"missing.pbrt\"\n")
+        .expect("root scene should be written");
+
+    let mut target = DebugTarget::new();
+    let error = parse_file(root.to_str().unwrap(), &mut target)
+        .expect_err("missing Include should be rejected");
+    assert!(error.msg.contains(root.to_str().unwrap()));
+    assert!(error.msg.contains("line 2"));
+    assert!(error.msg.contains("column 1"));
+    assert!(error.msg.contains("operation `Include`"));
 }
 
 #[test]
@@ -142,7 +246,7 @@ fn include_result_reaches_scene_builder() {
 }
 
 #[test]
-fn include_result_reaches_print_target() {
+fn include_expansion_reaches_print_target() {
     let directory = tempfile::tempdir().expect("temporary directory should be created");
     let root = directory.path().join("root.pbrt");
     let child = directory.path().join("child.pbrt");
@@ -156,4 +260,44 @@ fn include_result_reaches_print_target() {
     let output = String::from_utf8(bytes.lock().unwrap().clone()).expect("output should be UTF-8");
     assert!(output.contains("Identity"));
     assert!(output.contains("Translate 1 2 3"));
+    assert!(!output.contains("Include \"child.pbrt\""));
+}
+
+#[test]
+fn include_preserves_transform_and_material_state() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt");
+    fs::write(
+        &child,
+        "Translate 2 0 0\n\
+         Material \"diffuse\" \"rgb reflectance\" [.5 .5 .5]\n\
+         Shape \"sphere\" \"float radius\" [1]\n",
+    )
+    .expect("child scene should be written");
+    fs::write(
+        &root,
+        "WorldBegin\n\
+         Translate 1 0 0\n\
+         Include \"child.pbrt\"\n\
+         Shape \"sphere\" \"float radius\" [1]\n\
+         Translate 4 0 0\n\
+         Shape \"sphere\" \"float radius\" [1]\n\
+         WorldEnd\n",
+    )
+    .expect("root scene should be written");
+
+    let mut builder = SceneBuilder::new();
+    parse_file(root.to_str().unwrap(), &mut builder).expect("scene should parse");
+    assert_eq!(builder.shapes.len(), 3);
+
+    let translations: Vec<_> = builder
+        .shapes
+        .iter()
+        .map(|shape| shape.render_from_object.primary().m.m[3])
+        .collect();
+    assert_eq!(translations, [3.0, 3.0, 7.0]);
+    assert_eq!(builder.shapes[0].material_index, 0);
+    assert_eq!(builder.shapes[1].material_index, 0);
+    assert_eq!(builder.shapes[2].material_index, 0);
 }

--- a/tests/parser_include_sources.rs
+++ b/tests/parser_include_sources.rs
@@ -1,6 +1,25 @@
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use pbrt_r4::parser::read_file::read_file_with_include_sources;
-use pbrt_r4::parser::{parse_file, DebugTarget};
+use pbrt_r4::parser::{parse_file, parse_string, DebugTarget, PrintTarget, SceneBuilder};
+use std::cell::RefCell;
 use std::fs;
+use std::io::{Result as IoResult, Write};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedWriter {
+    fn write(&mut self, bytes: &[u8]) -> IoResult<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        Ok(())
+    }
+}
 
 fn operation_names(target: &DebugTarget) -> Vec<String> {
     target
@@ -16,27 +35,125 @@ fn include_sources_preserve_directive_order_and_work_directories() {
     let directory = tempfile::tempdir().expect("temporary directory should be created");
     let root = directory.path().join("root.pbrt");
     let child = directory.path().join("child.pbrt");
-    fs::write(&child, "Translate 1 2 3\n").expect("child scene should be written");
+    let grandchild = directory.path().join("grandchild.pbrt");
+    fs::write(&grandchild, "Rotate 90 0 1 0\n").expect("grandchild scene should be written");
+    fs::write(&child, "Include \"grandchild.pbrt\"\nTranslate 1 2 3\n")
+        .expect("child scene should be written");
     fs::write(&root, "Identity\nInclude \"child.pbrt\"\nScale 2 2 2\n")
         .expect("root scene should be written");
 
     let sources = read_file_with_include_sources(root.to_str().unwrap())
         .expect("include expansion should succeed");
-    assert!(sources.len() >= 7);
+    assert!(sources.len() >= 10);
     assert!(sources.iter().all(|source| !source.is_empty()));
 
     let mut target = DebugTarget::new();
     parse_file(root.to_str().unwrap(), &mut target).expect("scene should parse");
+    let mut identity_target = DebugTarget::new();
+    parse_string("Identity", &mut identity_target).expect("identity should parse");
+    let identity_name = operation_names(&identity_target)
+        .into_iter()
+        .next()
+        .expect("identity should be recorded");
     assert_eq!(
         operation_names(&target),
         [
             "WorkDirBegin",
-            "Identitiy",
+            identity_name.as_str(),
             "WorkDirBegin",
+            "WorkDirBegin",
+            "Rotate",
+            "WorkDirEnd",
             "Translate",
             "WorkDirEnd",
             "Scale",
             "WorkDirEnd",
         ]
     );
+}
+
+#[test]
+fn gzipped_include_is_parsed_in_order() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt.gz");
+    let child = directory.path().join("child.pbrt");
+    fs::write(&child, "Translate 1 2 3\n").expect("child scene should be written");
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(b"Identity\nInclude \"child.pbrt\"\nScale 2 2 2\n")
+        .expect("gzipped scene should be written");
+    fs::write(&root, encoder.finish().expect("gzip should finish"))
+        .expect("compressed root scene should be written");
+
+    let mut target = DebugTarget::new();
+    parse_file(root.to_str().unwrap(), &mut target).expect("gzipped scene should parse");
+    let names = operation_names(&target);
+    assert!(names.contains(&"Translate".to_string()));
+    assert!(names.contains(&"Scale".to_string()));
+}
+
+#[test]
+fn include_cycle_is_reported_as_an_error() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let first = directory.path().join("first.pbrt");
+    let second = directory.path().join("second.pbrt");
+    fs::write(&first, "Include \"second.pbrt\"\n").expect("first scene should be written");
+    fs::write(&second, "Include \"first.pbrt\"\n").expect("second scene should be written");
+
+    let error = read_file_with_include_sources(first.to_str().unwrap())
+        .expect_err("include cycle should be rejected");
+    assert!(error.to_string().contains("Include cycle detected"));
+}
+
+#[test]
+fn include_parse_errors_report_the_current_source_chunk() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt");
+    fs::write(&child, "NotAParserOperation\n").expect("child scene should be written");
+    fs::write(&root, "Identity\nInclude \"child.pbrt\"\n").expect("root scene should be written");
+
+    let mut target = DebugTarget::new();
+    let error = parse_file(root.to_str().unwrap(), &mut target)
+        .expect_err("invalid child operation should be rejected");
+    assert!(error.msg.contains("line 1"));
+    assert!(error.msg.contains("operation `NotAParserOperation`"));
+}
+
+#[test]
+fn include_result_reaches_scene_builder() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt");
+    fs::write(
+        &child,
+        "Material \"diffuse\" \"rgb reflectance\" [.5 .5 .5]\n\
+         Shape \"sphere\" \"float radius\" [1]\n",
+    )
+    .expect("child scene should be written");
+    fs::write(&root, "WorldBegin\nInclude \"child.pbrt\"\nWorldEnd\n")
+        .expect("root scene should be written");
+
+    let mut builder = SceneBuilder::new();
+    parse_file(root.to_str().unwrap(), &mut builder).expect("scene should parse");
+    assert_eq!(builder.materials.len(), 1);
+    assert_eq!(builder.shapes.len(), 1);
+}
+
+#[test]
+fn include_result_reaches_print_target() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt");
+    fs::write(&child, "Translate 1 2 3\n").expect("child scene should be written");
+    fs::write(&root, "Identity\nInclude \"child.pbrt\"\n").expect("root scene should be written");
+
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let writer = Arc::new(RefCell::new(SharedWriter(bytes.clone())));
+    let mut target = PrintTarget::new(writer);
+    parse_file(root.to_str().unwrap(), &mut target).expect("scene should parse");
+    let output = String::from_utf8(bytes.lock().unwrap().clone()).expect("output should be UTF-8");
+    assert!(output.contains("Identity"));
+    assert!(output.contains("Translate 1 2 3"));
 }

--- a/tests/parser_include_sources.rs
+++ b/tests/parser_include_sources.rs
@@ -1,0 +1,42 @@
+use pbrt_r4::parser::read_file::read_file_with_include_sources;
+use pbrt_r4::parser::{parse_file, DebugTarget};
+use std::fs;
+
+fn operation_names(target: &DebugTarget) -> Vec<String> {
+    target
+        .operations
+        .borrow()
+        .iter()
+        .map(|operation| operation.name.clone())
+        .collect()
+}
+
+#[test]
+fn include_sources_preserve_directive_order_and_work_directories() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let root = directory.path().join("root.pbrt");
+    let child = directory.path().join("child.pbrt");
+    fs::write(&child, "Translate 1 2 3\n").expect("child scene should be written");
+    fs::write(&root, "Identity\nInclude \"child.pbrt\"\nScale 2 2 2\n")
+        .expect("root scene should be written");
+
+    let sources = read_file_with_include_sources(root.to_str().unwrap())
+        .expect("include expansion should succeed");
+    assert!(sources.len() >= 7);
+    assert!(sources.iter().all(|source| !source.is_empty()));
+
+    let mut target = DebugTarget::new();
+    parse_file(root.to_str().unwrap(), &mut target).expect("scene should parse");
+    assert_eq!(
+        operation_names(&target),
+        [
+            "WorkDirBegin",
+            "Identitiy",
+            "WorkDirBegin",
+            "Translate",
+            "WorkDirEnd",
+            "Scale",
+            "WorkDirEnd",
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- Align streaming Include handling with pbrt-v4 by keeping Include notifications out of the normal parser session.
- Add file, line, column, and operation context to Include errors.
- Add regression coverage for Include state continuity, missing files, invalid child input, gzip inputs, and tar.gz scenes.
- Deduplicate parser input-stack error construction.

## Validation
- cargo fmt --all
- cargo test --test parser_include_sources
- cargo test --test parser_comments
- cargo test --test parser_upgrade
- cargo test --all
- cargo build --release
- git diff --check

Base: develop