### PR TITLE
perf(parser): avoid whitespace result allocations

### DIFF
--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -4,6 +4,7 @@ use crate::util::base::Float;
 use crate::util::spectrum::*;
 use nom::bytes;
 use nom::character;
+use nom::combinator::recognize;
 use nom::multi;
 use nom::number;
 use nom::sequence;
@@ -11,11 +12,11 @@ use nom::IResult;
 use std::io::{Error, ErrorKind};
 
 pub fn space0(s: &str) -> IResult<&str, &str> {
-    return nom::combinator::recognize(multi::many0_count(space_or_comment))(s);
+    return recognize(multi::many0_count(space_or_comment))(s);
 }
 
 pub fn space1(s: &str) -> IResult<&str, &str> {
-    return nom::combinator::recognize(multi::many1_count(space_or_comment))(s);
+    return recognize(multi::many1_count(space_or_comment))(s);
 }
 
 fn space_or_comment(s: &str) -> IResult<&str, &str> {

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -11,11 +11,11 @@ use nom::IResult;
 use std::io::{Error, ErrorKind};
 
 pub fn space0(s: &str) -> IResult<&str, &str> {
-    return nom::combinator::recognize(multi::many0(space_or_comment))(s);
+    return nom::combinator::recognize(multi::many0_count(space_or_comment))(s);
 }
 
 pub fn space1(s: &str) -> IResult<&str, &str> {
-    return nom::combinator::recognize(multi::many1(space_or_comment))(s);
+    return nom::combinator::recognize(multi::many1_count(space_or_comment))(s);
 }
 
 fn space_or_comment(s: &str) -> IResult<&str, &str> {


### PR DESCRIPTION
## Summary
- Replace nom `many0` / `many1` with `many0_count` / `many1_count` for parser whitespace/comment runs.
- Preserve the existing `space0` / `space1` input-consumption interface while avoiding temporary result vectors.
- Address review feedback by importing `recognize` at file scope.

## Validation
- `cargo fmt`
- `cargo test --test parser_common --test parser_comments --test parser_include_sources`
- `cargo test -q`
- `cargo build --release`
- Existing 100,000-curve measurement: approximately 0.826s -> 0.778s.

Design: `docs/parser-hot-path-optimization-design_ja.md` in the devkit repository.