### PR TITLE
feat(gpu): add validated triangle scene IR

### DIFF
--- a/src/gpu/compiler.rs
+++ b/src/gpu/compiler.rs
@@ -3,7 +3,7 @@
 use super::ir::{GpuSceneIr, GpuSceneView};
 use std::sync::Arc;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GpuCompiledScene {
     ir: Arc<GpuSceneIr>,
 }

--- a/src/gpu/ir.rs
+++ b/src/gpu/ir.rs
@@ -4,6 +4,53 @@
 //! raw pointers, shader bindings, or CPU trait objects. Geometry, materials,
 //! and textures will be added in later IR phases.
 
+pub type GpuFloat = f32;
+pub type GpuIndex = u32;
+
+macro_rules! typed_id {
+    ($name:ident) => {
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+        pub struct $name(pub GpuIndex);
+    };
+}
+
+typed_id!(TransformId);
+typed_id!(GeometryId);
+typed_id!(PrimitiveId);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GpuPoint2(pub [GpuFloat; 2]);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GpuPoint3(pub [GpuFloat; 3]);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GpuVector3(pub [GpuFloat; 3]);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GpuNormal3(pub [GpuFloat; 3]);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GpuMatrix4x4(pub [[GpuFloat; 4]; 4]);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GpuStaticTransform {
+    pub render_from_object: GpuMatrix4x4,
+    pub object_from_render: GpuMatrix4x4,
+    pub swaps_handedness: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GpuTransform {
+    Static(GpuStaticTransform),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GpuBounds3 {
+    pub min: GpuPoint3,
+    pub max: GpuPoint3,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GpuIrVersion {
     pub major: u16,
@@ -14,15 +61,15 @@ pub const CURRENT_IR_VERSION: GpuIrVersion = GpuIrVersion { major: 1, minor: 0 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GpuBounds2i {
-    pub min: [i32; 2],
-    pub max: [i32; 2],
+    pub min: [GpuIndex; 2],
+    pub max: [GpuIndex; 2],
 }
 
 impl GpuBounds2i {
     pub fn area(self) -> Option<u64> {
-        let width = i64::from(self.max[0]) - i64::from(self.min[0]);
-        let height = i64::from(self.max[1]) - i64::from(self.min[1]);
-        (width > 0 && height > 0).then(|| (width as u64) * (height as u64))
+        let width = u64::from(self.max[0]).checked_sub(u64::from(self.min[0]))?;
+        let height = u64::from(self.max[1]).checked_sub(u64::from(self.min[1]))?;
+        (width > 0 && height > 0).then(|| width.checked_mul(height))?
     }
 }
 
@@ -30,6 +77,27 @@ impl GpuBounds2i {
 pub struct GpuRenderConfig {
     pub pixel_bounds: GpuBounds2i,
     pub sample_count: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuTriangleMesh {
+    pub positions: Vec<GpuPoint3>,
+    pub indices: Vec<[GpuIndex; 3]>,
+    pub normals: Option<Vec<GpuNormal3>>,
+    pub tangents: Option<Vec<GpuVector3>>,
+    pub uvs: Option<Vec<GpuPoint2>>,
+    pub face_indices: Option<Vec<GpuIndex>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum GpuGeometry {
+    TriangleMesh(GpuTriangleMesh),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GpuPrimitive {
+    pub geometry: GeometryId,
+    pub transform: TransformId,
 }
 
 impl Default for GpuRenderConfig {
@@ -44,18 +112,21 @@ impl Default for GpuRenderConfig {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GpuSceneData {
+    pub transforms: Vec<GpuTransform>,
+    pub geometry: Vec<GpuGeometry>,
+    pub primitives: Vec<GpuPrimitive>,
     pub render: GpuRenderConfig,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GpuSceneDraft {
     pub version: GpuIrVersion,
     pub data: GpuSceneData,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GpuSceneIr {
     version: GpuIrVersion,
     data: GpuSceneData,
@@ -75,6 +146,28 @@ pub enum GpuIrValidationError {
     },
     InvalidPixelBounds,
     InvalidSampleCount,
+    EmptyTriangleMesh {
+        geometry: GeometryId,
+    },
+    TriangleIndexOutOfBounds {
+        geometry: GeometryId,
+        index: GpuIndex,
+    },
+    DegenerateTriangle {
+        geometry: GeometryId,
+        triangle: GpuIndex,
+    },
+    AttributeLengthMismatch {
+        geometry: GeometryId,
+    },
+    InvalidGeometryReference {
+        primitive: PrimitiveId,
+        geometry: GeometryId,
+    },
+    InvalidTransformReference {
+        primitive: PrimitiveId,
+        transform: TransformId,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -103,6 +196,37 @@ impl GpuSceneDraft {
         if self.data.render.sample_count == 0 {
             issues.push(GpuIrValidationError::InvalidSampleCount);
         }
+        for (geometry_index, geometry) in self.data.geometry.iter().enumerate() {
+            let geometry_id = GeometryId(geometry_index as GpuIndex);
+            match geometry {
+                GpuGeometry::TriangleMesh(mesh) => {
+                    validate_triangle_mesh(geometry_id, mesh, &mut issues)
+                }
+            }
+        }
+        for (primitive_index, primitive) in self.data.primitives.iter().enumerate() {
+            let primitive_id = PrimitiveId(primitive_index as GpuIndex);
+            if usize::try_from(primitive.geometry.0)
+                .ok()
+                .and_then(|index| self.data.geometry.get(index))
+                .is_none()
+            {
+                issues.push(GpuIrValidationError::InvalidGeometryReference {
+                    primitive: primitive_id,
+                    geometry: primitive.geometry,
+                });
+            }
+            if usize::try_from(primitive.transform.0)
+                .ok()
+                .and_then(|index| self.data.transforms.get(index))
+                .is_none()
+            {
+                issues.push(GpuIrValidationError::InvalidTransformReference {
+                    primitive: primitive_id,
+                    transform: primitive.transform,
+                });
+            }
+        }
         if issues.is_empty() {
             Ok(GpuSceneIr {
                 version: self.version,
@@ -113,6 +237,48 @@ impl GpuSceneDraft {
                 issues: issues.into_boxed_slice(),
             })
         }
+    }
+}
+
+fn validate_triangle_mesh(
+    geometry: GeometryId,
+    mesh: &GpuTriangleMesh,
+    issues: &mut Vec<GpuIrValidationError>,
+) {
+    if mesh.positions.is_empty() || mesh.indices.is_empty() {
+        issues.push(GpuIrValidationError::EmptyTriangleMesh { geometry });
+        return;
+    }
+    let position_count = mesh.positions.len();
+    for (triangle_index, triangle) in mesh.indices.iter().enumerate() {
+        if triangle
+            .iter()
+            .any(|index| usize::try_from(*index).map_or(true, |index| index >= position_count))
+        {
+            let index = triangle
+                .iter()
+                .copied()
+                .find(|index| usize::try_from(*index).map_or(true, |index| index >= position_count))
+                .unwrap_or_default();
+            issues.push(GpuIrValidationError::TriangleIndexOutOfBounds { geometry, index });
+        }
+        if triangle[0] == triangle[1] || triangle[1] == triangle[2] || triangle[2] == triangle[0] {
+            issues.push(GpuIrValidationError::DegenerateTriangle {
+                geometry,
+                triangle: triangle_index as GpuIndex,
+            });
+        }
+    }
+    let expected = position_count;
+    if mesh.normals.as_ref().is_some_and(|v| v.len() != expected)
+        || mesh.tangents.as_ref().is_some_and(|v| v.len() != expected)
+        || mesh.uvs.as_ref().is_some_and(|v| v.len() != expected)
+        || mesh
+            .face_indices
+            .as_ref()
+            .is_some_and(|v| v.len() != mesh.indices.len())
+    {
+        issues.push(GpuIrValidationError::AttributeLengthMismatch { geometry });
     }
 }
 

--- a/src/gpu/webgpu.rs
+++ b/src/gpu/webgpu.rs
@@ -11,7 +11,7 @@ use super::ir::{GpuRenderConfig, GpuSceneView};
 #[derive(Clone, Copy, Debug, Default)]
 pub struct WebGpuPrepareOptions;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct WebGpuExecutableScene {
     scene: GpuCompiledScene,
 }

--- a/tests/webgpu_stub.rs
+++ b/tests/webgpu_stub.rs
@@ -2,7 +2,9 @@
 
 use pbrt_r4::gpu::compiler::GpuCompiledScene;
 use pbrt_r4::gpu::ir::{
-    GpuIrVersion, GpuRenderConfig, GpuSceneData, GpuSceneDraft, CURRENT_IR_VERSION,
+    GeometryId, GpuGeometry, GpuIrValidationError, GpuIrVersion, GpuMatrix4x4, GpuPoint3,
+    GpuPrimitive, GpuRenderConfig, GpuSceneData, GpuSceneDraft, GpuStaticTransform, GpuTransform,
+    GpuTriangleMesh, TransformId, CURRENT_IR_VERSION,
 };
 use pbrt_r4::gpu::webgpu::{WebGpuPrepareOptions, WebGpuRenderer};
 
@@ -10,6 +12,37 @@ fn minimal_scene() -> GpuCompiledScene {
     let draft = GpuSceneDraft {
         version: CURRENT_IR_VERSION,
         data: GpuSceneData {
+            transforms: vec![GpuTransform::Static(GpuStaticTransform {
+                render_from_object: GpuMatrix4x4([
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ]),
+                object_from_render: GpuMatrix4x4([
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ]),
+                swaps_handedness: false,
+            })],
+            geometry: vec![GpuGeometry::TriangleMesh(GpuTriangleMesh {
+                positions: vec![
+                    GpuPoint3([0.0, 0.0, 0.0]),
+                    GpuPoint3([1.0, 0.0, 0.0]),
+                    GpuPoint3([0.0, 1.0, 0.0]),
+                ],
+                indices: vec![[0, 1, 2]],
+                normals: None,
+                tangents: None,
+                uvs: None,
+                face_indices: None,
+            })],
+            primitives: vec![GpuPrimitive {
+                geometry: GeometryId(0),
+                transform: TransformId(0),
+            }],
             render: GpuRenderConfig::default(),
         },
     };
@@ -44,8 +77,36 @@ fn incompatible_ir_version_is_rejected_before_prepare() {
             minor: 0,
         },
         data: GpuSceneData {
+            transforms: Vec::new(),
+            geometry: Vec::new(),
+            primitives: Vec::new(),
             render: GpuRenderConfig::default(),
         },
     };
     assert!(draft.finish().is_err());
+}
+
+#[test]
+fn invalid_triangle_index_is_rejected() {
+    let draft = GpuSceneDraft {
+        version: CURRENT_IR_VERSION,
+        data: GpuSceneData {
+            transforms: Vec::new(),
+            geometry: vec![GpuGeometry::TriangleMesh(GpuTriangleMesh {
+                positions: vec![GpuPoint3([0.0, 0.0, 0.0])],
+                indices: vec![[0, 1, 0]],
+                normals: None,
+                tangents: None,
+                uvs: None,
+                face_indices: None,
+            })],
+            primitives: Vec::new(),
+            render: GpuRenderConfig::default(),
+        },
+    };
+    let errors = draft.finish().unwrap_err();
+    assert!(errors
+        .issues()
+        .iter()
+        .any(|issue| matches!(issue, GpuIrValidationError::TriangleIndexOutOfBounds { .. })));
 }


### PR DESCRIPTION
## Summary
- Add the first validated semantic GPU IR types for WebGPU development.
- Add typed transform, geometry, and primitive identifiers plus TriangleMesh payloads.
- Validate triangle indices, degeneracy, attribute lengths, and primitive references before backend preparation.
- Keep WebGPU rendering explicitly unimplemented; no CPU fallback or fake output is introduced.

## Validation
- `cargo fmt --all`
- `cargo test --features webgpu --test webgpu_stub`
- `cargo check --no-default-features`
- `cargo diff --check`

Base branch: `feature/gpu` (GPU development trunk).