### PR TITLE
fix(texture): support two-channel float imagemaps

### DIFF
--- a/src/textures/imagemap.rs
+++ b/src/textures/imagemap.rs
@@ -591,9 +591,12 @@ fn normalize_raw_image_for_float(raw: &RawImage) -> Result<(Vec<Float>, usize), 
     let normalized = match raw.channels {
         1 => (raw.data_f32(), 1),
         2 => {
-            return Err(PbrtError::error(
-                "Unsupported two-channel image for Float imagemap",
-            ));
+            // Match pbrt-v4 Image::Read: treat Y+A images as a Y-only image.
+            let mut y = Vec::with_capacity(pixels);
+            for pixel in 0..pixels {
+                y.push(raw.channel(pixel, 0));
+            }
+            (y, 1)
         }
         3 => (raw.data_f32(), 3),
         4 => {

--- a/tests/float_imagemap_channels.rs
+++ b/tests/float_imagemap_channels.rs
@@ -68,7 +68,7 @@ fn nonopaque_rgba_float_imagemap_uses_alpha_for_bilinear() {
 }
 
 #[test]
-fn two_channel_float_imagemap_is_rejected() {
+fn two_channel_float_imagemap_uses_luma_and_ignores_alpha() {
     let file = tempfile::Builder::new()
         .prefix("pbrt-r4-two-channel-imagemap-")
         .suffix(".png")
@@ -84,7 +84,15 @@ fn two_channel_float_imagemap_is_rejected() {
     let s_tex: HashMap<String, Arc<SpectrumTexture>> = HashMap::new();
     let tp = TextureParameterDictionary::new(&geom_params, &f_tex, &s_tex);
 
-    assert!(FloatTexture::create("imagemap", &Transform::identity(), &tp).is_err());
+    let texture = FloatTexture::create("imagemap", &Transform::identity(), &tp).unwrap();
+    let value = texture.evaluate(&TextureEvalContext::default());
+    assert!((value - 51.0 / 255.0).abs() < 1e-5);
+    match texture {
+        FloatTexture::ImageMap(image_map) => {
+            assert_eq!(image_map.mipmap_channel_count(), 1);
+        }
+        _ => panic!("expected imagemap texture"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Match pbrt-v4 behavior for Y+A images in Float ImageMap by using only the Y channel.
- Build a one-channel Float MIPMap instead of rejecting two-channel input.
- Update regression coverage to verify the value, ignored alpha, and one-channel MIPMap.

## Validation
- cargo fmt
- cargo test --test float_imagemap_channels
- cargo test --test read_image
- cargo build --release
- bistro_cafe_small_64.pbrt rendered successfully with --quick --nthreads 16 --texture-cache off