### PR TITLE
perf(parser): dispatch directives by name

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -129,15 +129,12 @@ fn parser_error_at(source: &str, offset: usize, operation: &str, message: &str) 
     PbrtError::error(&message)
 }
 
-fn operation_name(input: &str) -> &str {
-    operation_name_token(input).unwrap_or("<end-of-input>")
-}
-
-fn operation_name_token(input: &str) -> Option<&str> {
+fn operation_name_token(input: &str) -> Option<(&str, bool)> {
     let end = input
         .find(|character: char| character.is_ascii_whitespace() || character == '#')
         .unwrap_or(input.len());
-    (!input[..end].is_empty()).then_some(&input[..end])
+    let token = &input[..end];
+    (!token.is_empty()).then_some((token, token.bytes().all(|byte| byte.is_ascii_alphabetic())))
 }
 
 fn parse_next_operation<'a>(
@@ -151,8 +148,23 @@ fn parse_next_operation<'a>(
     }
 
     let operation_input = remaining;
-    let name = operation_name(operation_input);
-    let (remaining, operation) = parse_operation(operation_input)
+    let Some((name, valid_identifier)) = operation_name_token(operation_input) else {
+        return Err(parser_error(
+            source,
+            operation_input,
+            "<end-of-input>",
+            "expected a directive name",
+        ));
+    };
+    if !valid_identifier {
+        return Err(parser_error(
+            source,
+            operation_input,
+            name,
+            "directive name must contain only ASCII letters",
+        ));
+    }
+    let (remaining, operation) = parse_operation(operation_input, name)
         .map_err(|error| parser_error(source, operation_input, name, &error.to_string()))?;
     Ok(Some((remaining, operation_input, operation)))
 }
@@ -190,7 +202,7 @@ fn parse_opnodes(s: &str) -> Result<Vec<OPNode>, PbrtError> {
 fn parse_opnodes_core(s: &str) -> Result<Vec<OPNode>, PbrtError> {
     let result = nom::combinator::all_consuming(multi::many0(sequence::delimited(
         space0,
-        parse_operation,
+        parse_operation_from_input,
         space0,
     )))(s);
     match result {
@@ -201,6 +213,22 @@ fn parse_opnodes_core(s: &str) -> Result<Vec<OPNode>, PbrtError> {
             return Err(PbrtError::from(e.to_string()));
         }
     }
+}
+
+fn parse_operation_from_input(s: &str) -> IResult<&str, OPNode> {
+    let Some((name, valid_identifier)) = operation_name_token(s) else {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            s,
+            nom::error::ErrorKind::Tag,
+        )));
+    };
+    if !valid_identifier {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            s,
+            nom::error::ErrorKind::Alpha,
+        )));
+    }
+    parse_operation(s, name)
 }
 
 pub struct OPNode {
@@ -300,6 +328,17 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                     return Err(PbrtError::error(&msg));
                 }
                 context.transform(&vec);
+            }
+            "TransformTimes" => {
+                let Some(args) = op.args.as_ref() else {
+                    return Err(PbrtError::error("TransformTimes requires arguments."));
+                };
+                let vec = args.get_floats("args");
+                if vec.len() != 2 {
+                    let msg = format!("{} required {} arguments", opname, 2);
+                    return Err(PbrtError::error(&msg));
+                }
+                context.transform_times(vec[0], vec[1]);
             }
             "CoordinateSystem" => {
                 let Some(args) = op.args.as_ref() else {
@@ -666,14 +705,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
 
 //-----------------------------------
 
-fn parse_operation(s: &str) -> IResult<&str, OPNode> {
-    let Some(name) = operation_name_token(s) else {
-        return Err(nom::Err::Error(nom::error::Error::new(
-            s,
-            nom::error::ErrorKind::Tag,
-        )));
-    };
-
+fn parse_operation<'a>(s: &'a str, name: &str) -> IResult<&'a str, OPNode> {
     match name {
         "Identity" => parse_identity(s),
         "Translate" => parse_translate(s),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -130,7 +130,14 @@ fn parser_error_at(source: &str, offset: usize, operation: &str, message: &str) 
 }
 
 fn operation_name(input: &str) -> &str {
-    input.split_whitespace().next().unwrap_or("<end-of-input>")
+    operation_name_token(input).unwrap_or("<end-of-input>")
+}
+
+fn operation_name_token(input: &str) -> Option<&str> {
+    let end = input
+        .find(|character: char| character.is_ascii_whitespace() || character == '#')
+        .unwrap_or(input.len());
+    (!input[..end].is_empty()).then_some(&input[..end])
 }
 
 fn parse_next_operation<'a>(
@@ -660,56 +667,62 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
 //-----------------------------------
 
 fn parse_operation(s: &str) -> IResult<&str, OPNode> {
-    return nom::branch::alt((
-        nom::branch::alt((
-            parse_identity,
-            parse_translate,
-            parse_rotate,
-            parse_scale,
-            parse_look_at,
-            parse_concat_transform,
-            parse_transform,
-            parse_coordinate_system,
-            parse_coord_sys_transform,
-            parse_color_space,
-            parse_active_transform,
-            parse_transform_times,
-        )),
-        nom::branch::alt((
-            parse_pixel_filter,
-            parse_film,
-            parse_sampler,
-            parse_accelerator,
-            parse_integrator,
-            parse_camera,
-            parse_make_named_medium,
-            parse_medium_interface,
-            parse_option,
-        )),
-        nom::branch::alt((
-            parse_world_begin,
-            parse_attribute,
-            parse_attribute_begin,
-            parse_attribute_end,
-            parse_transform_begin,
-            parse_transform_end,
-            parse_texture,
-            parse_material,
-            parse_make_named_material,
-            parse_named_material,
-            parse_light_source,
-            parse_area_light_source,
-            parse_shape,
-            parse_reverse_orientation,
-            parse_object_begin,
-            parse_object_end,
-            parse_object_instance,
-            parse_world_end,
-            parse_include,
-            parse_import,
-        )),
-        nom::branch::alt((parse_work_dir_begin, parse_work_dir_end)),
-    ))(s);
+    let Some(name) = operation_name_token(s) else {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            s,
+            nom::error::ErrorKind::Tag,
+        )));
+    };
+
+    match name {
+        "Identity" => parse_identity(s),
+        "Translate" => parse_translate(s),
+        "Rotate" => parse_rotate(s),
+        "Scale" => parse_scale(s),
+        "LookAt" => parse_look_at(s),
+        "ConcatTransform" => parse_concat_transform(s),
+        "Transform" => parse_transform(s),
+        "CoordinateSystem" => parse_coordinate_system(s),
+        "CoordSysTransform" => parse_coord_sys_transform(s),
+        "ColorSpace" => parse_color_space(s),
+        "ActiveTransform" => parse_active_transform(s),
+        "TransformTimes" => parse_transform_times(s),
+        "PixelFilter" => parse_pixel_filter(s),
+        "Film" => parse_film(s),
+        "Sampler" => parse_sampler(s),
+        "Accelerator" => parse_accelerator(s),
+        "Integrator" => parse_integrator(s),
+        "Camera" => parse_camera(s),
+        "MakeNamedMedium" => parse_make_named_medium(s),
+        "MediumInterface" => parse_medium_interface(s),
+        "Option" => parse_option(s),
+        "WorldBegin" => parse_world_begin(s),
+        "Attribute" => parse_attribute(s),
+        "AttributeBegin" => parse_attribute_begin(s),
+        "AttributeEnd" => parse_attribute_end(s),
+        "TransformBegin" => parse_transform_begin(s),
+        "TransformEnd" => parse_transform_end(s),
+        "Texture" => parse_texture(s),
+        "Material" => parse_material(s),
+        "MakeNamedMaterial" => parse_make_named_material(s),
+        "NamedMaterial" => parse_named_material(s),
+        "LightSource" => parse_light_source(s),
+        "AreaLightSource" => parse_area_light_source(s),
+        "Shape" => parse_shape(s),
+        "ReverseOrientation" => parse_reverse_orientation(s),
+        "ObjectBegin" => parse_object_begin(s),
+        "ObjectEnd" => parse_object_end(s),
+        "ObjectInstance" => parse_object_instance(s),
+        "WorldEnd" => parse_world_end(s),
+        "Include" => parse_include(s),
+        "Import" => parse_import(s),
+        "WorkDirBegin" => parse_work_dir_begin(s),
+        "WorkDirEnd" => parse_work_dir_end(s),
+        _ => Err(nom::Err::Error(nom::error::Error::new(
+            s,
+            nom::error::ErrorKind::Tag,
+        ))),
+    }
 }
 
 fn parse_op_void<'a>(s: &'a str, name: &str) -> IResult<&'a str, OPNode> {

--- a/tests/parser_dispatch.rs
+++ b/tests/parser_dispatch.rs
@@ -1,4 +1,4 @@
-use pbrt_r4::parser::{parse_string, DebugTarget};
+use pbrt_r4::parser::{parse_string, parse_string_upgraded, DebugTarget};
 
 fn operation_names(target: &DebugTarget) -> Vec<String> {
     target
@@ -51,4 +51,104 @@ fn dispatch_rejects_a_known_name_with_a_suffix() {
 
     assert!(error.msg.contains("operation `AttributeBeginExtra`"));
     assert!(target.operations.borrow().is_empty());
+}
+
+#[test]
+fn dispatches_every_parser_operation() {
+    let cases = [
+        "Identity\n",
+        "Translate 1 2 3\n",
+        "Rotate 1 0 1 0\n",
+        "Scale 1 1 1\n",
+        "LookAt 0 0 1 0 0 0 0 1 0\n",
+        "ConcatTransform [1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1]\n",
+        "Transform [1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1]\n",
+        "CoordinateSystem \"camera\"\n",
+        "CoordSysTransform \"camera\"\n",
+        "ColorSpace \"srgb\"\n",
+        "ActiveTransform All\n",
+        "PixelFilter \"box\"\n",
+        "Film \"rgb\"\n",
+        "Sampler \"independent\"\n",
+        "Accelerator \"bvh\"\n",
+        "Integrator \"path\"\n",
+        "Camera \"perspective\"\n",
+        "MakeNamedMedium \"medium\"\n",
+        "MediumInterface \"inside\" \"outside\"\n",
+        "Option \"integer xresolution\" 1\n",
+        "WorldBegin\n",
+        "Attribute \"material\"\n",
+        "AttributeBegin\n",
+        "AttributeEnd\n",
+        "TransformBegin\n",
+        "TransformEnd\n",
+        "Texture \"texture\" \"spectrum\" \"imagemap\"\n",
+        "Material \"diffuse\"\n",
+        "MakeNamedMaterial \"material\"\n",
+        "NamedMaterial \"material\"\n",
+        "LightSource \"point\"\n",
+        "AreaLightSource \"diffuse\"\n",
+        "Shape \"sphere\"\n",
+        "ReverseOrientation\n",
+        "ObjectBegin \"object\"\n",
+        "ObjectEnd\n",
+        "ObjectInstance \"object\"\n",
+        "WorldEnd\n",
+        "Include \"child.pbrt\"\n",
+        "Import \"child.pbrt\"\n",
+        "WorkDirBegin \"/tmp\"\n",
+        "WorkDirEnd\n",
+    ];
+
+    for source in cases {
+        let mut target = DebugTarget::new();
+        parse_string(source, &mut target)
+            .unwrap_or_else(|error| panic!("failed to dispatch {source:?}: {error:?}"));
+        assert_eq!(
+            target.operations.borrow().len(),
+            1,
+            "expected one operation for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn dispatch_reports_invalid_identifier_and_unknown_operation() {
+    for source in ["123\n", "Shape-é\n"] {
+        let mut target = DebugTarget::new();
+        let error = parse_string(source, &mut target).expect_err("invalid name should fail");
+        assert!(
+            error.msg.contains("line 1"),
+            "unexpected error: {}",
+            error.msg
+        );
+        assert!(target.operations.borrow().is_empty());
+    }
+
+    let mut target = DebugTarget::new();
+    let error =
+        parse_string("UnknownDirective\n", &mut target).expect_err("unknown directive should fail");
+    assert!(error.msg.contains("operation `UnknownDirective`"));
+}
+
+#[test]
+fn dispatch_preserves_malformed_operation_errors() {
+    let mut target = DebugTarget::new();
+    let error = parse_string("Translate 1 2\n", &mut target)
+        .expect_err("missing operation argument should fail");
+
+    assert!(error.msg.contains("line 1"));
+    assert!(error.msg.contains("operation `Translate`"));
+}
+
+#[test]
+fn dispatch_streaming_and_upgrade_paths_have_the_same_operations() {
+    let source = "WorldBegin\nAttributeBegin\nShape \"sphere\"\nAttributeEnd\nWorldEnd\n";
+    let mut streaming = DebugTarget::new();
+    let mut upgraded = DebugTarget::new();
+
+    parse_string(source, &mut streaming).expect("streaming parser should succeed");
+    parse_string_upgraded(source, &mut upgraded).expect("upgrade parser should succeed");
+
+    assert_eq!(operation_names(&streaming), operation_names(&upgraded));
 }

--- a/tests/parser_dispatch.rs
+++ b/tests/parser_dispatch.rs
@@ -1,0 +1,54 @@
+use pbrt_r4::parser::{parse_string, DebugTarget};
+
+fn operation_names(target: &DebugTarget) -> Vec<String> {
+    target
+        .operations
+        .borrow()
+        .iter()
+        .map(|operation| operation.name.clone())
+        .collect()
+}
+
+#[test]
+fn dispatch_preserves_common_prefix_directives() {
+    let mut target = DebugTarget::new();
+    parse_string(
+        "AttributeBegin\nAttributeEnd\nTransformBegin\nTransformEnd\nWorldBegin\nWorldEnd\n",
+        &mut target,
+    )
+    .expect("common-prefix directives should be dispatched exactly");
+
+    assert_eq!(
+        operation_names(&target),
+        [
+            "AttributeBegin",
+            "AttributeEnd",
+            "TransformBegin",
+            "TransformEnd",
+            "WorldBegin",
+            "WorldEnd",
+        ]
+    );
+}
+
+#[test]
+fn dispatch_accepts_comment_after_directive_name() {
+    let mut target = DebugTarget::new();
+    parse_string(
+        "WorldBegin# comment without a separating space\n",
+        &mut target,
+    )
+    .expect("a comment may immediately follow a void directive");
+
+    assert_eq!(operation_names(&target), ["WorldBegin"]);
+}
+
+#[test]
+fn dispatch_rejects_a_known_name_with_a_suffix() {
+    let mut target = DebugTarget::new();
+    let error = parse_string("AttributeBeginExtra\n", &mut target)
+        .expect_err("a suffixed directive must not match AttributeBegin");
+
+    assert!(error.msg.contains("operation `AttributeBeginExtra`"));
+    assert!(target.operations.borrow().is_empty());
+}


### PR DESCRIPTION
## Summary
- Dispatch parser operations by one exact directive-name match instead of trying the full `nom::alt` chain.
- Keep existing directive parsers and error propagation unchanged.
- Treat `#` as a valid directive-token terminator and reject known-name suffixes.
- Add external regression tests for common prefixes, comment adjacency, and unknown suffixes.

## Validation
- `cargo fmt`
- `cargo test --test parser_dispatch --test parser_comments --test parser_common --test parser_include_sources`
- `cargo test -q`
- `cargo build --release`
- Existing 100,000-curve measurement: approximately 0.778s -> 0.614s with direct dispatch.

Design: `docs/parser-hot-path-optimization-design_ja.md` in the devkit repository.