### PR TITLE
feat(webgpu): execute diffuse wavefront scenes on hardware ray query

### DIFF
--- a/src/gpu/compiler/light.rs
+++ b/src/gpu/compiler/light.rs
@@ -1,11 +1,16 @@
 use super::{
-    compile_rgb_spectrum, compile_transform, finite_parameter, light_source_location,
-    GpuCompileError, GpuDiffuseAreaLight, GpuIndex, GpuLight, GpuPointLight, GpuSourceLocation,
-    GpuSpectrumResource, GpuSpectrumTexture, GpuTransform, GpuUniformInfiniteLight,
-    LightSceneEntity, SceneBuilder, TransformId,
+    build_mip_storage, compile_rgb_spectrum, compile_transform, encode_mip_storage,
+    finite_parameter, gpu_color_encoding, invalid_parameter, light_source_location, raw_encoding,
+    raw_linear_pixels, GpuCompileError, GpuDiffuseAreaLight, GpuImageChannels, GpuImageFilter,
+    GpuImageResource, GpuImageWrapMode, GpuIndex, GpuLight, GpuPointLight, GpuSourceLocation,
+    GpuSpectrumResource, GpuSpectrumTexture, GpuTextureMapping, GpuTransform,
+    GpuUniformInfiniteLight, LightSceneEntity, SceneBuilder, TransformId,
 };
-use crate::gpu::ir::{LightId, SpectrumTextureId};
+use crate::gpu::ir::{GpuSpectrumType, ImageId, LightId, SpectrumTextureId, TextureMappingId};
+use crate::parser::scene_builder::path_resolver::make_absolute_path;
 use crate::parser::scene_builder::AreaLightSceneEntity;
+use crate::util::imageio::{read_raw_image_with_encoding, ColorEncoding};
+use std::path::Path;
 
 pub fn compile_light(
     _builder: &SceneBuilder,
@@ -51,9 +56,12 @@ pub fn compile_light(
 }
 
 pub fn compile_area_light(
+    builder: &SceneBuilder,
     area: &AreaLightSceneEntity,
     spectra: &mut Vec<GpuSpectrumResource>,
     spectrum_textures: &mut Vec<GpuSpectrumTexture>,
+    images: &mut Vec<GpuImageResource>,
+    texture_mappings: &mut Vec<GpuTextureMapping>,
     lights: &mut Vec<GpuLight>,
     source: &GpuSourceLocation,
 ) -> Result<LightId, GpuCompileError> {
@@ -63,9 +71,9 @@ pub fn compile_area_light(
             source: source.clone(),
         });
     }
-    if !area.base.params.get_one_filename("filename", "").is_empty() {
+    if area.base.params.get_floats_ref("power").is_some() {
         return Err(GpuCompileError::UnsupportedSceneFeature {
-            feature: "area light image emission",
+            feature: "area light power normalization",
             source: source.clone(),
         });
     }
@@ -75,9 +83,32 @@ pub fn compile_area_light(
             source: source.clone(),
         });
     }
-    let emission = compile_rgb_spectrum(&area.base.params, "L", [1.0, 1.0, 1.0], source, spectra)?;
-    let emission_texture = SpectrumTextureId(spectrum_textures.len() as GpuIndex);
-    spectrum_textures.push(GpuSpectrumTexture::Constant { value: emission });
+    let params = make_absolute_path(&area.base.params, &builder.seen_work_dirs);
+    let filename = params.get_one_filename("filename", "");
+    let emission_texture = if filename.is_empty() {
+        let emission = compile_rgb_spectrum(&params, "L", [1.0, 1.0, 1.0], source, spectra)?;
+        let emission_texture = SpectrumTextureId(spectrum_textures.len() as GpuIndex);
+        spectrum_textures.push(GpuSpectrumTexture::Constant { value: emission });
+        emission_texture
+    } else {
+        if params.get_points_ref("L").is_some()
+            || params.get_spectrums_ref("L").is_some()
+            || params.get_sampled_spectra_ref("L").is_some()
+        {
+            return Err(invalid_parameter(
+                "filename",
+                "both L and filename are specified for a diffuse area light",
+                source,
+            ));
+        }
+        compile_area_light_image(
+            &filename,
+            images,
+            texture_mappings,
+            spectrum_textures,
+            source,
+        )?
+    };
     let scale = finite_parameter(&area.base.params, "scale", 1.0, source)?;
     let light_id = LightId(lights.len() as GpuIndex);
     lights.push(GpuLight::DiffuseArea(GpuDiffuseAreaLight {
@@ -86,4 +117,80 @@ pub fn compile_area_light(
         two_sided: area.base.params.get_one_bool("twosided", false),
     }));
     Ok(light_id)
+}
+
+fn compile_area_light_image(
+    filename: &str,
+    images: &mut Vec<GpuImageResource>,
+    texture_mappings: &mut Vec<GpuTextureMapping>,
+    spectrum_textures: &mut Vec<GpuSpectrumTexture>,
+    source: &GpuSourceLocation,
+) -> Result<SpectrumTextureId, GpuCompileError> {
+    let encoding = if Path::new(filename)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("png"))
+    {
+        ColorEncoding::parse("sRGB")
+    } else {
+        ColorEncoding::parse("linear")
+    }
+    .map_err(|error| GpuCompileError::InvalidParameter {
+        parameter: "filename",
+        detail: error.msg,
+        source: source.clone(),
+    })?;
+    let raw = read_raw_image_with_encoding(filename, encoding).map_err(|error| {
+        GpuCompileError::InvalidParameter {
+            parameter: "filename",
+            detail: error.msg,
+            source: source.clone(),
+        }
+    })?;
+    let width = u32::try_from(raw.resolution.x)
+        .map_err(|_| invalid_parameter("filename", "image width must be positive", source))?;
+    let height = u32::try_from(raw.resolution.y)
+        .map_err(|_| invalid_parameter("filename", "image height must be positive", source))?;
+    if width == 0 || height == 0 || !matches!(raw.channels, 3 | 4) {
+        return Err(invalid_parameter(
+            "filename",
+            "diffuse area light image must have RGB or RGBA channels",
+            source,
+        ));
+    }
+    let source_pixels = raw_linear_pixels(&raw, source)?;
+    let mut pixels = Vec::with_capacity(width as usize * height as usize * 3);
+    for pixel in source_pixels.chunks_exact(raw.channels) {
+        pixels.extend_from_slice(&pixel[..3]);
+    }
+    let (linear_storage, mip_levels) = build_mip_storage(&pixels, width, height, 3);
+    let encoding = raw_encoding(&raw);
+    let storage = encode_mip_storage(&linear_storage, &raw.data, encoding, 3);
+    let image = ImageId(images.len() as GpuIndex);
+    images.push(GpuImageResource {
+        resolution: [width, height],
+        channels: GpuImageChannels::Rgb,
+        storage,
+        mip_levels,
+        color_encoding: gpu_color_encoding(encoding),
+    });
+    let mapping = TextureMappingId(texture_mappings.len() as GpuIndex);
+    texture_mappings.push(GpuTextureMapping::Uv {
+        su: 1.0,
+        sv: -1.0,
+        du: 0.0,
+        dv: 1.0,
+    });
+    let texture = SpectrumTextureId(spectrum_textures.len() as GpuIndex);
+    spectrum_textures.push(GpuSpectrumTexture::Image {
+        image,
+        mapping,
+        scale: 1.0,
+        invert: false,
+        swrap: GpuImageWrapMode::Clamp,
+        twrap: GpuImageWrapMode::Clamp,
+        filter: GpuImageFilter::Bilinear,
+        spectrum_type: GpuSpectrumType::Illuminant,
+    });
+    Ok(texture)
 }

--- a/src/gpu/compiler/mod.rs
+++ b/src/gpu/compiler/mod.rs
@@ -148,6 +148,7 @@ impl SceneBuilder {
                 &float_texture_ids,
                 &spectrum_texture_ids,
                 &mut images,
+                &mut texture_mappings,
                 &mut materials,
                 &mut primitives,
                 &mut lights,
@@ -166,6 +167,7 @@ impl SceneBuilder {
                 &float_texture_ids,
                 &spectrum_texture_ids,
                 &mut images,
+                &mut texture_mappings,
                 &mut materials,
                 &mut primitives,
                 &mut lights,
@@ -190,6 +192,7 @@ impl SceneBuilder {
                     &float_texture_ids,
                     &spectrum_texture_ids,
                     &mut images,
+                    &mut texture_mappings,
                     &mut materials,
                     &mut primitives,
                     &mut lights,
@@ -723,6 +726,7 @@ fn compile_shape(
     float_texture_ids: &[Option<super::ir::FloatTextureId>],
     spectrum_texture_ids: &[Option<super::ir::SpectrumTextureId>],
     images: &mut Vec<GpuImageResource>,
+    texture_mappings: &mut Vec<GpuTextureMapping>,
     materials: &mut Vec<GpuMaterial>,
     primitives: &mut Vec<GpuPrimitive>,
     lights: &mut Vec<GpuLight>,
@@ -786,7 +790,16 @@ fn compile_shape(
                     &source,
                 )
             })?;
-            light::compile_area_light(area, spectra, spectrum_textures, lights, &source)
+            light::compile_area_light(
+                builder,
+                area,
+                spectra,
+                spectrum_textures,
+                images,
+                texture_mappings,
+                lights,
+                &source,
+            )
         })
         .transpose()?;
     let alpha = material_texture_id(

--- a/src/gpu/webgpu/device.rs
+++ b/src/gpu/webgpu/device.rs
@@ -82,14 +82,19 @@ impl DeviceContext {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
         let (required_features, required_limits, experimental_features) =
             match options.acceleration_mode {
-                AccelerationMode::HardwareRayQuery => (
-                    wgpu::Features::EXPERIMENTAL_RAY_QUERY,
-                    wgpu::Limits::default().using_minimum_supported_acceleration_structure_values(),
-                    // SAFETY: hardware mode is only requested after the adapter capability
-                    // check above. The experimental API is explicitly part of this backend's
-                    // selected mode.
-                    unsafe { wgpu::ExperimentalFeatures::enabled() },
-                ),
+                AccelerationMode::HardwareRayQuery => {
+                    let mut limits = wgpu::Limits::default()
+                        .using_minimum_supported_acceleration_structure_values();
+                    limits.max_storage_buffers_per_shader_stage = 9;
+                    (
+                        wgpu::Features::EXPERIMENTAL_RAY_QUERY,
+                        limits,
+                        // SAFETY: hardware mode is only requested after the adapter capability
+                        // check above. The experimental API is explicitly part of this backend's
+                        // selected mode.
+                        unsafe { wgpu::ExperimentalFeatures::enabled() },
+                    )
+                }
                 AccelerationMode::SoftwareBvh => (
                     wgpu::Features::empty(),
                     wgpu::Limits::default(),
@@ -145,7 +150,7 @@ impl DeviceContext {
                     .contains(fallback.get_info().backend.into())
                 && fallback.features().contains(required_features)
                 && (options.acceleration_mode == AccelerationMode::SoftwareBvh
-                    || fallback.limits().check_limits(&required_limits))
+                    || required_limits.check_limits(&fallback.limits()))
             {
                 candidates.push(fallback);
             }

--- a/src/gpu/webgpu/device.rs
+++ b/src/gpu/webgpu/device.rs
@@ -114,7 +114,7 @@ impl DeviceContext {
             });
             candidates.retain(|adapter| {
                 adapter.features().contains(required_features)
-                    && adapter.limits().check_limits(&required_limits)
+                    && required_limits.check_limits(&adapter.limits())
             });
             if candidates.is_empty() && had_feature_candidate {
                 return Err(BackendError::AdapterRequest(format!(

--- a/src/gpu/webgpu/geometry.rs
+++ b/src/gpu/webgpu/geometry.rs
@@ -311,6 +311,21 @@ fn normal_transform(
 }
 
 impl ScenePlan {
+    pub fn supports_wavefront_min(&self, scene: GpuSceneView<'_>) -> bool {
+        matches!(scene.lights, [GpuLight::Point(_)])
+            && self.lights.len() == 1
+            && self.lights[0].kind == 0
+            && self
+                .primitives
+                .iter()
+                .all(|primitive| primitive.alpha.is_none())
+            && self.materials.iter().all(|material| {
+                matches!(material.reflectance, MaterialReflectancePlan::Constant(_))
+                    && material.normal_map.is_none()
+                    && material.displacement.is_none()
+            })
+    }
+
     pub fn validate_custom_data(custom_data: u32) -> Result<(), PlanError> {
         if custom_data > MAX_TLAS_CUSTOM_DATA {
             return Err(PlanError::LimitExceeded {

--- a/src/gpu/webgpu/mod.rs
+++ b/src/gpu/webgpu/mod.rs
@@ -6,6 +6,7 @@ mod geometry;
 mod renderer;
 pub mod shader;
 mod software;
+pub mod wavefront;
 
 pub use device::{AccelerationMode, BackendPreference, PowerPreference, PrepareOptions};
 pub use error::{BackendError, PlanError};

--- a/src/gpu/webgpu/renderer.rs
+++ b/src/gpu/webgpu/renderer.rs
@@ -5,6 +5,7 @@ use super::error::BackendError;
 use super::geometry::{HardwareAcceleration, ScenePlan};
 use super::shader::{build_shader_set, ShaderStageId};
 use super::software::SoftwareAcceleration;
+use super::wavefront::WavefrontLayout;
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 
 enum SceneResources {
@@ -15,6 +16,7 @@ enum SceneResources {
 pub struct ExecutableScene {
     scene: GpuCompiledScene,
     resources: SceneResources,
+    supports_wavefront_min: bool,
 }
 
 impl ExecutableScene {
@@ -24,8 +26,19 @@ impl ExecutableScene {
 }
 
 struct Pipeline {
-    pipeline: wgpu::ComputePipeline,
+    stages: Vec<(ShaderStageId, wgpu::ComputePipeline)>,
     bind_group_layout: wgpu::BindGroupLayout,
+}
+
+impl Pipeline {
+    fn stage(&self, id: ShaderStageId) -> &wgpu::ComputePipeline {
+        &self
+            .stages
+            .iter()
+            .find(|(stage_id, _)| *stage_id == id)
+            .unwrap_or_else(|| panic!("WebGPU pipeline does not contain stage {id:?}"))
+            .1
+    }
 }
 
 pub struct Renderer {
@@ -45,6 +58,7 @@ impl Renderer {
 
     pub fn prepare(&mut self, scene: &GpuCompiledScene) -> Result<ExecutableScene, BackendError> {
         let plan = ScenePlan::from_scene(scene.view())?;
+        let supports_wavefront_min = plan.supports_wavefront_min(scene.view());
         let resources = match self.device_context.acceleration_mode {
             AccelerationMode::HardwareRayQuery => {
                 SceneResources::Hardware(HardwareAcceleration::create(&self.device_context, &plan)?)
@@ -56,6 +70,7 @@ impl Renderer {
         Ok(ExecutableScene {
             scene: scene.clone(),
             resources,
+            supports_wavefront_min,
         })
     }
 
@@ -93,6 +108,11 @@ impl Renderer {
                 .ok_or(BackendError::Readback("output size overflow".to_string()))?,
         )
         .map_err(|_| BackendError::Readback("output size overflow".to_string()))?;
+        let wavefront_layout = WavefrontLayout::for_pixel_count(
+            u32::try_from(pixel_count)
+                .map_err(|_| BackendError::Readback("pixel count exceeds u32".to_string()))?,
+        )
+        .ok_or_else(|| BackendError::Readback("wavefront arena size overflow".to_string()))?;
 
         let (bvh_primitive_offset, bvh_node_offset) = match &scene.resources {
             SceneResources::Hardware(_) => (0, 0),
@@ -101,6 +121,8 @@ impl Renderer {
                 acceleration.bvh_node_offset,
             ),
         };
+        let use_wavefront_min =
+            matches!(&scene.resources, SceneResources::Hardware(_)) && scene.supports_wavefront_min;
         let uniform_buffer = self
             .device_context
             .device
@@ -120,7 +142,9 @@ impl Renderer {
             .create_buffer(&wgpu::BufferDescriptor {
                 label: Some("pbrt-r4 WebGPU film output"),
                 size: output_size,
-                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_SRC
+                    | wgpu::BufferUsages::COPY_DST,
                 mapped_at_creation: false,
             });
         let readback_buffer = self
@@ -130,6 +154,15 @@ impl Renderer {
                 label: Some("pbrt-r4 WebGPU film readback"),
                 size: output_size,
                 usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            });
+        let wavefront_buffer = self
+            .device_context
+            .device
+            .create_buffer(&wgpu::BufferDescriptor {
+                label: Some("pbrt-r4 WebGPU wavefront arena"),
+                size: u64::from(wavefront_layout.byte_len),
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
                 mapped_at_creation: false,
             });
         let bind_group =
@@ -156,6 +189,7 @@ impl Renderer {
                             buffer_entry(7, acceleration.material_buffer.as_entire_binding()),
                             buffer_entry(8, acceleration.light_buffer.as_entire_binding()),
                             buffer_entry(9, acceleration.texture_buffer.as_entire_binding()),
+                            buffer_entry(10, wavefront_buffer.as_entire_binding()),
                         ],
                     }),
                 SceneResources::Software(acceleration) => self
@@ -184,14 +218,45 @@ impl Renderer {
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("pbrt-r4 WebGPU dispatch"),
                 });
+        if use_wavefront_min {
+            encoder.clear_buffer(&output_buffer, 0, None);
+            encoder.clear_buffer(&wavefront_buffer, 0, None);
+        }
         {
             let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: Some("pbrt-r4 WebGPU render pass"),
                 timestamp_writes: None,
             });
-            pass.set_pipeline(&self.pipeline.pipeline);
-            pass.set_bind_group(0, &bind_group, &[]);
-            pass.dispatch_workgroups(width.div_ceil(8), height.div_ceil(8), 1);
+            if use_wavefront_min {
+                let wavefront_workgroups = u32::try_from(pixel_count)
+                    .map_err(|_| BackendError::Readback("pixel count exceeds u32".to_string()))?
+                    .div_ceil(64);
+                for sample_offset in 0..request.sample_count {
+                    pass.set_bind_group(0, &bind_group, &[]);
+                    pass.set_pipeline(self.pipeline.stage(ShaderStageId::GenerateCamera));
+                    pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                    for _ in 0..scene_view.render.integrator.max_depth {
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::IntersectClosest));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::ShadeDiffusePoint));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::IntersectShadow));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::FinishBounce));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                    }
+                    pass.set_pipeline(self.pipeline.stage(ShaderStageId::UpdateFilm));
+                    pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                    if sample_offset + 1 < request.sample_count {
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::AdvanceSample));
+                        pass.dispatch_workgroups(1, 1, 1);
+                    }
+                }
+            } else {
+                pass.set_bind_group(0, &bind_group, &[]);
+                pass.set_pipeline(self.pipeline.stage(ShaderStageId::LegacyRender));
+                pass.dispatch_workgroups(width.div_ceil(8), height.div_ceil(8), 1);
+            }
         }
         encoder.copy_buffer_to_buffer(&output_buffer, 0, &readback_buffer, 0, output_size);
         self.device_context.queue.submit(Some(encoder.finish()));
@@ -243,10 +308,6 @@ fn buffer_entry(binding: u32, resource: wgpu::BindingResource<'_>) -> wgpu::Bind
 
 fn create_pipeline(context: &DeviceContext, mode: AccelerationMode) -> Pipeline {
     let shader_set = build_shader_set(mode).expect("built-in WebGPU shader recipe is valid");
-    let entry_point = shader_set
-        .stage(ShaderStageId::LegacyRender)
-        .expect("legacy WebGPU render stage is registered")
-        .entry_point;
     let bind_group_layout = match mode {
         AccelerationMode::HardwareRayQuery => create_hardware_bind_group_layout(&context.device),
         AccelerationMode::SoftwareBvh => create_software_bind_group_layout(&context.device),
@@ -264,18 +325,26 @@ fn create_pipeline(context: &DeviceContext, mode: AccelerationMode) -> Pipeline 
             bind_group_layouts: &[Some(&bind_group_layout)],
             immediate_size: 0,
         });
-    let pipeline = context
-        .device
-        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some("pbrt-r4 WebGPU compute pipeline"),
-            layout: Some(&pipeline_layout),
-            module: &shader,
-            entry_point: Some(entry_point),
-            compilation_options: Default::default(),
-            cache: None,
-        });
+    let stages = shader_set
+        .stages
+        .iter()
+        .map(|stage| {
+            let pipeline =
+                context
+                    .device
+                    .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                        label: Some(stage.entry_point),
+                        layout: Some(&pipeline_layout),
+                        module: &shader,
+                        entry_point: Some(stage.entry_point),
+                        compilation_options: Default::default(),
+                        cache: None,
+                    });
+            (stage.id, pipeline)
+        })
+        .collect();
     Pipeline {
-        pipeline,
+        stages,
         bind_group_layout,
     }
 }
@@ -293,6 +362,16 @@ fn create_hardware_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLa
             count: None,
         },
     );
+    entries.push(wgpu::BindGroupLayoutEntry {
+        binding: 10,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only: false },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    });
     device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: Some("pbrt-r4 WebGPU hardware bind group layout"),
         entries: &entries,

--- a/src/gpu/webgpu/renderer.rs
+++ b/src/gpu/webgpu/renderer.rs
@@ -3,7 +3,7 @@ use super::super::ir::{GpuMatrix4x4, GpuRenderOutput, GpuRenderRequest, GpuScene
 use super::device::{AccelerationMode, DeviceContext, PrepareOptions};
 use super::error::BackendError;
 use super::geometry::{HardwareAcceleration, ScenePlan};
-use super::shader::build_shader_set;
+use super::shader::{build_shader_set, ShaderStageId};
 use super::software::SoftwareAcceleration;
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 
@@ -243,6 +243,10 @@ fn buffer_entry(binding: u32, resource: wgpu::BindingResource<'_>) -> wgpu::Bind
 
 fn create_pipeline(context: &DeviceContext, mode: AccelerationMode) -> Pipeline {
     let shader_set = build_shader_set(mode).expect("built-in WebGPU shader recipe is valid");
+    let entry_point = shader_set
+        .stage(ShaderStageId::LegacyRender)
+        .expect("legacy WebGPU render stage is registered")
+        .entry_point;
     let bind_group_layout = match mode {
         AccelerationMode::HardwareRayQuery => create_hardware_bind_group_layout(&context.device),
         AccelerationMode::SoftwareBvh => create_software_bind_group_layout(&context.device),
@@ -266,7 +270,7 @@ fn create_pipeline(context: &DeviceContext, mode: AccelerationMode) -> Pipeline 
             label: Some("pbrt-r4 WebGPU compute pipeline"),
             layout: Some(&pipeline_layout),
             module: &shader,
-            entry_point: Some(shader_set.entry_point),
+            entry_point: Some(entry_point),
             compilation_options: Default::default(),
             cache: None,
         });

--- a/src/gpu/webgpu/shader/fragment.rs
+++ b/src/gpu/webgpu/shader/fragment.rs
@@ -10,10 +10,12 @@ pub enum FragmentId {
     AreaGeometry,
     AreaSampling,
     Emission,
+    WavefrontAbi,
     HardwareBindings,
     RayQueryTraversal,
     SoftwareBvhTraversal,
     EntryMain,
+    EntryWavefront,
 }
 
 #[derive(Clone)]

--- a/src/gpu/webgpu/shader/mod.rs
+++ b/src/gpu/webgpu/shader/mod.rs
@@ -3,10 +3,27 @@ mod fragment;
 use super::device::AccelerationMode;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ShaderStageId {
+    LegacyRender,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ShaderStage {
+    pub id: ShaderStageId,
+    pub entry_point: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ShaderSet {
     pub source: String,
     pub label: &'static str,
-    pub entry_point: &'static str,
+    pub stages: Vec<ShaderStage>,
+}
+
+impl ShaderSet {
+    pub fn stage(&self, id: ShaderStageId) -> Option<&ShaderStage> {
+        self.stages.iter().find(|stage| stage.id == id)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -130,6 +147,9 @@ pub fn build_shader_set(mode: AccelerationMode) -> Result<ShaderSet, ShaderBuild
     Ok(ShaderSet {
         source,
         label,
-        entry_point: "main",
+        stages: vec![ShaderStage {
+            id: ShaderStageId::LegacyRender,
+            entry_point: "main",
+        }],
     })
 }

--- a/src/gpu/webgpu/shader/mod.rs
+++ b/src/gpu/webgpu/shader/mod.rs
@@ -2,9 +2,16 @@ mod fragment;
 
 use super::device::AccelerationMode;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ShaderStageId {
     LegacyRender,
+    GenerateCamera,
+    IntersectClosest,
+    ShadeDiffusePoint,
+    IntersectShadow,
+    FinishBounce,
+    UpdateFilm,
+    AdvanceSample,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -114,10 +121,20 @@ pub fn build_shader_set(mode: AccelerationMode) -> Result<ShaderSet, ShaderBuild
             dependencies: vec![fragment::FragmentId::AreaSampling],
         },
         fragment::Fragment {
+            id: fragment::FragmentId::WavefrontAbi,
+            path: "shaders/common/wavefront.wgsl",
+            source: include_str!("../shaders/common/wavefront.wgsl"),
+            dependencies: vec![fragment::FragmentId::Abi],
+        },
+        fragment::Fragment {
             id: fragment::FragmentId::HardwareBindings,
             path: "shaders/intersection/ray_query.wgsl:bindings",
             source: "@group(0) @binding(2)\nvar acceleration: acceleration_structure;\n",
-            dependencies: common_ids.clone(),
+            dependencies: {
+                let mut dependencies = common_ids.clone();
+                dependencies.push(fragment::FragmentId::WavefrontAbi);
+                dependencies
+            },
         },
         fragment::Fragment {
             id: fragment::FragmentId::RayQueryTraversal,
@@ -137,8 +154,21 @@ pub fn build_shader_set(mode: AccelerationMode) -> Result<ShaderSet, ShaderBuild
             source: include_str!("../shaders/entry/main.wgsl"),
             dependencies: vec![traversal],
         },
+        fragment::Fragment {
+            id: fragment::FragmentId::EntryWavefront,
+            path: "shaders/entry/wavefront.wgsl",
+            source: include_str!("../shaders/entry/wavefront.wgsl"),
+            dependencies: vec![fragment::FragmentId::RayQueryTraversal],
+        },
     ];
-    let composed = fragment::compose(&fragments, &[fragment::FragmentId::EntryMain])
+    let roots = match mode {
+        AccelerationMode::HardwareRayQuery => vec![
+            fragment::FragmentId::EntryMain,
+            fragment::FragmentId::EntryWavefront,
+        ],
+        AccelerationMode::SoftwareBvh => vec![fragment::FragmentId::EntryMain],
+    };
+    let composed = fragment::compose(&fragments, &roots)
         .map_err(|error| ShaderBuildError::Fragment(format!("{error:?}")))?;
     let source = match mode {
         AccelerationMode::HardwareRayQuery => format!("enable wgpu_ray_query;\n\n{composed}"),
@@ -147,9 +177,45 @@ pub fn build_shader_set(mode: AccelerationMode) -> Result<ShaderSet, ShaderBuild
     Ok(ShaderSet {
         source,
         label,
-        stages: vec![ShaderStage {
-            id: ShaderStageId::LegacyRender,
-            entry_point: "main",
-        }],
+        stages: match mode {
+            AccelerationMode::HardwareRayQuery => vec![
+                ShaderStage {
+                    id: ShaderStageId::LegacyRender,
+                    entry_point: "main",
+                },
+                ShaderStage {
+                    id: ShaderStageId::GenerateCamera,
+                    entry_point: "generate_camera",
+                },
+                ShaderStage {
+                    id: ShaderStageId::IntersectClosest,
+                    entry_point: "intersect_closest",
+                },
+                ShaderStage {
+                    id: ShaderStageId::ShadeDiffusePoint,
+                    entry_point: "shade_diffuse_point",
+                },
+                ShaderStage {
+                    id: ShaderStageId::IntersectShadow,
+                    entry_point: "intersect_shadow",
+                },
+                ShaderStage {
+                    id: ShaderStageId::FinishBounce,
+                    entry_point: "finish_bounce",
+                },
+                ShaderStage {
+                    id: ShaderStageId::UpdateFilm,
+                    entry_point: "update_film",
+                },
+                ShaderStage {
+                    id: ShaderStageId::AdvanceSample,
+                    entry_point: "advance_sample",
+                },
+            ],
+            AccelerationMode::SoftwareBvh => vec![ShaderStage {
+                id: ShaderStageId::LegacyRender,
+                entry_point: "main",
+            }],
+        },
     })
 }

--- a/src/gpu/webgpu/shaders/common/abi.wgsl
+++ b/src/gpu/webgpu/shaders/common/abi.wgsl
@@ -15,6 +15,7 @@ struct Primitive {
     alpha: u32,
     _reserved_alpha: u32,
     flags: u32,
+    // Explicit trailing padding keeps the storage-array stride at 32 bytes.
     _padding: vec2<u32>,
 };
 

--- a/src/gpu/webgpu/shaders/common/wavefront.wgsl
+++ b/src/gpu/webgpu/shaders/common/wavefront.wgsl
@@ -1,0 +1,25 @@
+const WAVEFRONT_STATE_INACTIVE: u32 = 0u;
+const WAVEFRONT_STATE_RAY: u32 = 1u;
+const WAVEFRONT_STATE_MISS: u32 = 2u;
+const WAVEFRONT_STATE_HIT: u32 = 3u;
+
+struct WavefrontSlot {
+    ray_origin: vec4<f32>,
+    ray_direction: vec4<f32>,
+    intersection_ids: vec4<u32>,
+    intersection_data: vec4<f32>,
+    shadow_origin: vec4<f32>,
+    shadow_direction: vec4<f32>,
+    contribution: vec4<f32>,
+    radiance: vec4<f32>,
+    throughput: vec4<f32>,
+    path_info: vec4<u32>,
+};
+
+struct WavefrontArena {
+    control: vec4<u32>,
+    slots: array<WavefrontSlot>,
+};
+
+@group(0) @binding(10)
+var<storage, read_write> wavefront: WavefrontArena;

--- a/src/gpu/webgpu/shaders/entry/wavefront.wgsl
+++ b/src/gpu/webgpu/shaders/entry/wavefront.wgsl
@@ -1,0 +1,292 @@
+fn wavefront_pixel_index(global_id: vec3<u32>) -> u32 {
+    return global_id.x;
+}
+
+@compute @workgroup_size(64)
+fn generate_camera(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let index = wavefront_pixel_index(global_id);
+    let width = u32(camera.viewport.z);
+    let height = u32(camera.viewport.w);
+    let pixel_count = width * height;
+    if (index >= pixel_count) {
+        return;
+    }
+
+    let local_pixel = vec2<u32>(index % width, index / width);
+    let pixel = vec2<i32>(local_pixel) + vec2<i32>(camera.viewport.xy);
+    let sample_index = camera.sampler_info.z + wavefront.control.x;
+    let camera_sample = independent_camera_sample(pixel, sample_index);
+    let filter_offset = mix(-camera.filter_info.xy, camera.filter_info.xy, camera_sample.filter_sample);
+    let film_position = vec2<f32>(pixel) + filter_offset + vec2<f32>(0.5);
+    let camera_target = transform(
+        camera.camera_from_raster,
+        vec4<f32>(film_position, 0.0, 1.0),
+    );
+    var camera_origin = vec3<f32>(0.0);
+    var camera_direction = normalize(camera_target.xyz);
+    if (camera.camera_info.x > 0.0) {
+        let lens = camera.camera_info.x * sample_uniform_disk_concentric(camera_sample.lens);
+        let focus_t = camera.camera_info.y / camera_direction.z;
+        let focus = focus_t * camera_direction;
+        camera_origin = vec3<f32>(lens, 0.0);
+        camera_direction = normalize(focus - camera_origin);
+    }
+
+    let ray_origin = transform(camera.render_from_camera, vec4<f32>(camera_origin, 1.0)).xyz;
+    let ray_direction = normalize(transform(
+        camera.render_from_camera,
+        vec4<f32>(camera_direction, 0.0),
+    ).xyz);
+    wavefront.slots[index].ray_origin = vec4<f32>(ray_origin, 0.0);
+    wavefront.slots[index].ray_direction = vec4<f32>(ray_direction, 0.0);
+    wavefront.slots[index].intersection_ids = vec4<u32>(WAVEFRONT_STATE_RAY, 0u, 0u, 0u);
+    wavefront.slots[index].intersection_data = vec4<f32>(0.0);
+    wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
+    wavefront.slots[index].shadow_direction = vec4<f32>(0.0);
+    wavefront.slots[index].contribution = vec4<f32>(0.0);
+    wavefront.slots[index].radiance = vec4<f32>(0.0);
+    wavefront.slots[index].throughput = vec4<f32>(1.0);
+    wavefront.slots[index].path_info = vec4<u32>(0u);
+}
+
+@compute @workgroup_size(64)
+fn intersect_closest(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let index = wavefront_pixel_index(global_id);
+    if (index >= arrayLength(&wavefront.slots)
+        || wavefront.slots[index].intersection_ids.x != WAVEFRONT_STATE_RAY) {
+        return;
+    }
+
+    let origin = wavefront.slots[index].ray_origin.xyz;
+    let direction = wavefront.slots[index].ray_direction.xyz;
+    var query: ray_query;
+    rayQueryInitialize(
+        &query,
+        acceleration,
+        RayDesc(0u, 0xFFu, 0.0001, 1.0e30, origin, direction),
+    );
+    while (rayQueryProceed(&query)) {
+        rayQueryConfirmIntersection(&query);
+    }
+    let intersection = rayQueryGetCommittedIntersection(&query);
+    if (intersection.kind == RAY_QUERY_INTERSECTION_NONE) {
+        wavefront.slots[index].intersection_ids = vec4<u32>(WAVEFRONT_STATE_MISS, 0u, 0u, 0u);
+        wavefront.slots[index].intersection_data = vec4<f32>(0.0);
+        return;
+    }
+
+    wavefront.slots[index].intersection_ids = vec4<u32>(
+        WAVEFRONT_STATE_HIT,
+        intersection.instance_custom_data,
+        intersection.primitive_index,
+        intersection.geometry_index,
+    );
+    wavefront.slots[index].intersection_data = vec4<f32>(
+        intersection.t,
+        intersection.barycentrics,
+        0.0,
+    );
+}
+
+@compute @workgroup_size(64)
+fn shade_diffuse_point(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let index = wavefront_pixel_index(global_id);
+    if (index >= arrayLength(&wavefront.slots)) {
+        return;
+    }
+    if (wavefront.slots[index].intersection_ids.x != WAVEFRONT_STATE_HIT) {
+        wavefront.slots[index].contribution = vec4<f32>(0.0);
+        wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
+        wavefront.slots[index].path_info.y = 0u;
+        return;
+    }
+
+    let primitive_index = wavefront.slots[index].intersection_ids.y;
+    let triangle_index = wavefront.slots[index].intersection_ids.z;
+    let primitive = primitives[primitive_index];
+    let index_offset = primitive.first_index + triangle_index * 3u;
+    let i0 = primitive.first_vertex + indices[index_offset];
+    let i1 = primitive.first_vertex + indices[index_offset + 1u];
+    let i2 = primitive.first_vertex + indices[index_offset + 2u];
+    let barycentrics = vec3<f32>(
+        1.0 - wavefront.slots[index].intersection_data.y
+            - wavefront.slots[index].intersection_data.z,
+        wavefront.slots[index].intersection_data.y,
+        wavefront.slots[index].intersection_data.z,
+    );
+    let transform_table = transforms[primitive_index];
+    let object_position = vertices[i0].position.xyz * barycentrics.x
+        + vertices[i1].position.xyz * barycentrics.y
+        + vertices[i2].position.xyz * barycentrics.z;
+    let position = transform(
+        transform_table.render_from_object,
+        vec4<f32>(object_position, 1.0),
+    ).xyz;
+    let render_p0 = transform(transform_table.render_from_object, vertices[i0].position).xyz;
+    let render_p1 = transform(transform_table.render_from_object, vertices[i1].position).xyz;
+    let render_p2 = transform(transform_table.render_from_object, vertices[i2].position).xyz;
+    var geometric_normal = normalize(cross(render_p1 - render_p0, render_p2 - render_p0));
+    if ((primitive.flags & 1u) != 0u) {
+        geometric_normal = -geometric_normal;
+    }
+    let object_normal = vertices[i0].normal.xyz * barycentrics.x
+        + vertices[i1].normal.xyz * barycentrics.y
+        + vertices[i2].normal.xyz * barycentrics.z;
+    var normal = geometric_normal;
+    if (dot(object_normal, object_normal) > 1.0e-20) {
+        normal = normalize(transform(
+            transform_table.normal_from_object,
+            vec4<f32>(object_normal, 0.0),
+        ).xyz);
+        normal = select(-normal, normal, dot(normal, geometric_normal) >= 0.0);
+    }
+
+    let wo = -wavefront.slots[index].ray_direction.xyz;
+    let object_position_error = 4.172327e-7 * (
+        abs(barycentrics.x * vertices[i0].position.xyz)
+        + abs(barycentrics.y * vertices[i1].position.xyz)
+        + abs(barycentrics.z * vertices[i2].position.xyz)
+    );
+    let position_error = transformed_position_error(
+        transform_table.render_from_object,
+        object_position,
+        object_position_error,
+    );
+    let reflectance = materials[primitive.material].reflectance.xyz;
+    let light = lights[0];
+    let to_light = light.position.xyz - position;
+    let distance_squared = max(dot(to_light, to_light), 1.0e-8);
+    let wi = normalize(to_light);
+    let cosine = abs(dot(normal, wi));
+    let same_hemisphere = dot(normal, wo) * dot(normal, wi) > 0.0;
+    if (same_hemisphere && cosine > 0.0) {
+        let shadow_origin = offset_ray_origin(
+            position,
+            position_error,
+            geometric_normal,
+            to_light,
+        );
+        wavefront.slots[index].shadow_origin = vec4<f32>(shadow_origin, 1.0);
+        wavefront.slots[index].shadow_direction = vec4<f32>(to_light, 0.0);
+        wavefront.slots[index].contribution = vec4<f32>(
+            wavefront.slots[index].throughput.xyz * reflectance
+                * light.intensity.xyz * cosine
+                / (3.141592653589793 * distance_squared),
+            1.0,
+        );
+    } else {
+        wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
+        wavefront.slots[index].contribution = vec4<f32>(0.0);
+    }
+
+    let width = u32(camera.viewport.z);
+    let local_pixel = vec2<u32>(index % width, index / width);
+    let pixel = vec2<i32>(local_pixel) + vec2<i32>(camera.viewport.xy);
+    let sample_index = camera.sampler_info.z + wavefront.control.x;
+    let depth = wavefront.slots[index].path_info.x;
+    let ray_sample = independent_ray_sample(pixel, sample_index, depth);
+    let disk = sample_uniform_disk_concentric(ray_sample.indirect.direction);
+    var local_wi = vec3<f32>(disk, sqrt(max(0.0, 1.0 - dot(disk, disk))));
+    if (dot(normal, wo) < 0.0) {
+        local_wi.z = -local_wi.z;
+    }
+    let frame_x = coordinate_tangent(normal);
+    let frame_y = cross(normal, frame_x);
+    let next_direction = normalize(
+        frame_x * local_wi.x + frame_y * local_wi.y + normal * local_wi.z,
+    );
+    var next_throughput = wavefront.slots[index].throughput.xyz * reflectance;
+    var continue_path = true;
+    if (depth >= 1u) {
+        let maximum = max(next_throughput.x, max(next_throughput.y, next_throughput.z));
+        if (maximum < 1.0) {
+            let q = 1.0 - maximum;
+            if (ray_sample.indirect.roulette < q) {
+                continue_path = false;
+            } else {
+                next_throughput /= 1.0 - q;
+            }
+        }
+    }
+    wavefront.slots[index].ray_origin = vec4<f32>(offset_ray_origin(
+        position,
+        position_error,
+        geometric_normal,
+        next_direction,
+    ), 0.0);
+    wavefront.slots[index].ray_direction = vec4<f32>(next_direction, 0.0);
+    wavefront.slots[index].throughput = vec4<f32>(next_throughput, 1.0);
+    wavefront.slots[index].path_info.y = select(0u, 1u, continue_path);
+}
+
+@compute @workgroup_size(64)
+fn intersect_shadow(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let index = wavefront_pixel_index(global_id);
+    if (index >= arrayLength(&wavefront.slots)
+        || wavefront.slots[index].shadow_origin.w == 0.0) {
+        return;
+    }
+
+    let source_primitive = wavefront.slots[index].intersection_ids.y;
+    let source_triangle = wavefront.slots[index].intersection_ids.z;
+    var query: ray_query;
+    rayQueryInitialize(
+        &query,
+        acceleration,
+        RayDesc(
+            0u,
+            0xFFu,
+            0.0,
+            0.9999,
+            wavefront.slots[index].shadow_origin.xyz,
+            wavefront.slots[index].shadow_direction.xyz,
+        ),
+    );
+    while (rayQueryProceed(&query)) {
+        let candidate = rayQueryGetCandidateIntersection(&query);
+        if (candidate.instance_custom_data == source_primitive
+            && candidate.primitive_index == source_triangle) {
+            continue;
+        }
+        rayQueryConfirmIntersection(&query);
+    }
+    if (rayQueryGetCommittedIntersection(&query).kind != RAY_QUERY_INTERSECTION_NONE) {
+        wavefront.slots[index].contribution = vec4<f32>(0.0);
+    }
+}
+
+@compute @workgroup_size(64)
+fn finish_bounce(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let index = wavefront_pixel_index(global_id);
+    if (index >= arrayLength(&wavefront.slots)) {
+        return;
+    }
+    wavefront.slots[index].radiance += wavefront.slots[index].contribution;
+    wavefront.slots[index].contribution = vec4<f32>(0.0);
+    wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
+    if (wavefront.slots[index].path_info.y != 0u) {
+        wavefront.slots[index].path_info.x += 1u;
+        wavefront.slots[index].intersection_ids.x = WAVEFRONT_STATE_RAY;
+    } else {
+        wavefront.slots[index].intersection_ids.x = WAVEFRONT_STATE_INACTIVE;
+    }
+}
+
+@compute @workgroup_size(64)
+fn update_film(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let index = wavefront_pixel_index(global_id);
+    if (index >= arrayLength(&wavefront.slots)) {
+        return;
+    }
+    output[index] += vec4<f32>(
+        wavefront.slots[index].radiance.xyz / f32(camera.sampler_info.w),
+        1.0 / f32(camera.sampler_info.w),
+    );
+}
+
+@compute @workgroup_size(1)
+fn advance_sample(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    if (global_id.x == 0u) {
+        wavefront.control.x += 1u;
+    }
+}

--- a/src/gpu/webgpu/wavefront.rs
+++ b/src/gpu/webgpu/wavefront.rs
@@ -1,81 +1,26 @@
-//! Host-side layout for the GPU wavefront work queues.
+//! Host-side layout for the initial fixed-slot GPU wavefront arena.
 
-const ALIGNMENT: u32 = 16;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum QueueKind {
-    Camera,
-    Hit,
-    Miss,
-    Shadow,
-    Film,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct QueueRegion {
-    pub offset: u32,
-    pub stride: u32,
-    pub capacity: u32,
-}
-
-impl QueueRegion {
-    pub fn byte_len(self) -> u32 {
-        self.stride.saturating_mul(self.capacity)
-    }
-}
+pub const WAVEFRONT_SLOT_STRIDE: u32 = 160;
+pub const WAVEFRONT_CONTROL_SIZE: u32 = 16;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WavefrontLayout {
-    pub camera: QueueRegion,
-    pub hit: QueueRegion,
-    pub miss: QueueRegion,
-    pub shadow: QueueRegion,
-    pub film: QueueRegion,
+    pub capacity: u32,
     pub byte_len: u32,
 }
 
 impl WavefrontLayout {
     pub fn for_pixel_count(pixel_count: u32) -> Option<Self> {
-        let mut offset = 0;
-        let camera = allocate(&mut offset, 32, pixel_count)?;
-        let hit = allocate(&mut offset, 48, pixel_count)?;
-        let miss = allocate(&mut offset, 16, pixel_count)?;
-        let shadow = allocate(&mut offset, 32, pixel_count)?;
-        let film = allocate(&mut offset, 16, pixel_count)?;
+        let byte_len = WAVEFRONT_SLOT_STRIDE
+            .checked_mul(pixel_count)?
+            .checked_add(WAVEFRONT_CONTROL_SIZE)?;
         Some(Self {
-            camera,
-            hit,
-            miss,
-            shadow,
-            film,
-            byte_len: offset,
+            capacity: pixel_count,
+            byte_len,
         })
     }
 
-    pub fn region(self, kind: QueueKind) -> QueueRegion {
-        match kind {
-            QueueKind::Camera => self.camera,
-            QueueKind::Hit => self.hit,
-            QueueKind::Miss => self.miss,
-            QueueKind::Shadow => self.shadow,
-            QueueKind::Film => self.film,
-        }
+    pub fn slot_offset(self, index: u32) -> Option<u32> {
+        (index < self.capacity).then(|| WAVEFRONT_CONTROL_SIZE + index * WAVEFRONT_SLOT_STRIDE)
     }
-}
-
-fn allocate(offset: &mut u32, stride: u32, capacity: u32) -> Option<QueueRegion> {
-    *offset = align(*offset, ALIGNMENT)?;
-    let region = QueueRegion {
-        offset: *offset,
-        stride,
-        capacity,
-    };
-    *offset = (*offset).checked_add(region.byte_len())?;
-    Some(region)
-}
-
-fn align(value: u32, alignment: u32) -> Option<u32> {
-    value
-        .checked_add(alignment - 1)
-        .map(|value| value / alignment * alignment)
 }

--- a/src/gpu/webgpu/wavefront.rs
+++ b/src/gpu/webgpu/wavefront.rs
@@ -1,0 +1,81 @@
+//! Host-side layout for the GPU wavefront work queues.
+
+const ALIGNMENT: u32 = 16;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum QueueKind {
+    Camera,
+    Hit,
+    Miss,
+    Shadow,
+    Film,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct QueueRegion {
+    pub offset: u32,
+    pub stride: u32,
+    pub capacity: u32,
+}
+
+impl QueueRegion {
+    pub fn byte_len(self) -> u32 {
+        self.stride.saturating_mul(self.capacity)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WavefrontLayout {
+    pub camera: QueueRegion,
+    pub hit: QueueRegion,
+    pub miss: QueueRegion,
+    pub shadow: QueueRegion,
+    pub film: QueueRegion,
+    pub byte_len: u32,
+}
+
+impl WavefrontLayout {
+    pub fn for_pixel_count(pixel_count: u32) -> Option<Self> {
+        let mut offset = 0;
+        let camera = allocate(&mut offset, 32, pixel_count)?;
+        let hit = allocate(&mut offset, 48, pixel_count)?;
+        let miss = allocate(&mut offset, 16, pixel_count)?;
+        let shadow = allocate(&mut offset, 32, pixel_count)?;
+        let film = allocate(&mut offset, 16, pixel_count)?;
+        Some(Self {
+            camera,
+            hit,
+            miss,
+            shadow,
+            film,
+            byte_len: offset,
+        })
+    }
+
+    pub fn region(self, kind: QueueKind) -> QueueRegion {
+        match kind {
+            QueueKind::Camera => self.camera,
+            QueueKind::Hit => self.hit,
+            QueueKind::Miss => self.miss,
+            QueueKind::Shadow => self.shadow,
+            QueueKind::Film => self.film,
+        }
+    }
+}
+
+fn allocate(offset: &mut u32, stride: u32, capacity: u32) -> Option<QueueRegion> {
+    *offset = align(*offset, ALIGNMENT)?;
+    let region = QueueRegion {
+        offset: *offset,
+        stride,
+        capacity,
+    };
+    *offset = (*offset).checked_add(region.byte_len())?;
+    Some(region)
+}
+
+fn align(value: u32, alignment: u32) -> Option<u32> {
+    value
+        .checked_add(alignment - 1)
+        .map(|value| value / alignment * alignment)
+}

--- a/tests/gpu/webgpu.rs
+++ b/tests/gpu/webgpu.rs
@@ -1530,9 +1530,7 @@ fn software_renderer_tests_area_light_visibility() {
 
 #[test]
 fn hardware_and_software_diffuse_area_lights_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -1715,18 +1713,14 @@ fn explicit_backend_preference_does_not_fallback() {
 
 #[test]
 fn webgpu_prepare_accepts_validated_ir() {
-    let Some(mut renderer) = renderer_or_skip() else {
-        return;
-    };
+    let mut renderer = hardware_renderer();
     let executable = renderer.prepare(&minimal_scene()).unwrap();
     assert_eq!(executable.scene().version, &CURRENT_IR_VERSION);
 }
 
 #[test]
 fn webgpu_render_returns_a_pixel_buffer() {
-    let Some(mut renderer) = renderer_or_skip() else {
-        return;
-    };
+    let mut renderer = hardware_renderer();
     let scene = minimal_scene();
     let executable = renderer.prepare(&scene).unwrap();
     let output = renderer
@@ -1741,9 +1735,7 @@ fn webgpu_render_returns_a_pixel_buffer() {
 
 #[test]
 fn webgpu_render_rejects_invalid_sample_range() {
-    let Some(mut renderer) = renderer_or_skip() else {
-        return;
-    };
+    let mut renderer = hardware_renderer();
     let scene = minimal_scene();
     let executable = renderer.prepare(&scene).unwrap();
     assert!(matches!(
@@ -1758,15 +1750,10 @@ fn webgpu_render_rejects_invalid_sample_range() {
     ));
 }
 
-fn renderer_or_skip() -> Option<Renderer> {
-    match Renderer::new(&PrepareOptions::default()) {
-        Ok(renderer) => Some(renderer),
-        Err(pbrt_r4::gpu::webgpu::BackendError::MissingRayQueryFeature) => {
-            eprintln!("skipping hardware WebGPU test: adapter has no ray-query capability");
-            None
-        }
-        Err(error) => panic!("unexpected WebGPU initialization error: {error}"),
-    }
+fn hardware_renderer() -> Renderer {
+    Renderer::new(&PrepareOptions::default()).unwrap_or_else(|error| {
+        panic!("Hardware Ray Query is required for this WebGPU test: {error}")
+    })
 }
 
 #[test]
@@ -2034,25 +2021,24 @@ fn software_renderer_applies_v4_russian_roulette() {
 
 #[test]
 fn hardware_and_software_diffuse_indirect_bounce_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
     })
     .unwrap();
-    let scene = indirect_bounce_scene(2);
-    let hardware_scene = hardware.prepare(&scene).unwrap();
-    let software_scene = software.prepare(&scene).unwrap();
     let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
-    let hardware_output = hardware.render(&hardware_scene, &request).unwrap();
-    let software_output = software.render(&software_scene, &request).unwrap();
-    for (hardware_channel, software_channel) in hardware_output.rgb[0]
-        .into_iter()
-        .zip(software_output.rgb[0])
-    {
-        assert!((hardware_channel - software_channel).abs() < 1.0e-5);
+    for scene in [indirect_bounce_scene(2), roulette_bounce_scene(3, 17)] {
+        let hardware_scene = hardware.prepare(&scene).unwrap();
+        let software_scene = software.prepare(&scene).unwrap();
+        let hardware_output = hardware.render(&hardware_scene, &request).unwrap();
+        let software_output = software.render(&software_scene, &request).unwrap();
+        for (hardware_channel, software_channel) in hardware_output.rgb[0]
+            .into_iter()
+            .zip(software_output.rgb[0])
+        {
+            assert!((hardware_channel - software_channel).abs() < 1.0e-5);
+        }
     }
 }
 
@@ -2095,9 +2081,7 @@ fn software_renderer_rejects_zero_alpha_shadow_occluders() {
 
 #[test]
 fn hardware_and_software_independent_sample_ranges_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -2121,9 +2105,7 @@ fn hardware_and_software_independent_sample_ranges_match() {
 
 #[test]
 fn hardware_and_software_depth_of_field_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -2147,9 +2129,7 @@ fn hardware_and_software_depth_of_field_match() {
 
 #[test]
 fn hardware_and_software_point_light_shadows_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -2171,9 +2151,7 @@ fn hardware_and_software_point_light_shadows_match() {
 
 #[test]
 fn hardware_and_software_uniform_point_light_selection_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -2274,9 +2252,7 @@ fn software_renderer_preserves_uniform_sampler_pmf_with_infinite_light() {
 
 #[test]
 fn hardware_and_software_uniform_infinite_miss_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -2373,9 +2349,7 @@ fn software_renderer_evaluates_bump_map() {
 
 #[test]
 fn hardware_and_software_bump_map_results_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -2399,9 +2373,7 @@ fn hardware_and_software_bump_map_results_match() {
 
 #[test]
 fn hardware_and_software_normal_map_results_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -2582,9 +2554,7 @@ fn software_renderer_uses_bilinear_for_zero_ewa_differentials() {
 
 #[test]
 fn hardware_and_software_mipmap_lod_results_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -2613,9 +2583,7 @@ fn hardware_and_software_mipmap_lod_results_match() {
 
 #[test]
 fn hardware_and_software_modes_match_the_cpu_reference_scene() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -2637,9 +2605,7 @@ fn hardware_and_software_modes_match_the_cpu_reference_scene() {
 
 #[test]
 fn hardware_and_software_reverse_orientation_results_match() {
-    let Some(mut hardware) = renderer_or_skip() else {
-        return;
-    };
+    let mut hardware = hardware_renderer();
     let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()

--- a/tests/gpu_shader_composer.rs
+++ b/tests/gpu_shader_composer.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "webgpu")]
 
 use pbrt_r4::gpu::webgpu::shader::build_shader_set;
+use pbrt_r4::gpu::webgpu::shader::ShaderStageId;
 use pbrt_r4::gpu::webgpu::AccelerationMode;
 
 #[test]
@@ -14,6 +15,18 @@ fn built_in_shader_sources_are_deterministic_and_mode_specific() {
     assert!(hardware.source.contains("enable wgpu_ray_query;"));
     assert!(!software.source.contains("enable wgpu_ray_query;"));
     assert!(hardware.source.contains("BEGIN pbrt-r4 shader fragment"));
-    assert_eq!(hardware.entry_point, "main");
-    assert_eq!(software.entry_point, "main");
+    assert_eq!(
+        hardware
+            .stage(ShaderStageId::LegacyRender)
+            .unwrap()
+            .entry_point,
+        "main"
+    );
+    assert_eq!(
+        software
+            .stage(ShaderStageId::LegacyRender)
+            .unwrap()
+            .entry_point,
+        "main"
+    );
 }

--- a/tests/gpu_shader_composer.rs
+++ b/tests/gpu_shader_composer.rs
@@ -29,4 +29,54 @@ fn built_in_shader_sources_are_deterministic_and_mode_specific() {
             .entry_point,
         "main"
     );
+    assert_eq!(
+        hardware
+            .stage(ShaderStageId::GenerateCamera)
+            .unwrap()
+            .entry_point,
+        "generate_camera"
+    );
+    assert_eq!(
+        hardware
+            .stage(ShaderStageId::IntersectClosest)
+            .unwrap()
+            .entry_point,
+        "intersect_closest"
+    );
+    assert_eq!(
+        hardware
+            .stage(ShaderStageId::ShadeDiffusePoint)
+            .unwrap()
+            .entry_point,
+        "shade_diffuse_point"
+    );
+    assert_eq!(
+        hardware
+            .stage(ShaderStageId::IntersectShadow)
+            .unwrap()
+            .entry_point,
+        "intersect_shadow"
+    );
+    assert_eq!(
+        hardware
+            .stage(ShaderStageId::FinishBounce)
+            .unwrap()
+            .entry_point,
+        "finish_bounce"
+    );
+    assert_eq!(
+        hardware
+            .stage(ShaderStageId::UpdateFilm)
+            .unwrap()
+            .entry_point,
+        "update_film"
+    );
+    assert_eq!(
+        hardware
+            .stage(ShaderStageId::AdvanceSample)
+            .unwrap()
+            .entry_point,
+        "advance_sample"
+    );
+    assert!(software.stage(ShaderStageId::GenerateCamera).is_none());
 }

--- a/tests/gpu_wavefront.rs
+++ b/tests/gpu_wavefront.rs
@@ -1,0 +1,23 @@
+#![cfg(feature = "webgpu")]
+
+use pbrt_r4::gpu::webgpu::wavefront::{
+    WavefrontLayout, WAVEFRONT_CONTROL_SIZE, WAVEFRONT_SLOT_STRIDE,
+};
+
+#[test]
+fn fixed_slot_layout_is_checked_and_contiguous() {
+    let layout = WavefrontLayout::for_pixel_count(3).unwrap();
+
+    assert_eq!(layout.capacity, 3);
+    assert_eq!(
+        layout.byte_len,
+        WAVEFRONT_CONTROL_SIZE + 3 * WAVEFRONT_SLOT_STRIDE
+    );
+    assert_eq!(layout.slot_offset(0), Some(WAVEFRONT_CONTROL_SIZE));
+    assert_eq!(
+        layout.slot_offset(2),
+        Some(WAVEFRONT_CONTROL_SIZE + 2 * WAVEFRONT_SLOT_STRIDE)
+    );
+    assert_eq!(layout.slot_offset(3), None);
+    assert!(WavefrontLayout::for_pixel_count(u32::MAX).is_none());
+}

--- a/tests/gpu_webgpu_ply.rs
+++ b/tests/gpu_webgpu_ply.rs
@@ -1,0 +1,51 @@
+#![cfg(feature = "webgpu")]
+
+use pbrt_r4::gpu::ir::{GpuRenderConfig, GpuRenderRequest};
+use pbrt_r4::gpu::webgpu::{PrepareOptions, Renderer};
+use pbrt_r4::parser::{parse_string, SceneBuilder};
+
+#[test]
+fn hardware_wavefront_renders_a_plymesh_from_the_cpu_loader() {
+    let file = tempfile::Builder::new().suffix(".ply").tempfile().unwrap();
+    std::fs::write(
+        file.path(),
+        "ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\nproperty float y\nproperty float z\nelement face 1\nproperty list uchar int vertex_indices\nend_header\n-0.5 -0.5 0\n0.5 -0.5 0\n0 0.5 0\n3 0 1 2\n",
+    )
+    .unwrap();
+
+    let mut builder = SceneBuilder::new();
+    parse_string(
+        &format!(
+            r#"
+                Film "rgb" "integer xresolution" [1] "integer yresolution" [1]
+                Sampler "independent" "integer pixelsamples" [1]
+                PixelFilter "box"
+                Integrator "volpath" "integer maxdepth" [1]
+                LookAt 0 0 2 0 0 0 0 1 0
+                Camera "perspective" "float fov" [45]
+                WorldBegin
+                Material "diffuse" "rgb reflectance" [0.5 0.5 0.5]
+                LightSource "point" "point3 from" [0 0 2] "rgb I" [10 10 10]
+                Shape "plymesh" "string filename" ["{}"]
+                WorldEnd
+            "#,
+            file.path().display()
+        ),
+        &mut builder,
+    )
+    .unwrap();
+
+    let scene = builder.build_gpu_ir().unwrap();
+    let mut renderer = Renderer::new(&PrepareOptions::default()).unwrap_or_else(|error| {
+        panic!("Hardware Ray Query is required for this WebGPU test: {error}")
+    });
+    let executable = renderer.prepare(&scene).unwrap();
+    let output = renderer
+        .render(
+            &executable,
+            &GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(output.rgb.len(), 1);
+}


### PR DESCRIPTION
## Summary

- add the initial Hardware Ray Query wavefront execution path
- support triangle meshes, CPU-loaded PLY meshes, constant Diffuse, and one PointLight
- add shadow queries, multiple samples, Diffuse multiple bounces, and Russian roulette
- keep the wavefront arena ABI aligned with vec4-based GPU buffer records
- add Hardware GPU tests for the minimal scene and PLY input

## Verification

- `cargo fmt --all`
- `cargo check --features webgpu --tests`
- focused shader and wavefront ABI tests
- Hardware Vulkan Ray Query tests for sample accumulation, shadows, reverse orientation, multiple bounces, and PLY rendering
