### PR TITLE
perf(parser): pass owned parsed parameters

### DIFF
--- a/src/paramdict/parameter_dictionary.rs
+++ b/src/paramdict/parameter_dictionary.rs
@@ -125,6 +125,41 @@ fn add_values<T: Clone>(
     }
 }
 
+fn add_owned_values<T>(
+    k: &mut Vec<String>,
+    m: &mut HashMap<String, SharedValues<T>>,
+    key: &str,
+    values: Vec<T>,
+) {
+    k.push(key.to_string());
+    let keyname = get_key_name(key);
+    if let Some(storage) = m.get(&keyname) {
+        *write_values(storage) = values;
+    } else {
+        m.insert(keyname, RwLock::new(values));
+    }
+}
+
+fn add_owned_values_with_type<T>(
+    k: &mut Vec<String>,
+    m: &mut HashMap<String, SharedValues<T>>,
+    parameter_type: &str,
+    name: &str,
+    values: Vec<T>,
+) {
+    let key = if parameter_type.is_empty() {
+        name.to_string()
+    } else {
+        format!("{parameter_type} {name}")
+    };
+    k.push(key);
+    if let Some(storage) = m.get(name) {
+        *write_values(storage) = values;
+    } else {
+        m.insert(name.to_string(), RwLock::new(values));
+    }
+}
+
 fn add_value_no_key<T: Clone>(m: &mut HashMap<String, SharedValues<T>>, key: &str, v: T) {
     let keyname = get_key_name(key);
     match m.get(&keyname) {
@@ -230,6 +265,28 @@ impl ParameterDictionary {
         add_values(&mut self.keys, &mut self.ints, key, v);
     }
 
+    pub fn add_owned_bools(&mut self, key: &str, values: Vec<bool>) {
+        add_owned_values(&mut self.keys, &mut self.bools, key, values);
+    }
+
+    pub fn add_owned_bools_typed(&mut self, parameter_type: &str, name: &str, values: Vec<bool>) {
+        add_owned_values_with_type(
+            &mut self.keys,
+            &mut self.bools,
+            parameter_type,
+            name,
+            values,
+        );
+    }
+
+    pub fn add_owned_ints(&mut self, key: &str, values: Vec<i32>) {
+        add_owned_values(&mut self.keys, &mut self.ints, key, values);
+    }
+
+    pub fn add_owned_ints_typed(&mut self, parameter_type: &str, name: &str, values: Vec<i32>) {
+        add_owned_values_with_type(&mut self.keys, &mut self.ints, parameter_type, name, values);
+    }
+
     pub fn add_float(&mut self, key: &str, v: Float) {
         add_value(&mut self.keys, &mut self.floats, key, v);
     }
@@ -251,6 +308,57 @@ impl ParameterDictionary {
         }
     }
 
+    pub fn add_owned_floats(&mut self, key: &str, values: Vec<Float>) {
+        let t = get_key_type(key);
+        match t.as_str() {
+            "point" | "point2" | "point3" | "point4" | "normal" | "vector" | "vector2"
+            | "vector3" | "vector4" | "color" | "rgb" => {
+                add_owned_values(&mut self.keys, &mut self.points, key, values)
+            }
+            "xyz" => self.add_xyz(key, &values),
+            "blackbody" => add_owned_values(&mut self.keys, &mut self.floats, key, values),
+            _ => add_owned_values(&mut self.keys, &mut self.floats, key, values),
+        }
+    }
+
+    pub fn add_owned_floats_typed(&mut self, parameter_type: &str, name: &str, values: Vec<Float>) {
+        match parameter_type {
+            "point" | "point2" | "point3" | "point4" | "normal" | "vector" | "vector2"
+            | "vector3" | "vector4" | "color" | "rgb" => add_owned_values_with_type(
+                &mut self.keys,
+                &mut self.points,
+                parameter_type,
+                name,
+                values,
+            ),
+            "xyz" => {
+                let xyz = RGBSpectrum::rgb_from_xyz(&values);
+                let rgb = xyz.to_rgb();
+                add_owned_values_with_type(
+                    &mut self.keys,
+                    &mut self.points,
+                    parameter_type,
+                    name,
+                    rgb.to_vec(),
+                );
+            }
+            "blackbody" => add_owned_values_with_type(
+                &mut self.keys,
+                &mut self.floats,
+                parameter_type,
+                name,
+                values,
+            ),
+            _ => add_owned_values_with_type(
+                &mut self.keys,
+                &mut self.floats,
+                parameter_type,
+                name,
+                values,
+            ),
+        }
+    }
+
     pub fn add_string(&mut self, key: &str, v: &str) {
         add_value(&mut self.keys, &mut self.strings, key, String::from(v));
     }
@@ -260,8 +368,42 @@ impl ParameterDictionary {
         add_values(&mut self.keys, &mut self.strings, key, &vv);
     }
 
+    pub fn add_owned_strings(&mut self, key: &str, values: Vec<String>) {
+        add_owned_values(&mut self.keys, &mut self.strings, key, values);
+    }
+
+    pub fn add_owned_strings_typed(
+        &mut self,
+        parameter_type: &str,
+        name: &str,
+        values: Vec<String>,
+    ) {
+        add_owned_values_with_type(
+            &mut self.keys,
+            &mut self.strings,
+            parameter_type,
+            name,
+            values,
+        );
+    }
+
     pub fn add_spectrum(&mut self, key: &str, v: &Spectrum) {
         add_value(&mut self.keys, &mut self.spectrums, key, v.clone());
+    }
+
+    pub fn add_owned_spectrums_typed(
+        &mut self,
+        parameter_type: &str,
+        name: &str,
+        values: Vec<Spectrum>,
+    ) {
+        add_owned_values_with_type(
+            &mut self.keys,
+            &mut self.spectrums,
+            parameter_type,
+            name,
+            values,
+        );
     }
 
     pub fn add_spectrums(&mut self, key: &str, v: &[Spectrum]) {
@@ -276,8 +418,37 @@ impl ParameterDictionary {
         add_value(&mut self.keys, &mut self.sampled_spectra, key, sampled);
     }
 
+    pub fn add_owned_sampled_spectra_typed(
+        &mut self,
+        parameter_type: &str,
+        name: &str,
+        values: Vec<SampledSpectrumParam>,
+    ) {
+        add_owned_values_with_type(
+            &mut self.keys,
+            &mut self.sampled_spectra,
+            parameter_type,
+            name,
+            values,
+        );
+    }
+
     pub fn add_point(&mut self, key: &str, v: &[Float]) {
         add_values(&mut self.keys, &mut self.points, key, v);
+    }
+
+    pub fn add_owned_points(&mut self, key: &str, values: Vec<Float>) {
+        add_owned_values(&mut self.keys, &mut self.points, key, values);
+    }
+
+    pub fn add_owned_points_typed(&mut self, parameter_type: &str, name: &str, values: Vec<Float>) {
+        add_owned_values_with_type(
+            &mut self.keys,
+            &mut self.points,
+            parameter_type,
+            name,
+            values,
+        );
     }
 
     //--------------------

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -1,7 +1,5 @@
 use crate::paramdict::wellknown_params;
-use crate::paramdict::ParameterDictionary;
-use crate::util::base::Float;
-use crate::util::spectrum::*;
+use crate::parser::parsed_parameter::{ParsedParameter, ParsedParameterValues};
 use nom::bytes;
 use nom::character;
 use nom::combinator::recognize;
@@ -9,7 +7,6 @@ use nom::multi;
 use nom::number;
 use nom::sequence;
 use nom::IResult;
-use std::io::{Error, ErrorKind};
 
 pub fn space0(s: &str) -> IResult<&str, &str> {
     return recognize(multi::many0_count(space_or_comment))(s);
@@ -70,17 +67,20 @@ pub fn parse_list(s: &str) -> IResult<&str, Vec<&str>> {
 }
 
 pub fn get_param_type(s: &str) -> (&str, &str) {
-    let ss: Vec<&str> = s.split_ascii_whitespace().collect();
-    if ss.len() == 2 {
-        return (ss[0], ss[1]);
-    } else if ss.len() == 1 {
-        if let Some(t) = wellknown_params::find_type_from_key(ss[0]) {
-            return (t, ss[0]);
-        } else {
-            return ("", ss[0]);
-        }
-    } else {
+    let mut parts = s.split_ascii_whitespace();
+    let Some(first) = parts.next() else {
         return ("", s);
+    };
+    let Some(second) = parts.next() else {
+        return (
+            wellknown_params::find_type_from_key(first).unwrap_or(""),
+            first,
+        );
+    };
+    if parts.next().is_none() {
+        (first, second)
+    } else {
+        ("", s)
     }
 }
 
@@ -96,203 +96,77 @@ pub fn convert_bool(s: &str) -> Result<bool, std::str::ParseBoolError> {
     }
 }
 
-pub fn parse_params(s: &str) -> IResult<&str, ParameterDictionary> {
-    let (s, v) = multi::separated_list0(
-        space1,
-        nom::branch::permutation((
-            sequence::terminated(string_literal, space1),
-            nom::branch::alt((parse_list, parse_listed_literal)),
-        )),
-    )(s)?;
-    let mut params = ParameterDictionary::new();
-    for vv in &v {
-        let org_key = vv.0;
-        let (t, key) = get_param_type(org_key);
-        let new_key = format!("{t} {key}");
-        match t {
-            "string" => {
-                let s_values = &vv.1;
-                params.add_strings(&new_key, &s_values);
-            }
-            "texture" => {
-                let s_values = &vv.1;
-                params.add_strings(&new_key, &s_values);
-            }
-            "spectrum" => {
-                let s_values = &vv.1;
-                let values: Result<Vec<Float>, _> =
-                    s_values.iter().map(|s| s.parse::<Float>()).collect();
-                if let Ok(values) = values {
-                    let spectrum = if values.len() == 1 {
-                        Some(Spectrum::from(values[0]))
-                    } else if values.len() == 3 {
-                        Some(Spectrum::from_rgb(&values, SpectrumType::Albedo))
-                    } else if values.len() >= 2 && values.len() % 2 == 0 {
-                        let mut lambda = Vec::with_capacity(values.len() / 2);
-                        let mut sampled = Vec::with_capacity(values.len() / 2);
-                        for pair in values.chunks_exact(2) {
-                            lambda.push(pair[0]);
-                            sampled.push(pair[1]);
-                        }
-                        params.add_sampled_spectrum(&new_key, &lambda, &sampled);
-                        Some(Spectrum::from_sampled(&lambda, &sampled))
-                    } else {
-                        None
-                    };
-                    if let Some(spectrum) = spectrum {
-                        params.add_spectrum(&new_key, &spectrum);
-                    } else {
-                        params.add_strings(&new_key, &s_values);
-                    }
-                } else {
-                    params.add_strings(&new_key, &s_values);
-                }
-            }
-            "bool" => {
-                let s_values = &vv.1;
-                let values: Result<Vec<bool>, _> =
-                    s_values.iter().map(|s| convert_bool(s)).collect();
-                let values = match values {
-                    Ok(values) => values,
-                    Err(_) => {
-                        return Err(nom::Err::Failure(nom::error::Error::new(
-                            s,
-                            nom::error::ErrorKind::Fail,
-                        )))
-                    }
-                };
-                params.add_bools(&new_key, &values);
-            }
-            "integer" => {
-                let s_values = &vv.1;
-                let values: Vec<i32> = match s_values.iter().map(|s| s.parse::<i32>()).collect() {
-                    Ok(values) => values,
-                    Err(_) => {
-                        return Err(nom::Err::Failure(nom::error::Error::new(
-                            s,
-                            nom::error::ErrorKind::Fail,
-                        )))
-                    }
-                };
-                params.add_ints(&new_key, &values);
-            }
-            "color" | "rgb" | "xyz" => {
-                let s_values = &vv.1;
-                let values: Vec<Float> = match s_values.iter().map(|s| s.parse::<Float>()).collect()
-                {
-                    Ok(values) => values,
-                    Err(_) => {
-                        return Err(nom::Err::Failure(nom::error::Error::new(
-                            s,
-                            nom::error::ErrorKind::Fail,
-                        )))
-                    }
-                };
-                match t {
-                    "color" => params.add_color(&new_key, &values),
-                    "rgb" => params.add_rgb(&new_key, &values),
-                    "xyz" => params.add_xyz(&new_key, &values),
-                    _ => {}
-                }
-            }
-            "blackbody" => {
-                let s_values = &vv.1;
-                let values: Vec<Float> = match s_values.iter().map(|s| s.parse::<Float>()).collect()
-                {
-                    Ok(values) => values,
-                    Err(_) => {
-                        return Err(nom::Err::Failure(nom::error::Error::new(
-                            s,
-                            nom::error::ErrorKind::Fail,
-                        )))
-                    }
-                };
-                params.add_blackbody(&new_key, &values);
-            }
-            "point" | "point2" | "point3" | "point4" => {
-                let s_values = &vv.1;
-                let values: Vec<Float> = match s_values.iter().map(|s| s.parse::<Float>()).collect()
-                {
-                    Ok(values) => values,
-                    Err(_) => {
-                        return Err(nom::Err::Failure(nom::error::Error::new(
-                            s,
-                            nom::error::ErrorKind::Fail,
-                        )))
-                    }
-                };
-                params.add_point(&new_key, &values);
-            }
-            "vector" | "vector2" | "vector3" | "vector4" => {
-                let s_values = &vv.1;
-                let values: Vec<Float> = match s_values.iter().map(|s| s.parse::<Float>()).collect()
-                {
-                    Ok(values) => values,
-                    Err(_) => {
-                        return Err(nom::Err::Failure(nom::error::Error::new(
-                            s,
-                            nom::error::ErrorKind::Fail,
-                        )))
-                    }
-                };
-                params.add_point(&new_key, &values);
-            }
-            "normal" => {
-                let s_values = &vv.1;
-                let values: Vec<Float> = match s_values.iter().map(|s| s.parse::<Float>()).collect()
-                {
-                    Ok(values) => values,
-                    Err(_) => {
-                        return Err(nom::Err::Failure(nom::error::Error::new(
-                            s,
-                            nom::error::ErrorKind::Fail,
-                        )))
-                    }
-                };
-                params.add_point(&new_key, &values);
-            }
-            "float" => {
-                let s_values = &vv.1;
-                let values: Vec<Float> = match s_values.iter().map(|s| s.parse::<Float>()).collect()
-                {
-                    Ok(values) => values,
-                    Err(_) => {
-                        return Err(nom::Err::Failure(nom::error::Error::new(
-                            s,
-                            nom::error::ErrorKind::Fail,
-                        )))
-                    }
-                };
-                params.add_floats(&new_key, &values);
-            }
-            _ => {
-                let s_values = &vv.1;
-                let values: Vec<Float> = match s_values.iter().map(|s| s.parse::<Float>()).collect()
-                {
-                    Ok(values) => values,
-                    Err(_) => {
-                        return Err(nom::Err::Failure(nom::error::Error::new(
-                            s,
-                            nom::error::ErrorKind::Fail,
-                        )))
-                    }
-                };
-                params.add_floats(&new_key, &values);
-            }
+fn parsed_values<'a>(s: &'a str, parameter_type: &str) -> IResult<&'a str, ParsedParameterValues> {
+    let (mut rest, in_array) = match nom::bytes::complete::tag::<_, _, nom::error::Error<_>>("[")(s)
+    {
+        Ok((rest, _)) => {
+            let (rest, _) = space0(rest)?;
+            (rest, true)
+        }
+        Err(_) => (s, false),
+    };
+    let mut values = ParsedParameterValues::new_for_type(parameter_type);
+    loop {
+        let (next, literal) = parse_literal(rest)?;
+        values.push_literal(literal).map_err(|_| {
+            nom::Err::Failure(nom::error::Error::new(rest, nom::error::ErrorKind::Fail))
+        })?;
+        rest = next;
+        let (next, _) = match space1(rest) {
+            Ok(value) => value,
+            Err(_) => break,
+        };
+        rest = next;
+        if in_array && rest.starts_with(']') {
+            break;
+        }
+        if !in_array {
+            break;
         }
     }
-    let rest = s.trim_start();
-    if v.is_empty() && rest.starts_with('"') {
+    let (rest_after_space, _) = space0(rest)?;
+    rest = rest_after_space;
+    if in_array {
+        let (rest_after_close, _) = character::complete::char(']')(rest)?;
+        Ok((rest_after_close, values))
+    } else {
+        Ok((rest, values))
+    }
+}
+
+pub fn parse_params(s: &str) -> IResult<&str, Vec<ParsedParameter>> {
+    let mut rest = s;
+    let mut parameters = Vec::new();
+    loop {
+        let after_space = match space1(rest) {
+            Ok((next, _)) => next,
+            Err(_) => rest,
+        };
+        rest = after_space;
+        if !rest.starts_with('"') {
+            break;
+        }
+        let (next, declaration) = sequence::terminated(string_literal, space1)(rest)?;
+        let (parameter_type, name) = get_param_type(declaration);
+        let (next, values) = parsed_values(next, parameter_type)?;
+        parameters.push(ParsedParameter {
+            parameter_type: parameter_type.to_string(),
+            name: name.to_string(),
+            values,
+        });
+        rest = next;
+    }
+    if parameters.is_empty() && rest.trim_start().starts_with('"') {
         return Err(nom::Err::Failure(nom::error::Error::new(
-            s,
+            rest,
             nom::error::ErrorKind::Fail,
         )));
     }
-    if rest.starts_with('[') {
+    if rest.trim_start().starts_with('[') {
         return Err(nom::Err::Failure(nom::error::Error::new(
-            s,
+            rest,
             nom::error::ErrorKind::Fail,
         )));
     }
-    return Ok((s, params));
+    Ok((rest, parameters))
 }

--- a/src/parser/debug_target.rs
+++ b/src/parser/debug_target.rs
@@ -1,5 +1,5 @@
 use super::parse_target::*;
-use crate::paramdict::*;
+use super::ParsedParameterVector;
 use crate::util::base::*;
 use std::cell::{Cell, RefCell};
 
@@ -175,49 +175,49 @@ impl ParseTarget for DebugTarget {
             .borrow_mut()
             .push(Operation::new("TransformTimes", &v));
     }
-    fn pixel_filter(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn pixel_filter(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}pixel_filter:\"{name}\"", self.get_indent());
         let v = vec![String::from(name)];
         self.operations
             .borrow_mut()
             .push(Operation::new("PixelFilter", &v));
     }
-    fn film(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn film(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}film:\"{name}\"", self.get_indent());
         let v = vec![String::from(name)];
         self.operations
             .borrow_mut()
             .push(Operation::new("Film", &v));
     }
-    fn sampler(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn sampler(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}sampler:\"{name}\"", self.get_indent());
         let v = vec![String::from(name)];
         self.operations
             .borrow_mut()
             .push(Operation::new("Sampler", &v));
     }
-    fn accelerator(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn accelerator(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}accelerator:\"{name}\"", self.get_indent());
         let v = vec![String::from(name)];
         self.operations
             .borrow_mut()
             .push(Operation::new("Accelerator", &v));
     }
-    fn integrator(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn integrator(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}integrator:\"{name}\"", self.get_indent());
         let v = vec![String::from(name)];
         self.operations
             .borrow_mut()
             .push(Operation::new("Integrator", &v));
     }
-    fn camera(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn camera(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}camera:\"{name}\"", self.get_indent());
         let v = vec![String::from("")];
         self.operations
             .borrow_mut()
             .push(Operation::new("Camera", &v));
     }
-    fn make_named_medium(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn make_named_medium(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}make_named_medium:\"{name}\"", self.get_indent());
         let v = vec![String::from("")];
         self.operations
@@ -242,7 +242,7 @@ impl ParseTarget for DebugTarget {
             .push(Operation::new("WorldBegin", &v));
         self.inc_indent();
     }
-    fn attribute(&mut self, target: &str, _params: &ParameterDictionary) {
+    fn attribute(&mut self, target: &str, _params: ParsedParameterVector) {
         println!("{}attribute:\"{target}\"", self.get_indent());
         let v = vec![String::from(target)];
         self.operations
@@ -281,7 +281,7 @@ impl ParseTarget for DebugTarget {
             .borrow_mut()
             .push(Operation::new("TransformEnd", &v));
     }
-    fn texture(&mut self, name: &str, t: &str, tex_name: &str, _params: &ParameterDictionary) {
+    fn texture(&mut self, name: &str, t: &str, tex_name: &str, _params: ParsedParameterVector) {
         println!(
             "{}texture:\"{}\", \"{}\", \"{}\"",
             self.get_indent(),
@@ -294,14 +294,14 @@ impl ParseTarget for DebugTarget {
             .borrow_mut()
             .push(Operation::new("Texture", &v));
     }
-    fn material(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn material(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}material:\"{name}\"", self.get_indent());
         let v = vec![String::from(name)];
         self.operations
             .borrow_mut()
             .push(Operation::new("Material", &v));
     }
-    fn make_named_material(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn make_named_material(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}make_named_material:\"{name}\"", self.get_indent());
         let v = vec![String::from(name)];
         self.operations
@@ -315,21 +315,21 @@ impl ParseTarget for DebugTarget {
             .borrow_mut()
             .push(Operation::new("NamedMaterial", &v));
     }
-    fn light_source(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn light_source(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}light_source:\"{name}\"", self.get_indent());
         let v = vec![String::from(name)];
         self.operations
             .borrow_mut()
             .push(Operation::new("LightSource", &v));
     }
-    fn area_light_source(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn area_light_source(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}area_light_source:\"{name}\"", self.get_indent());
         let v = vec![String::from(name)];
         self.operations
             .borrow_mut()
             .push(Operation::new("AreaLightSource", &v));
     }
-    fn shape(&mut self, name: &str, _params: &ParameterDictionary) {
+    fn shape(&mut self, name: &str, _params: ParsedParameterVector) {
         println!("{}shape:\"{name}\"", self.get_indent());
         let v = vec![String::from(name)];
         self.operations
@@ -405,7 +405,7 @@ impl ParseTarget for DebugTarget {
             .push(Operation::new("WorkDirEnd", &v));
     }
 
-    fn include(&mut self, filename: &str, _params: &ParameterDictionary) {
+    fn include(&mut self, filename: &str, _params: ParsedParameterVector) {
         println!("{}include:\"{filename}\"", self.get_indent());
         let v = vec![String::from(filename)];
         self.operations
@@ -413,7 +413,7 @@ impl ParseTarget for DebugTarget {
             .push(Operation::new("Include", &v));
     }
 
-    fn import(&mut self, filename: &str, _params: &ParameterDictionary) {
+    fn import(&mut self, filename: &str, _params: ParsedParameterVector) {
         println!("{}import:\"{filename}\"", self.get_indent());
         let v = vec![String::from(filename)];
         self.operations

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,7 @@
 pub mod common;
 pub mod debug_target;
 pub mod parse_target;
+pub mod parsed_parameter;
 pub mod print_target;
 pub mod read_file;
 pub mod remove_comment;
@@ -11,6 +12,10 @@ pub mod upgrade;
 
 pub use debug_target::DebugTarget;
 pub use parse_target::ParseTarget;
+pub use parsed_parameter::{
+    parsed_parameters_from_dictionary, ParsedParameter, ParsedParameterValues,
+    ParsedParameterVector, ParsedSpectrumToken,
+};
 pub use print_target::PrintTarget;
 pub use scene_builder::SceneBuilder;
 pub use to_ply_target::ToPlyTarget;
@@ -92,7 +97,7 @@ pub fn parse_string(s: &str, context: &mut dyn ParseTarget) -> Result<(), PbrtEr
 pub fn parse_string_upgraded(s: &str, context: &mut dyn ParseTarget) -> Result<(), PbrtError> {
     let mut ops = parse_opnodes(s)?;
     upgrade::upgrade_opnodes(&mut ops)?;
-    evaluate_opnodes(&ops, context)
+    evaluate_opnodes(ops, context)
 }
 
 pub fn parse_file_without_include(
@@ -175,11 +180,12 @@ pub fn parse_string_core(s: &str, context: &mut dyn ParseTarget) -> Result<(), P
         let Some((remaining, operation_input, operation)) = parse_next_operation(s, input)? else {
             return Ok(());
         };
-        if let Err(error) = evaluate_opnodes(std::slice::from_ref(&operation), context) {
+        let operation_name = operation.name.clone();
+        if let Err(error) = evaluate_opnodes(vec![operation], context) {
             return Err(parser_error(
                 s,
                 operation_input,
-                &operation.name,
+                &operation_name,
                 &error.to_string(),
             ));
         }
@@ -234,14 +240,48 @@ fn parse_operation_from_input(s: &str) -> IResult<&str, OPNode> {
 pub struct OPNode {
     pub name: String,
     pub args: Option<ParameterDictionary>,
-    pub params: Option<ParameterDictionary>,
+    pub params: Option<ParameterStorage>,
+}
+
+pub enum ParameterStorage {
+    Parsed(ParsedParameterVector),
+    Dictionary(ParameterDictionary),
+}
+
+impl ParameterStorage {
+    pub fn into_parsed(self) -> ParsedParameterVector {
+        match self {
+            Self::Parsed(parameters) => parameters,
+            Self::Dictionary(dictionary) => parsed_parameters_from_dictionary(&dictionary),
+        }
+    }
+
+    pub fn into_dictionary(self) -> ParameterDictionary {
+        match self {
+            Self::Parsed(parameters) => {
+                crate::parser::parsed_parameter::into_parameter_dictionary(parameters)
+            }
+            Self::Dictionary(dictionary) => dictionary,
+        }
+    }
+
+    pub fn as_dictionary_mut(&mut self) -> Option<&mut ParameterDictionary> {
+        match self {
+            Self::Dictionary(dictionary) => Some(dictionary),
+            Self::Parsed(_) => None,
+        }
+    }
+}
+
+fn take_params(op: &mut OPNode) -> Option<ParsedParameterVector> {
+    op.params.take().map(ParameterStorage::into_parsed)
 }
 
 impl OPNode {
     pub fn new(
         name: &str,
         args: Option<ParameterDictionary>,
-        params: Option<ParameterDictionary>,
+        params: Option<ParameterStorage>,
     ) -> Self {
         OPNode {
             name: String::from(name),
@@ -251,8 +291,8 @@ impl OPNode {
     }
 }
 
-fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(), PbrtError> {
-    for op in ops {
+fn evaluate_opnodes(ops: Vec<OPNode>, context: &mut dyn ParseTarget) -> Result<(), PbrtError> {
+    for mut op in ops {
         let opname: &str = &op.name;
         match opname {
             "Identity" => {
@@ -401,7 +441,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("PixelFilter requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("PixelFilter requires parameters."));
                 };
                 context.pixel_filter(name, params);
@@ -414,7 +454,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("Film requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Film requires parameters."));
                 };
                 context.film(name, params);
@@ -427,7 +467,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("Sampler requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Sampler requires parameters."));
                 };
                 context.sampler(name, params);
@@ -440,7 +480,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("Accelerator requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Accelerator requires parameters."));
                 };
                 context.accelerator(name, params);
@@ -453,7 +493,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("Integrator requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Integrator requires parameters."));
                 };
                 context.integrator(name, params);
@@ -466,7 +506,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("Camera requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Camera requires parameters."));
                 };
                 context.camera(name, params);
@@ -479,7 +519,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("MakeNamedMedium requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("MakeNamedMedium requires parameters."));
                 };
                 context.make_named_medium(name, params);
@@ -513,7 +553,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(target) = vec.first() else {
                     return Err(PbrtError::error("Attribute requires a target."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Attribute requires parameters."));
                 };
                 context.attribute(target, params);
@@ -546,7 +586,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(tex_name) = tex_name_values.first() else {
                     return Err(PbrtError::error("Texture requires a texture target."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Texture requires parameters."));
                 };
                 context.texture(&name, &tp, &tex_name, params);
@@ -559,7 +599,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("Material requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Material requires parameters."));
                 };
                 context.material(name, params);
@@ -572,7 +612,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("MakeNamedMaterial requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("MakeNamedMaterial requires parameters."));
                 };
                 context.make_named_material(name, params);
@@ -595,7 +635,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("LightSource requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("LightSource requires parameters."));
                 };
                 context.light_source(name, params);
@@ -608,7 +648,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("AreaLightSource requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("AreaLightSource requires parameters."));
                 };
                 context.area_light_source(name, params);
@@ -621,7 +661,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(name) = vec.first() else {
                     return Err(PbrtError::error("Shape requires a name."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Shape requires parameters."));
                 };
                 context.shape(name, params);
@@ -676,7 +716,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(filename) = vec.first() else {
                     return Err(PbrtError::error("Include requires a filename."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Include requires parameters."));
                 };
                 context.include(filename, params);
@@ -689,7 +729,7 @@ fn evaluate_opnodes(ops: &[OPNode], context: &mut dyn ParseTarget) -> Result<(),
                 let Some(filename) = vec.first() else {
                     return Err(PbrtError::error("Import requires a filename."));
                 };
-                let Some(params) = op.params.as_ref() else {
+                let Some(params) = take_params(&mut op) else {
                     return Err(PbrtError::error("Import requires parameters."));
                 };
                 context.import(filename, params);
@@ -848,7 +888,10 @@ fn parse_op_string_params<'a>(s: &'a str, opname: &str) -> IResult<&'a str, OPNo
     ))(s)?;
     let mut args = ParameterDictionary::new();
     args.add_string("arg1", a);
-    return Ok((s, OPNode::new(op, Some(args), Some(params))));
+    return Ok((
+        s,
+        OPNode::new(op, Some(args), Some(ParameterStorage::Parsed(params))),
+    ));
 }
 
 fn parse_op_string_string_string_params<'a>(s: &'a str, opname: &str) -> IResult<&'a str, OPNode> {
@@ -861,7 +904,10 @@ fn parse_op_string_string_string_params<'a>(s: &'a str, opname: &str) -> IResult
     args.add_string("arg1", a[0]);
     args.add_string("arg2", a[1]);
     args.add_string("arg3", a[2]);
-    return Ok((s, OPNode::new(op, Some(args), Some(params))));
+    return Ok((
+        s,
+        OPNode::new(op, Some(args), Some(ParameterStorage::Parsed(params))),
+    ));
 }
 
 fn parse_identity(s: &str) -> IResult<&str, OPNode> {

--- a/src/parser/parse_target.rs
+++ b/src/parser/parse_target.rs
@@ -1,4 +1,4 @@
-use crate::paramdict::*;
+use crate::parser::ParsedParameterVector;
 use crate::util::base::*;
 
 //Sized
@@ -30,28 +30,28 @@ pub trait ParseTarget {
     fn active_transform_end_time(&mut self);
     fn active_transform_start_time(&mut self);
     fn transform_times(&mut self, start: Float, end: Float);
-    fn pixel_filter(&mut self, name: &str, params: &ParameterDictionary);
-    fn film(&mut self, name: &str, params: &ParameterDictionary);
-    fn sampler(&mut self, name: &str, params: &ParameterDictionary);
-    fn accelerator(&mut self, name: &str, params: &ParameterDictionary);
-    fn integrator(&mut self, name: &str, params: &ParameterDictionary);
-    fn camera(&mut self, name: &str, params: &ParameterDictionary);
-    fn make_named_medium(&mut self, name: &str, params: &ParameterDictionary);
+    fn pixel_filter(&mut self, name: &str, params: ParsedParameterVector);
+    fn film(&mut self, name: &str, params: ParsedParameterVector);
+    fn sampler(&mut self, name: &str, params: ParsedParameterVector);
+    fn accelerator(&mut self, name: &str, params: ParsedParameterVector);
+    fn integrator(&mut self, name: &str, params: ParsedParameterVector);
+    fn camera(&mut self, name: &str, params: ParsedParameterVector);
+    fn make_named_medium(&mut self, name: &str, params: ParsedParameterVector);
     fn medium_interface(&mut self, inside_name: &str, outside_name: &str);
 
     fn world_begin(&mut self);
-    fn attribute(&mut self, target: &str, params: &ParameterDictionary);
+    fn attribute(&mut self, target: &str, params: ParsedParameterVector);
     fn attribute_begin(&mut self);
     fn attribute_end(&mut self);
     fn transform_begin(&mut self);
     fn transform_end(&mut self);
-    fn texture(&mut self, name: &str, _type: &str, tex_name: &str, params: &ParameterDictionary);
-    fn material(&mut self, name: &str, params: &ParameterDictionary);
-    fn make_named_material(&mut self, name: &str, params: &ParameterDictionary);
+    fn texture(&mut self, name: &str, _type: &str, tex_name: &str, params: ParsedParameterVector);
+    fn material(&mut self, name: &str, params: ParsedParameterVector);
+    fn make_named_material(&mut self, name: &str, params: ParsedParameterVector);
     fn named_material(&mut self, name: &str);
-    fn light_source(&mut self, name: &str, params: &ParameterDictionary);
-    fn area_light_source(&mut self, name: &str, params: &ParameterDictionary);
-    fn shape(&mut self, name: &str, params: &ParameterDictionary);
+    fn light_source(&mut self, name: &str, params: ParsedParameterVector);
+    fn area_light_source(&mut self, name: &str, params: ParsedParameterVector);
+    fn shape(&mut self, name: &str, params: ParsedParameterVector);
     fn reverse_orientation(&mut self);
     fn object_begin(&mut self, name: &str);
     fn object_end(&mut self);
@@ -64,7 +64,7 @@ pub trait ParseTarget {
     //----------------------------------------
     fn work_dir_begin(&mut self, _path: &str) {}
     fn work_dir_end(&mut self) {}
-    fn include(&mut self, _filename: &str, _params: &ParameterDictionary) {}
-    fn import(&mut self, filename: &str, params: &ParameterDictionary);
+    fn include(&mut self, _filename: &str, _params: ParsedParameterVector) {}
+    fn import(&mut self, filename: &str, params: ParsedParameterVector);
     //----------------------------------------
 }

--- a/src/parser/parsed_parameter.rs
+++ b/src/parser/parsed_parameter.rs
@@ -1,0 +1,248 @@
+//! Owned, parser-side parameter values.
+//!
+//! This is the Rust counterpart of pbrt-v4's `ParsedParameter`.  It keeps
+//! lexical type information separate from the renderer-facing
+//! `ParameterDictionary` and lets a parse target take ownership of the
+//! values without first collecting borrowed strings.
+
+use crate::util::base::Float;
+use crate::util::spectrum::{Spectrum, SpectrumType};
+use std::collections::HashSet;
+
+#[derive(Debug, PartialEq)]
+pub enum ParsedParameterValues {
+    Bools(Vec<bool>),
+    Ints(Vec<i32>),
+    Floats(Vec<Float>),
+    /// Values already stored in `ParameterDictionary`'s point storage.
+    ///
+    /// This is used only by the legacy dictionary-to-parser adapter. Parser
+    /// input uses `Floats` and lets the dictionary classify the declaration.
+    StoredPoints(Vec<Float>),
+    Strings(Vec<String>),
+    SpectrumTokens(Vec<ParsedSpectrumToken>),
+    Spectrums(Vec<Spectrum>),
+    SampledSpectrums(Vec<crate::paramdict::SampledSpectrumParam>),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ParsedSpectrumToken {
+    Float { value: Float, raw: String },
+    String(String),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ParsedParameter {
+    pub parameter_type: String,
+    pub name: String,
+    pub values: ParsedParameterValues,
+}
+
+pub type ParsedParameterVector = Vec<ParsedParameter>;
+
+/// Converts a legacy dictionary into the parser-owned representation.
+///
+/// The streaming parser does not use this adapter. It exists for targets such
+/// as ToPly that still need to modify dictionary-shaped parameters.
+pub fn parsed_parameters_from_dictionary(
+    dictionary: &crate::paramdict::ParameterDictionary,
+) -> ParsedParameterVector {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for key in dictionary.get_keys() {
+        if !seen.insert(key.clone()) {
+            continue;
+        }
+        let mut parts = key.split_ascii_whitespace();
+        let first = parts.next().unwrap_or_default();
+        let rest = parts.collect::<Vec<_>>().join(" ");
+        let (parameter_type, name) = if rest.is_empty() {
+            (String::new(), first.to_string())
+        } else {
+            (first.to_string(), rest)
+        };
+        let storage_type = if parameter_type.is_empty() {
+            if dictionary.get_strings_ref(&name).is_some() {
+                "string"
+            } else if dictionary.get_bools_ref(&name).is_some() {
+                "bool"
+            } else if dictionary.get_ints_ref(&name).is_some() {
+                "integer"
+            } else {
+                match dictionary.get_key_type(&name).as_str() {
+                    "point" | "point2" | "point3" | "point4" | "vector" | "vector2" | "vector3"
+                    | "vector4" | "normal" | "color" | "rgb" | "xyz" => "point",
+                    _ => "float",
+                }
+            }
+        } else {
+            parameter_type.as_str()
+        };
+        let values = match storage_type {
+            "bool" => ParsedParameterValues::Bools(dictionary.get_bools(&name)),
+            "integer" => ParsedParameterValues::Ints(dictionary.get_ints(&name)),
+            "string" | "texture" => ParsedParameterValues::Strings(dictionary.get_strings(&name)),
+            "spectrum" => {
+                if dictionary.get_strings_ref(&name).is_some() {
+                    ParsedParameterValues::Strings(dictionary.get_strings(&name))
+                } else if dictionary.get_spectrums_ref(&name).is_some() {
+                    ParsedParameterValues::Spectrums(dictionary.get_spectrums(&name))
+                } else if dictionary.get_sampled_spectra_ref(&name).is_some() {
+                    ParsedParameterValues::SampledSpectrums(dictionary.get_sampled_spectra(&name))
+                } else {
+                    ParsedParameterValues::Floats(dictionary.get_floats(&name))
+                }
+            }
+            "point" | "point2" | "point3" | "point4" | "vector" | "vector2" | "vector3"
+            | "vector4" | "normal" | "color" | "rgb" | "xyz" => {
+                ParsedParameterValues::StoredPoints(dictionary.get_points(&name))
+            }
+            _ => ParsedParameterValues::Floats(dictionary.get_floats(&name)),
+        };
+        result.push(ParsedParameter {
+            parameter_type,
+            name,
+            values,
+        });
+    }
+    result
+}
+
+impl ParsedParameterValues {
+    pub fn new_for_type(parameter_type: &str) -> Self {
+        match parameter_type {
+            "string" | "texture" => Self::Strings(Vec::new()),
+            "spectrum" => Self::SpectrumTokens(Vec::new()),
+            "bool" => Self::Bools(Vec::new()),
+            "integer" => Self::Ints(Vec::new()),
+            _ => Self::Floats(Vec::new()),
+        }
+    }
+
+    pub fn push_literal(&mut self, literal: &str) -> Result<(), ()> {
+        match self {
+            Self::Bools(values) => values.push(
+                literal
+                    .parse::<bool>()
+                    .or_else(|_| match literal.to_ascii_lowercase().as_str() {
+                        "true" => Ok(true),
+                        "false" => Ok(false),
+                        _ => Err(()),
+                    })
+                    .map_err(|_| ())?,
+            ),
+            Self::Ints(values) => values.push(literal.parse::<i32>().map_err(|_| ())?),
+            Self::Floats(values) => values.push(literal.parse::<Float>().map_err(|_| ())?),
+            Self::StoredPoints(_) => return Err(()),
+            Self::Strings(values) => values.push(literal.to_string()),
+            Self::SpectrumTokens(values) => {
+                if let Ok(value) = literal.parse::<Float>() {
+                    values.push(ParsedSpectrumToken::Float {
+                        value,
+                        raw: literal.to_string(),
+                    });
+                } else {
+                    values.push(ParsedSpectrumToken::String(literal.to_string()));
+                }
+            }
+            Self::Spectrums(_) | Self::SampledSpectrums(_) => return Err(()),
+        }
+        Ok(())
+    }
+}
+
+pub fn into_parameter_dictionary(
+    parameters: ParsedParameterVector,
+) -> crate::paramdict::ParameterDictionary {
+    let mut dictionary = crate::paramdict::ParameterDictionary::new();
+    for parameter in parameters {
+        let parameter_type = parameter.parameter_type;
+        let name = parameter.name;
+        match parameter.values {
+            ParsedParameterValues::Bools(values) => {
+                dictionary.add_owned_bools_typed(&parameter_type, &name, values)
+            }
+            ParsedParameterValues::Ints(values) => {
+                dictionary.add_owned_ints_typed(&parameter_type, &name, values)
+            }
+            ParsedParameterValues::Floats(values) => {
+                dictionary.add_owned_floats_typed(&parameter_type, &name, values)
+            }
+            ParsedParameterValues::StoredPoints(values) => {
+                dictionary.add_owned_points_typed(&parameter_type, &name, values)
+            }
+            ParsedParameterValues::Strings(values) => {
+                dictionary.add_owned_strings_typed(&parameter_type, &name, values)
+            }
+            ParsedParameterValues::SpectrumTokens(tokens) => {
+                let numeric = tokens
+                    .iter()
+                    .map(|token| match token {
+                        ParsedSpectrumToken::Float { value, .. } => Ok(*value),
+                        ParsedSpectrumToken::String(_) => Err(()),
+                    })
+                    .collect::<Result<Vec<_>, _>>();
+                match numeric {
+                    Ok(values) => {
+                        if values.len() == 1 {
+                            dictionary.add_owned_spectrums_typed(
+                                &parameter_type,
+                                &name,
+                                vec![Spectrum::from(values[0])],
+                            );
+                        } else if values.len() == 3 {
+                            dictionary.add_owned_spectrums_typed(
+                                &parameter_type,
+                                &name,
+                                vec![Spectrum::from_rgb(&values, SpectrumType::Albedo)],
+                            );
+                        } else if values.len() >= 2 && values.len() % 2 == 0 {
+                            let (lambda, sampled): (Vec<_>, Vec<_>) = values
+                                .chunks_exact(2)
+                                .map(|pair| (pair[0], pair[1]))
+                                .unzip();
+                            let spectrum = Spectrum::from_sampled(&lambda, &sampled);
+                            dictionary.add_owned_sampled_spectra_typed(
+                                &parameter_type,
+                                &name,
+                                vec![crate::paramdict::SampledSpectrumParam {
+                                    lambda,
+                                    values: sampled,
+                                }],
+                            );
+                            dictionary.add_owned_spectrums_typed(
+                                &parameter_type,
+                                &name,
+                                vec![spectrum],
+                            );
+                        } else {
+                            dictionary.add_owned_strings_typed(
+                                &parameter_type,
+                                &name,
+                                values.into_iter().map(|value| value.to_string()).collect(),
+                            );
+                        }
+                    }
+                    Err(()) => dictionary.add_owned_strings_typed(
+                        &parameter_type,
+                        &name,
+                        tokens
+                            .into_iter()
+                            .map(|token| match token {
+                                ParsedSpectrumToken::Float { raw, .. } => raw,
+                                ParsedSpectrumToken::String(value) => value,
+                            })
+                            .collect(),
+                    ),
+                }
+            }
+            ParsedParameterValues::Spectrums(values) => {
+                dictionary.add_owned_spectrums_typed(&parameter_type, &name, values)
+            }
+            ParsedParameterValues::SampledSpectrums(values) => {
+                dictionary.add_owned_sampled_spectra_typed(&parameter_type, &name, values)
+            }
+        }
+    }
+    dictionary
+}

--- a/src/parser/print_target.rs
+++ b/src/parser/print_target.rs
@@ -1,4 +1,6 @@
 use super::parse_target::*;
+use super::parsed_parameter::into_parameter_dictionary;
+use super::ParsedParameterVector;
 use crate::paramdict::*;
 use crate::util::base::*;
 
@@ -280,8 +282,8 @@ impl ParseTarget for PrintTarget {
         self.print(&format!("{}Option \"{name}\" {value}\n", self.get_indent()));
     }
 
-    fn attribute(&mut self, target: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn attribute(&mut self, target: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}Attribute \"{target}\"{s_params}\n",
             self.get_indent()
@@ -321,53 +323,53 @@ impl ParseTarget for PrintTarget {
         ));
     }
 
-    fn pixel_filter(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn pixel_filter(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}PixelFilter \"{name}\"{s_params}\n",
             self.get_indent()
         ));
     }
 
-    fn film(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn film(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!("{}Film \"{name}\"{s_params}\n", self.get_indent()));
     }
 
-    fn sampler(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn sampler(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}Sampler \"{name}\"{s_params}\n",
             self.get_indent()
         ));
     }
 
-    fn accelerator(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn accelerator(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}Accelerator \"{name}\"{s_params}\n",
             self.get_indent()
         ));
     }
 
-    fn integrator(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn integrator(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}Integrator \"{name}\"{s_params}\n",
             self.get_indent()
         ));
     }
 
-    fn camera(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn camera(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}Camera \"{name}\"{s_params}\n",
             self.get_indent()
         ));
     }
 
-    fn make_named_medium(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn make_named_medium(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}NamedMedium \"{name}\"{s_params}\n",
             self.get_indent()
@@ -406,24 +408,24 @@ impl ParseTarget for PrintTarget {
         self.print(&format!("{}TransformEnd\n", self.get_indent()));
     }
 
-    fn texture(&mut self, name: &str, t: &str, tex_name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn texture(&mut self, name: &str, t: &str, tex_name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}Texture \"{name}\" \"{t}\" \"{tex_name}\"{s_params}\n",
             self.get_indent()
         ));
     }
 
-    fn material(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn material(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}Material \"{name}\"{s_params}\n",
             self.get_indent()
         ));
     }
 
-    fn make_named_material(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn make_named_material(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}MakeNamedMaterial \"{name}\"{s_params}\n",
             self.get_indent()
@@ -434,24 +436,24 @@ impl ParseTarget for PrintTarget {
         self.print(&format!("{}NamedMaterial \"{name}\"\n", self.get_indent()));
     }
 
-    fn light_source(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn light_source(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}LightSource \"{name}\"{s_params}\n",
             self.get_indent()
         ));
     }
 
-    fn area_light_source(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn area_light_source(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}AreaLightSource \"{name}\"{s_params}\n",
             self.get_indent()
         ));
     }
 
-    fn shape(&mut self, name: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn shape(&mut self, name: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}Shape \"{name}\"{s_params}\n",
             self.get_indent()
@@ -492,16 +494,16 @@ impl ParseTarget for PrintTarget {
         //Do not anything!
     }
 
-    fn include(&mut self, filename: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn include(&mut self, filename: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}Include \"{filename}\"{s_params}\n",
             self.get_indent()
         ));
     }
 
-    fn import(&mut self, filename: &str, params: &ParameterDictionary) {
-        let s_params = self.with_params(params);
+    fn import(&mut self, filename: &str, params: ParsedParameterVector) {
+        let s_params = self.with_params(&into_parameter_dictionary(params));
         self.print(&format!(
             "{}Import \"{filename}\"{s_params}\n",
             self.get_indent()

--- a/src/parser/scene_builder/parse_target_impl.rs
+++ b/src/parser/scene_builder/parse_target_impl.rs
@@ -16,7 +16,8 @@ use super::state::{ApiState, PushKind};
 use super::{SceneBuilder, CURVES_SHAPE_NAME};
 use crate::options::PbrtOptions;
 use crate::paramdict::ParameterDictionary;
-use crate::parser::{parse_file, parse_target::ParseTarget};
+use crate::parser::parsed_parameter::into_parameter_dictionary;
+use crate::parser::{parse_file, parse_target::ParseTarget, ParsedParameterVector};
 use crate::util::base::Float;
 use crate::util::spectrum::rgb_to_spectrum::lookup_color_space_by_name;
 use crate::util::transform::transform_set::{
@@ -121,10 +122,10 @@ impl SceneBuilder {
     /// dictionary inherits `graphicsState.colorSpace`.
     fn params_with_attributes(
         &self,
-        params: &ParameterDictionary,
+        params: ParameterDictionary,
         attrs: &ParameterDictionary,
     ) -> ParameterDictionary {
-        let mut p = params.clone();
+        let mut p = params;
         p.merge_missing(attrs);
         if !p.has_parameter("displacement") {
             p.rename_parameter("bumpmap", "displacement");
@@ -268,40 +269,40 @@ impl ParseTarget for SceneBuilder {
     }
 
     // ===== Options-block setters =============================================
-    fn pixel_filter(&mut self, name: &str, params: &ParameterDictionary) {
+    fn pixel_filter(&mut self, name: &str, params: ParsedParameterVector) {
         self.verify_options("PixelFilter");
         self.filter_name = name.to_string();
-        self.filter_params = params.clone();
+        self.filter_params = into_parameter_dictionary(params);
     }
 
-    fn film(&mut self, name: &str, params: &ParameterDictionary) {
+    fn film(&mut self, name: &str, params: ParsedParameterVector) {
         self.verify_options("Film");
         self.film_name = name.to_string();
-        self.film_params = params.clone();
+        self.film_params = into_parameter_dictionary(params);
     }
 
-    fn sampler(&mut self, name: &str, params: &ParameterDictionary) {
+    fn sampler(&mut self, name: &str, params: ParsedParameterVector) {
         self.verify_options("Sampler");
         self.sampler_name = name.to_string();
-        self.sampler_params = params.clone();
+        self.sampler_params = into_parameter_dictionary(params);
     }
 
-    fn accelerator(&mut self, name: &str, params: &ParameterDictionary) {
+    fn accelerator(&mut self, name: &str, params: ParsedParameterVector) {
         self.verify_options("Accelerator");
         self.accelerator_name = name.to_string();
-        self.accelerator_params = params.clone();
+        self.accelerator_params = into_parameter_dictionary(params);
     }
 
-    fn integrator(&mut self, name: &str, params: &ParameterDictionary) {
+    fn integrator(&mut self, name: &str, params: ParsedParameterVector) {
         self.verify_options("Integrator");
         self.integrator_name = name.to_string();
-        self.integrator_params = params.clone();
+        self.integrator_params = into_parameter_dictionary(params);
     }
 
-    fn camera(&mut self, name: &str, params: &ParameterDictionary) {
+    fn camera(&mut self, name: &str, params: ParsedParameterVector) {
         self.verify_options("Camera");
         self.camera_name = name.to_string();
-        self.camera_params = params.clone();
+        self.camera_params = into_parameter_dictionary(params);
         // pbrt's `LookAt` accumulates `cameraFromWorld` into the CTM, so
         // the active transform at the `Camera` directive is actually the
         // world-to-camera direction; `realize_camera` inverts it before
@@ -316,7 +317,8 @@ impl ParseTarget for SceneBuilder {
             .insert(String::from("camera"), self.camera_to_world.inverse());
     }
 
-    fn make_named_medium(&mut self, name: &str, params: &ParameterDictionary) {
+    fn make_named_medium(&mut self, name: &str, params: ParsedParameterVector) {
+        let params = into_parameter_dictionary(params);
         if self.media.contains_key(name) {
             warn!("Named medium \"{}\" redefined.", name);
         }
@@ -350,7 +352,8 @@ impl ParseTarget for SceneBuilder {
             .insert(String::from("world"), *self.top_transform());
     }
 
-    fn attribute(&mut self, target: &str, params: &ParameterDictionary) {
+    fn attribute(&mut self, target: &str, params: ParsedParameterVector) {
+        let params = into_parameter_dictionary(params);
         self.verify_world("Attribute");
         let gs = self.top_graphics_state_mut();
         let dict = match target {
@@ -421,8 +424,9 @@ impl ParseTarget for SceneBuilder {
         name: &str,
         type_name: &str,
         tex_name: &str,
-        params: &ParameterDictionary,
+        params: ParsedParameterVector,
     ) {
+        let params = into_parameter_dictionary(params);
         self.verify_world("Texture");
         let params =
             self.params_with_attributes(params, &self.top_graphics_state().texture_attributes);
@@ -456,7 +460,8 @@ impl ParseTarget for SceneBuilder {
         }
     }
 
-    fn material(&mut self, name: &str, params: &ParameterDictionary) {
+    fn material(&mut self, name: &str, params: ParsedParameterVector) {
+        let params = into_parameter_dictionary(params);
         self.verify_world("Material");
         if name.is_empty() || name == "interface" {
             // No surface material (used for volume boundaries).
@@ -478,7 +483,8 @@ impl ParseTarget for SceneBuilder {
         }
     }
 
-    fn make_named_material(&mut self, name: &str, params: &ParameterDictionary) {
+    fn make_named_material(&mut self, name: &str, params: ParsedParameterVector) {
+        let params = into_parameter_dictionary(params);
         let type_name = params.get_one_string("type", "");
         if type_name.is_empty() {
             error!("No parameter string \"type\" found in MakeNamedMaterial");
@@ -504,7 +510,8 @@ impl ParseTarget for SceneBuilder {
         gs.current_material_is_default = false;
     }
 
-    fn light_source(&mut self, name: &str, params: &ParameterDictionary) {
+    fn light_source(&mut self, name: &str, params: ParsedParameterVector) {
+        let params = into_parameter_dictionary(params);
         self.verify_world("LightSource");
         let render_from_object = self.render_from_object();
         let gs = self.top_graphics_state();
@@ -524,7 +531,8 @@ impl ParseTarget for SceneBuilder {
         });
     }
 
-    fn area_light_source(&mut self, name: &str, params: &ParameterDictionary) {
+    fn area_light_source(&mut self, name: &str, params: ParsedParameterVector) {
+        let params = into_parameter_dictionary(params);
         self.verify_world("AreaLightSource");
         // Bound to the next Shape; the actual entity push happens in
         // `shape()`.
@@ -535,7 +543,8 @@ impl ParseTarget for SceneBuilder {
         gs.area_light_params = params;
     }
 
-    fn shape(&mut self, name: &str, params: &ParameterDictionary) {
+    fn shape(&mut self, name: &str, params: ParsedParameterVector) {
+        let params = into_parameter_dictionary(params);
         self.verify_world("Shape");
 
         let render_from_object = self.render_from_object();
@@ -713,7 +722,7 @@ impl ParseTarget for SceneBuilder {
         self.work_dirs.pop();
     }
 
-    fn import(&mut self, filename: &str, _params: &ParameterDictionary) {
+    fn import(&mut self, filename: &str, _params: ParsedParameterVector) {
         let path = Path::new(filename);
         let resolved = if path.is_absolute() {
             path.to_path_buf()

--- a/src/parser/session.rs
+++ b/src/parser/session.rs
@@ -104,14 +104,15 @@ impl<'a> ParserSession<'a> {
                 continue;
             }
 
-            if let Err(error) = evaluate_opnodes(std::slice::from_ref(&operation), self.context) {
+            let operation_name = operation.name.clone();
+            if let Err(error) = evaluate_opnodes(vec![operation], self.context) {
                 let Some(frame) = self.frames.last() else {
                     return Err(Self::stack_empty_error());
                 };
                 return Err(parser_error_at(
                     &frame.source,
                     operation_offset,
-                    &operation.name,
+                    &operation_name,
                     &error.to_string(),
                 )
                 .with_file(&frame.path));

--- a/src/parser/to_ply_target.rs
+++ b/src/parser/to_ply_target.rs
@@ -1,4 +1,6 @@
 use super::parse_target::*;
+use super::parsed_parameter::{into_parameter_dictionary, parsed_parameters_from_dictionary};
+use super::{ParsedParameterValues, ParsedParameterVector};
 use crate::paramdict::*;
 use crate::util::base::*;
 use crate::util::error::*;
@@ -318,7 +320,7 @@ impl ParseTarget for ToPlyTarget {
         self.context.borrow_mut().option(name, value);
     }
 
-    fn attribute(&mut self, target: &str, params: &ParameterDictionary) {
+    fn attribute(&mut self, target: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().attribute(target, params);
     }
 
@@ -346,30 +348,30 @@ impl ParseTarget for ToPlyTarget {
         self.context.borrow_mut().transform_times(start, end);
     }
 
-    fn pixel_filter(&mut self, name: &str, params: &ParameterDictionary) {
+    fn pixel_filter(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().pixel_filter(name, params);
     }
 
-    fn film(&mut self, name: &str, params: &ParameterDictionary) {
+    fn film(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().film(name, params);
     }
 
-    fn sampler(&mut self, name: &str, params: &ParameterDictionary) {
+    fn sampler(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().sampler(name, params);
     }
 
-    fn accelerator(&mut self, name: &str, params: &ParameterDictionary) {
+    fn accelerator(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().accelerator(name, params);
     }
 
-    fn integrator(&mut self, name: &str, params: &ParameterDictionary) {
+    fn integrator(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().integrator(name, params);
     }
-    fn camera(&mut self, name: &str, params: &ParameterDictionary) {
+    fn camera(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().camera(name, params);
     }
 
-    fn make_named_medium(&mut self, name: &str, params: &ParameterDictionary) {
+    fn make_named_medium(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().make_named_medium(name, params);
     }
 
@@ -399,15 +401,15 @@ impl ParseTarget for ToPlyTarget {
         self.context.borrow_mut().transform_end();
     }
 
-    fn texture(&mut self, name: &str, t: &str, tex_name: &str, params: &ParameterDictionary) {
+    fn texture(&mut self, name: &str, t: &str, tex_name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().texture(name, t, tex_name, params);
     }
 
-    fn material(&mut self, name: &str, params: &ParameterDictionary) {
+    fn material(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().material(name, params);
     }
 
-    fn make_named_material(&mut self, name: &str, params: &ParameterDictionary) {
+    fn make_named_material(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().make_named_material(name, params);
     }
 
@@ -415,61 +417,67 @@ impl ParseTarget for ToPlyTarget {
         self.context.borrow_mut().named_material(name);
     }
 
-    fn light_source(&mut self, name: &str, params: &ParameterDictionary) {
+    fn light_source(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().light_source(name, params);
     }
 
-    fn area_light_source(&mut self, name: &str, params: &ParameterDictionary) {
+    fn area_light_source(&mut self, name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().area_light_source(name, params);
     }
 
-    fn shape(&mut self, name: &str, params: &ParameterDictionary) {
-        if name == "trianglemesh" {
-            if let Some(vi) = params.get_ints_ref("indices") {
-                if vi.len() < 500 {
-                    self.context.borrow_mut().shape(name, params);
-                    return;
-                }
-            }
-            if let Some(mesh) = convert_to_mesh(params) {
-                let dir = Path::new(&self.dir);
-                let dir = dir.join("geometry");
-                if let Err(e) = std::fs::create_dir_all(&dir) {
-                    error!("Error: {}", e);
-                    return;
-                }
-                let filename = self.get_ply_filename();
-                let filepath = dir.join(&filename);
-                {
-                    // Check if the mesh has tangent vectors
-                    if let Some(_) = params.get_points_ref("S") {
-                        warn!(
-                            "{}: PLY mesh will be missing tangent vectors \"S\".",
-                            filename
-                        );
-                    }
-                }
-                match write_mesh_to_ply(&mesh, &filepath) {
-                    Ok(_) => {
-                        let mut params = create_plymesh_params(params);
-                        let filepath = filepath
-                            .file_name()
-                            .map(|name| name.to_string_lossy().into_owned())
-                            .unwrap_or_else(|| "mesh.ply".to_string());
-                        let filepath = Path::new("geometry").join(filepath);
-                        let filepath = filepath.to_string_lossy().into_owned();
-                        params.add_string("string filename", &filepath);
-                        self.context.borrow_mut().shape("plymesh", &params);
-                    }
-                    Err(e) => {
-                        error!("Error: {}", e);
-                    }
-                }
-            }
-            self.count += 1;
-        } else {
+    fn shape(&mut self, name: &str, params: ParsedParameterVector) {
+        if name != "trianglemesh" {
             self.context.borrow_mut().shape(name, params);
+            return;
         }
+
+        let has_small_index_buffer = params.iter().any(|parameter| {
+            parameter.name == "indices"
+                && matches!(&parameter.values, ParsedParameterValues::Ints(values) if values.len() < 500)
+        });
+        if has_small_index_buffer {
+            self.context.borrow_mut().shape(name, params);
+            return;
+        }
+
+        let params = into_parameter_dictionary(params);
+        if let Some(mesh) = convert_to_mesh(&params) {
+            let dir = Path::new(&self.dir).join("geometry");
+            if let Err(e) = std::fs::create_dir_all(&dir) {
+                error!("Error: {}", e);
+                return;
+            }
+            let filename = self.get_ply_filename();
+            let filepath = dir.join(&filename);
+            {
+                // Check if the mesh has tangent vectors
+                if params.get_points_ref("S").is_some() {
+                    warn!(
+                        "{}: PLY mesh will be missing tangent vectors \"S\".",
+                        filename
+                    );
+                }
+            }
+            match write_mesh_to_ply(&mesh, &filepath) {
+                Ok(_) => {
+                    let mut params = create_plymesh_params(&params);
+                    let filepath = filepath
+                        .file_name()
+                        .map(|name| name.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| "mesh.ply".to_string());
+                    let filepath = Path::new("geometry").join(filepath);
+                    let filepath = filepath.to_string_lossy().into_owned();
+                    params.add_string("string filename", &filepath);
+                    self.context
+                        .borrow_mut()
+                        .shape("plymesh", parsed_parameters_from_dictionary(&params));
+                }
+                Err(e) => {
+                    error!("Error: {}", e);
+                }
+            }
+        }
+        self.count += 1;
     }
 
     fn reverse_orientation(&mut self) {
@@ -507,11 +515,11 @@ impl ParseTarget for ToPlyTarget {
         self.context.borrow_mut().work_dir_end();
     }
 
-    fn include(&mut self, file_name: &str, params: &ParameterDictionary) {
+    fn include(&mut self, file_name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().include(file_name, params);
     }
 
-    fn import(&mut self, file_name: &str, params: &ParameterDictionary) {
+    fn import(&mut self, file_name: &str, params: ParsedParameterVector) {
         self.context.borrow_mut().import(file_name, params);
     }
 }

--- a/src/parser/upgrade.rs
+++ b/src/parser/upgrade.rs
@@ -285,7 +285,11 @@ fn upgrade_directive(op: &mut OPNode) -> Result<(), PbrtError> {
         return Ok(());
     };
     let mut name = args.get_one_string("arg1", "");
-    let Some(params) = op.params.as_mut() else {
+    let Some(params) = op
+        .params
+        .as_mut()
+        .and_then(crate::parser::ParameterStorage::as_dictionary_mut)
+    else {
         return Ok(());
     };
     match op.name.as_str() {
@@ -467,8 +471,17 @@ pub fn upgrade_opnodes(ops: &mut [OPNode]) -> Result<(), PbrtError> {
     let mut texture_rename_count = 0usize;
     let mut object_rename_count = 0usize;
     for op in ops {
+        if let Some(params) = op.params.take() {
+            op.params = Some(crate::parser::ParameterStorage::Dictionary(
+                params.into_dictionary(),
+            ));
+        }
         for (before, after) in &texture_names {
-            if let Some(params) = op.params.as_mut() {
+            if let Some(params) = op
+                .params
+                .as_mut()
+                .and_then(crate::parser::ParameterStorage::as_dictionary_mut)
+            {
                 params.rename_texture_references(before, after);
             }
         }
@@ -487,7 +500,11 @@ pub fn upgrade_opnodes(ops: &mut [OPNode]) -> Result<(), PbrtError> {
                         op.name
                     )));
                 }
-                if let Some(params) = op.params.as_mut() {
+                if let Some(params) = op
+                    .params
+                    .as_mut()
+                    .and_then(crate::parser::ParameterStorage::as_dictionary_mut)
+                {
                     upgrade_material(&mut name, params)?;
                 }
                 args.replace_one_string("arg1", &name);
@@ -502,7 +519,11 @@ pub fn upgrade_opnodes(ops: &mut [OPNode]) -> Result<(), PbrtError> {
                             texture_rename_count += 1;
                             texture_names.insert(original.clone(), renamed.clone());
                             args.replace_one_string("arg1", &renamed);
-                            if let Some(params) = op.params.as_mut() {
+                            if let Some(params) = op
+                                .params
+                                .as_mut()
+                                .and_then(crate::parser::ParameterStorage::as_dictionary_mut)
+                            {
                                 params.rename_texture_references(&original, &previous);
                             }
                         } else {

--- a/tests/parser_comments.rs
+++ b/tests/parser_comments.rs
@@ -1,5 +1,6 @@
 use pbrt_r4::paramdict::ParameterDictionary;
 use pbrt_r4::parser::common::parse_params;
+use pbrt_r4::parser::parsed_parameter::into_parameter_dictionary;
 use pbrt_r4::parser::{parse_string, parse_string_upgraded, DebugTarget, SceneBuilder};
 
 fn debug_operations(target: &DebugTarget) -> Vec<(String, Vec<String>)> {
@@ -70,16 +71,16 @@ fn streaming_and_ast_paths_keep_large_shape_counts() {
 
 #[test]
 fn parse_params_accepts_comments_inside_arrays() {
-    let (_, params): (&str, ParameterDictionary) =
-        parse_params("\"float values\" [1 # between values\n 2 3]").unwrap();
+    let (_, params) = parse_params("\"float values\" [1 # between values\n 2 3]").unwrap();
+    let params: ParameterDictionary = into_parameter_dictionary(params);
 
     assert_eq!(params.get_floats("values"), vec![1.0, 2.0, 3.0]);
 }
 
 #[test]
 fn parse_params_accepts_comments_between_name_and_value() {
-    let (_, params): (&str, ParameterDictionary) =
-        parse_params("\"float value\" # before the value\n [1]").unwrap();
+    let (_, params) = parse_params("\"float value\" # before the value\n [1]").unwrap();
+    let params: ParameterDictionary = into_parameter_dictionary(params);
 
     assert_eq!(params.get_floats("value"), vec![1.0]);
 }
@@ -96,8 +97,8 @@ fn parse_string_accepts_comment_only_lines() {
 
 #[test]
 fn hash_inside_string_is_not_a_comment() {
-    let (_, params): (&str, ParameterDictionary) =
-        parse_params("\"string label\" [\"# not a comment\"]").unwrap();
+    let (_, params) = parse_params("\"string label\" [\"# not a comment\"]").unwrap();
+    let params: ParameterDictionary = into_parameter_dictionary(params);
 
     assert_eq!(params.get_strings("label"), vec!["# not a comment"]);
 }

--- a/tests/parser_common.rs
+++ b/tests/parser_common.rs
@@ -1,11 +1,12 @@
 use pbrt_r4::paramdict::ParameterDictionary;
 use pbrt_r4::parser::common::parse_params;
+use pbrt_r4::parser::parsed_parameter::into_parameter_dictionary;
 use pbrt_r4::util::spectrum::Spectrum;
 
 #[test]
 fn parse_numeric_spectrum_pairs() {
-    let (_, params): (&str, ParameterDictionary) =
-        parse_params("\"spectrum sigma_s\" [200 10 900 10]").unwrap();
+    let (_, params) = parse_params("\"spectrum sigma_s\" [200 10 900 10]").unwrap();
+    let params: ParameterDictionary = into_parameter_dictionary(params);
     let sp = params.get_one_spectrum("sigma_s", &Spectrum::zero());
     assert_eq!(sp, Spectrum::from_sampled(&[200.0, 900.0], &[10.0, 10.0]));
     let sampled = params.get_sampled_spectra_ref("sigma_s").unwrap();
@@ -16,6 +17,7 @@ fn parse_numeric_spectrum_pairs() {
 #[test]
 fn parse_string_spectrum_remains_string() {
     let (_, params) = parse_params("\"spectrum eta\" \"metal-Cu-eta\"").unwrap();
+    let params = into_parameter_dictionary(params);
     assert_eq!(params.get_strings("eta"), vec!["metal-Cu-eta"]);
 }
 

--- a/tests/parser_parsed_parameter.rs
+++ b/tests/parser_parsed_parameter.rs
@@ -1,0 +1,129 @@
+use pbrt_r4::parser::common::parse_params;
+use pbrt_r4::parser::parsed_parameter::{
+    into_parameter_dictionary, parsed_parameters_from_dictionary, ParsedParameterValues,
+    ParsedSpectrumToken,
+};
+use pbrt_r4::parser::{parse_string, DebugTarget, ToPlyTarget};
+use std::cell::RefCell;
+use std::sync::Arc;
+
+#[test]
+fn parse_params_keeps_owned_typed_values() {
+    let (_, parameters) = parse_params(
+        "\"bool enabled\" true \"integer count\" [1 2] \"float scale\" 0.5 \"string label\" \"hair\"",
+    )
+    .expect("parameters should parse");
+
+    assert!(matches!(
+        &parameters[0].values,
+        ParsedParameterValues::Bools(values) if values == &[true]
+    ));
+    assert!(matches!(
+        &parameters[1].values,
+        ParsedParameterValues::Ints(values) if values == &[1, 2]
+    ));
+    assert!(matches!(
+        &parameters[2].values,
+        ParsedParameterValues::Floats(values) if values == &[0.5]
+    ));
+    assert!(matches!(
+        &parameters[3].values,
+        ParsedParameterValues::Strings(values) if values == &["hair"]
+    ));
+}
+
+#[test]
+fn spectrum_tokens_preserve_numeric_and_named_paths() {
+    let (_, numeric) = parse_params("\"spectrum sigma\" [200 10 900 20]").unwrap();
+    assert!(matches!(
+        &numeric[0].values,
+            ParsedParameterValues::SpectrumTokens(values)
+            if values == &[
+                ParsedSpectrumToken::Float { value: 200.0, raw: "200".to_string() },
+                ParsedSpectrumToken::Float { value: 10.0, raw: "10".to_string() },
+                ParsedSpectrumToken::Float { value: 900.0, raw: "900".to_string() },
+                ParsedSpectrumToken::Float { value: 20.0, raw: "20".to_string() },
+            ]
+    ));
+
+    let (_, named) = parse_params("\"spectrum eta\" \"metal-Cu-eta\"").unwrap();
+    assert!(matches!(
+        &named[0].values,
+        ParsedParameterValues::SpectrumTokens(values)
+            if values == &[ParsedSpectrumToken::String("metal-Cu-eta".to_string())]
+    ));
+}
+
+#[test]
+fn mixed_spectrum_tokens_preserve_numeric_lexemes() {
+    let (_, parameters) = parse_params("\"spectrum values\" [1e2 \"named\"]").unwrap();
+    let dictionary = into_parameter_dictionary(parameters);
+
+    assert_eq!(dictionary.get_strings("values"), vec!["1e2", "named"]);
+}
+
+#[test]
+fn parsed_parameters_convert_to_the_existing_dictionary_storage() {
+    let (_, parameters) = parse_params("\"rgb reflectance\" [0.2 0.3 0.4]").unwrap();
+    let dictionary = into_parameter_dictionary(parameters);
+
+    assert_eq!(dictionary.get_points("reflectance"), vec![0.2, 0.3, 0.4]);
+}
+
+#[test]
+fn dictionary_round_trip_preserves_xyz_storage() {
+    let (_, parameters) = parse_params("\"xyz value\" [0.1 0.2 0.3]").unwrap();
+    let dictionary = into_parameter_dictionary(parameters);
+    let round_trip = into_parameter_dictionary(parsed_parameters_from_dictionary(&dictionary));
+
+    assert_eq!(
+        round_trip.get_points("value"),
+        dictionary.get_points("value")
+    );
+}
+
+#[test]
+fn dictionary_round_trip_preserves_untyped_well_known_points() {
+    let (_, parameters) = parse_params("\"P\" [1 2 3]").unwrap();
+    let dictionary = into_parameter_dictionary(parameters);
+    let round_trip = into_parameter_dictionary(parsed_parameters_from_dictionary(&dictionary));
+
+    assert_eq!(round_trip.get_points("P"), dictionary.get_points("P"));
+}
+
+#[test]
+fn dictionary_adapter_preserves_empty_typed_storage() {
+    let mut dictionary = pbrt_r4::paramdict::ParameterDictionary::new();
+    dictionary.add_owned_strings("string empty", Vec::new());
+
+    let parameters = parsed_parameters_from_dictionary(&dictionary);
+
+    assert!(matches!(
+        &parameters[0].values,
+        ParsedParameterValues::Strings(values) if values.is_empty()
+    ));
+}
+
+#[test]
+fn to_ply_forwards_small_triangle_parameters() {
+    let directory = tempfile::tempdir().unwrap();
+    let inner = Arc::new(RefCell::new(DebugTarget::new()));
+    let mut target = ToPlyTarget::new(directory.path().to_str().unwrap(), inner.clone());
+    parse_string(
+        "Shape \"trianglemesh\" \"integer indices\" [0 1 2] \"point3 P\" [0 0 0 1 0 0 0 1 0]",
+        &mut target,
+    )
+    .unwrap();
+
+    assert!(inner
+        .borrow()
+        .operations
+        .borrow()
+        .iter()
+        .any(|operation| operation.name == "Shape"));
+}
+
+#[test]
+fn invalid_typed_values_are_rejected_without_partial_parameters() {
+    assert!(parse_params("\"integer count\" [1 nope]").is_err());
+}


### PR DESCRIPTION
## Summary
- Introduce an owned `ParsedParameter` intermediate representation matching pbrt-v4 parser ownership.
- Parse typed values directly and move them into `ParameterDictionary` storage without the intermediate borrowed-string vector or typed-value clones.
- Transfer owned parameters through every `ParseTarget`; preserve inherited-attribute cloning only where required.
- Avoid the normal `ToPlyTarget` parameter round-trip and preserve dictionary adapter behavior for legacy upgrade paths.

## Validation
- `cargo fmt --all`
- `cargo test --test parser_parsed_parameter --test parser_common --test parser_comments --test parser_dispatch --test parser_include_sources --test parser_upgrade`
- `cargo test -q`
- `cargo build --release`
- Hair parser/scene measurements recorded in `docs/performance-survey.md` (r4/v4, parse and scene timings, RSS).

Stacked on the directive-dispatch PR.