### PR TITLE
feat(webgpu): add uniform and diffuse area lights to wavefront

### DIFF
--- a/src/gpu/webgpu/geometry.rs
+++ b/src/gpu/webgpu/geometry.rs
@@ -312,20 +312,39 @@ fn normal_transform(
 
 impl ScenePlan {
     pub fn supports_wavefront_min(&self, scene: GpuSceneView<'_>) -> bool {
-        matches!(
-            scene.lights,
-            [GpuLight::Point(_)] | [GpuLight::UniformInfinite(_)] | [GpuLight::DiffuseArea(_)]
-        ) && self.lights.len() == 1
-            && self.lights[0].kind <= 2
+        !scene.lights.is_empty()
+            && scene
+                .geometry
+                .iter()
+                .all(|geometry| matches!(geometry, GpuGeometry::TriangleMesh(_)))
+            && scene
+                .transforms
+                .iter()
+                .all(|transform| matches!(transform, GpuTransform::Static(_)))
+            && scene.images.iter().all(|image| image.mip_levels.len() <= 1)
+            && scene.lights.iter().all(|light| {
+                matches!(
+                    light,
+                    GpuLight::Point(_) | GpuLight::UniformInfinite(_) | GpuLight::DiffuseArea(_)
+                )
+            })
+            && self
+                .lights
+                .iter()
+                .take(
+                    self.lights
+                        .first()
+                        .map_or(0, |light| (light.flags >> 16) as usize),
+                )
+                .all(|light| light.kind <= 2)
             && self
                 .primitives
                 .iter()
                 .all(|primitive| primitive.alpha.is_none())
-            && self.materials.iter().all(|material| {
-                matches!(material.reflectance, MaterialReflectancePlan::Constant(_))
-                    && material.normal_map.is_none()
-                    && material.displacement.is_none()
-            })
+            && self
+                .materials
+                .iter()
+                .all(|material| material.normal_map.is_none() && material.displacement.is_none())
     }
 
     pub fn validate_custom_data(custom_data: u32) -> Result<(), PlanError> {
@@ -1050,13 +1069,8 @@ fn lower_lights(
     scene: GpuSceneView<'_>,
     area_light_occurrences: &[AreaLightOccurrence],
 ) -> Result<Vec<LightPlan>, BackendError> {
-    let mut lights = Vec::with_capacity(
-        scene
-            .lights
-            .len()
-            .saturating_add(area_light_occurrences.len())
-            .max(1),
-    );
+    let mut lights = Vec::with_capacity(scene.lights.len().max(1));
+    let mut area_sources = Vec::new();
     for (index, light) in scene.lights.iter().enumerate() {
         match light {
             GpuLight::Point(point) => {
@@ -1108,26 +1122,49 @@ fn lower_lights(
             GpuLight::DiffuseArea(area) => {
                 let light_id = LightId(index as u32);
                 let rgb = area_emission_rgb(scene, light_id)?;
-                for occurrence in area_light_occurrences
-                    .iter()
-                    .filter(|occurrence| occurrence.light == light_id)
-                {
-                    lights.push(LightPlan {
-                        position: [0.0; 4],
-                        intensity: [
-                            rgb[0] * area.scale,
-                            rgb[1] * area.scale,
-                            rgb[2] * area.scale,
-                            1.0,
-                        ],
-                        kind: 2,
-                        primitive: Some(occurrence.primitive),
-                        triangle: occurrence.triangle,
-                        flags: u32::from(area.two_sided)
-                            | (u32::from(occurrence.constant_zero_alpha) << 1),
-                    });
-                }
+                let source_index = checked_len(lights.len(), "light source table")?;
+                lights.push(LightPlan {
+                    position: [0.0; 4],
+                    intensity: [
+                        rgb[0] * area.scale,
+                        rgb[1] * area.scale,
+                        rgb[2] * area.scale,
+                        1.0,
+                    ],
+                    kind: 2,
+                    primitive: Some(0),
+                    triangle: 0,
+                    flags: u32::from(area.two_sided),
+                });
+                area_sources.push((source_index, light_id));
             }
+        }
+    }
+
+    let source_count = checked_len(lights.len(), "light source table")?;
+    for (source_index, light_id) in area_sources {
+        let geometry_offset = checked_len(lights.len(), "area light geometry table")?;
+        let mut geometry_count = 0u32;
+        let mut all_constant_zero_alpha = true;
+        for occurrence in area_light_occurrences
+            .iter()
+            .filter(|occurrence| occurrence.light == light_id)
+        {
+            all_constant_zero_alpha &= occurrence.constant_zero_alpha;
+            lights.push(LightPlan {
+                position: [0.0; 4],
+                intensity: [0.0; 4],
+                kind: 3,
+                primitive: Some(occurrence.primitive),
+                triangle: occurrence.triangle,
+                flags: u32::from(occurrence.constant_zero_alpha) << 1,
+            });
+            geometry_count += 1;
+        }
+        lights[source_index as usize].primitive = Some(geometry_offset);
+        lights[source_index as usize].triangle = geometry_count;
+        if geometry_count != 0 && all_constant_zero_alpha {
+            lights[source_index as usize].flags |= 1 << 1;
         }
     }
     if lights.is_empty() {
@@ -1139,6 +1176,16 @@ fn lower_lights(
             triangle: 0,
             flags: 0,
         });
+    }
+    if source_count > 0 {
+        if source_count > 0xffff {
+            return Err(BackendError::Plan(PlanError::LimitExceeded {
+                resource: "light source table",
+                value: source_count,
+                maximum: 0xffff,
+            }));
+        }
+        lights[0].flags |= source_count << 16;
     }
     Ok(lights)
 }

--- a/src/gpu/webgpu/geometry.rs
+++ b/src/gpu/webgpu/geometry.rs
@@ -312,9 +312,11 @@ fn normal_transform(
 
 impl ScenePlan {
     pub fn supports_wavefront_min(&self, scene: GpuSceneView<'_>) -> bool {
-        matches!(scene.lights, [GpuLight::Point(_)])
-            && self.lights.len() == 1
-            && self.lights[0].kind == 0
+        matches!(
+            scene.lights,
+            [GpuLight::Point(_)] | [GpuLight::UniformInfinite(_)] | [GpuLight::DiffuseArea(_)]
+        ) && self.lights.len() == 1
+            && self.lights[0].kind <= 2
             && self
                 .primitives
                 .iter()

--- a/src/gpu/webgpu/renderer.rs
+++ b/src/gpu/webgpu/renderer.rs
@@ -6,7 +6,11 @@ use super::geometry::{HardwareAcceleration, ScenePlan};
 use super::shader::{build_shader_set, ShaderStageId};
 use super::software::SoftwareAcceleration;
 use super::wavefront::WavefrontLayout;
+use std::time::{Duration, Instant};
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
+
+const WAVEFRONT_READBACK_SPP_INTERVAL: u32 = 8;
+const WAVEFRONT_READBACK_TIME_INTERVAL: Duration = Duration::from_secs(2);
 
 enum SceneResources {
     Hardware(HardwareAcceleration),
@@ -108,6 +112,16 @@ impl Renderer {
                 .ok_or(BackendError::Readback("output size overflow".to_string()))?,
         )
         .map_err(|_| BackendError::Readback("output size overflow".to_string()))?;
+        // The hardware wavefront index arena shares the film storage binding.
+        // One vec4 is reserved per index to keep concurrent writes independent.
+        // Ray A/B, classification queues, and the shadow queue each have a
+        // disjoint region in this index arena.
+        let queue_index_size = output_size
+            .checked_mul(6)
+            .ok_or_else(|| BackendError::Readback("ray queue index size overflow".to_string()))?;
+        let output_buffer_size = output_size
+            .checked_add(queue_index_size)
+            .ok_or_else(|| BackendError::Readback("film buffer size overflow".to_string()))?;
         let wavefront_layout = WavefrontLayout::for_pixel_count(
             u32::try_from(pixel_count)
                 .map_err(|_| BackendError::Readback("pixel count exceeds u32".to_string()))?,
@@ -141,7 +155,7 @@ impl Renderer {
             .device
             .create_buffer(&wgpu::BufferDescriptor {
                 label: Some("pbrt-r4 WebGPU film output"),
-                size: output_size,
+                size: output_buffer_size,
                 usage: wgpu::BufferUsages::STORAGE
                     | wgpu::BufferUsages::COPY_SRC
                     | wgpu::BufferUsages::COPY_DST,
@@ -156,13 +170,24 @@ impl Renderer {
                 usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
                 mapped_at_creation: false,
             });
+        let control_readback_buffer =
+            self.device_context
+                .device
+                .create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("pbrt-r4 WebGPU wavefront control readback"),
+                    size: u64::from(super::wavefront::WAVEFRONT_CONTROL_SIZE),
+                    usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                    mapped_at_creation: false,
+                });
         let wavefront_buffer = self
             .device_context
             .device
             .create_buffer(&wgpu::BufferDescriptor {
                 label: Some("pbrt-r4 WebGPU wavefront arena"),
                 size: u64::from(wavefront_layout.byte_len),
-                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::COPY_SRC,
                 mapped_at_creation: false,
             });
         let bind_group =
@@ -212,51 +237,39 @@ impl Renderer {
                     }),
             };
 
+        if use_wavefront_min {
+            let wavefront_workgroups = u32::try_from(pixel_count)
+                .map_err(|_| BackendError::Readback("pixel count exceeds u32".to_string()))?
+                .div_ceil(64);
+            return self.render_wavefront(
+                scene,
+                request,
+                pixel_bounds,
+                pixel_count,
+                output_size,
+                wavefront_workgroups,
+                &output_buffer,
+                &readback_buffer,
+                &control_readback_buffer,
+                &wavefront_buffer,
+                &bind_group,
+            );
+        }
+
         let mut encoder =
             self.device_context
                 .device
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("pbrt-r4 WebGPU dispatch"),
                 });
-        if use_wavefront_min {
-            encoder.clear_buffer(&output_buffer, 0, None);
-            encoder.clear_buffer(&wavefront_buffer, 0, None);
-        }
         {
             let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: Some("pbrt-r4 WebGPU render pass"),
                 timestamp_writes: None,
             });
-            if use_wavefront_min {
-                let wavefront_workgroups = u32::try_from(pixel_count)
-                    .map_err(|_| BackendError::Readback("pixel count exceeds u32".to_string()))?
-                    .div_ceil(64);
-                for sample_offset in 0..request.sample_count {
-                    pass.set_bind_group(0, &bind_group, &[]);
-                    pass.set_pipeline(self.pipeline.stage(ShaderStageId::GenerateCamera));
-                    pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
-                    for _ in 0..scene_view.render.integrator.max_depth {
-                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::IntersectClosest));
-                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
-                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::ShadeDiffusePoint));
-                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
-                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::IntersectShadow));
-                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
-                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::FinishBounce));
-                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
-                    }
-                    pass.set_pipeline(self.pipeline.stage(ShaderStageId::UpdateFilm));
-                    pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
-                    if sample_offset + 1 < request.sample_count {
-                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::AdvanceSample));
-                        pass.dispatch_workgroups(1, 1, 1);
-                    }
-                }
-            } else {
-                pass.set_bind_group(0, &bind_group, &[]);
-                pass.set_pipeline(self.pipeline.stage(ShaderStageId::LegacyRender));
-                pass.dispatch_workgroups(width.div_ceil(8), height.div_ceil(8), 1);
-            }
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.set_pipeline(self.pipeline.stage(ShaderStageId::LegacyRender));
+            pass.dispatch_workgroups(width.div_ceil(8), height.div_ceil(8), 1);
         }
         encoder.copy_buffer_to_buffer(&output_buffer, 0, &readback_buffer, 0, output_size);
         self.device_context.queue.submit(Some(encoder.finish()));
@@ -287,6 +300,179 @@ impl Renderer {
         readback_buffer.unmap();
         GpuRenderOutput::new(pixel_bounds, rgb.into_boxed_slice(), request)
             .map_err(|error| BackendError::Readback(format!("invalid render output: {error:?}")))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn render_wavefront(
+        &self,
+        scene: &ExecutableScene,
+        request: GpuRenderRequest,
+        pixel_bounds: super::super::ir::GpuBounds2i,
+        pixel_count: usize,
+        output_size: wgpu::BufferAddress,
+        wavefront_workgroups: u32,
+        output_buffer: &wgpu::Buffer,
+        readback_buffer: &wgpu::Buffer,
+        control_readback_buffer: &wgpu::Buffer,
+        wavefront_buffer: &wgpu::Buffer,
+        bind_group: &wgpu::BindGroup,
+    ) -> Result<GpuRenderOutput, BackendError> {
+        let mut sample_offset = 0u32;
+        let mut samples_since_readback = 0u32;
+        let mut last_readback = Instant::now();
+        let mut latest_rgb = None;
+
+        while sample_offset < request.sample_count {
+            let mut encoder = self.device_context.device.create_command_encoder(
+                &wgpu::CommandEncoderDescriptor {
+                    label: Some("pbrt-r4 WebGPU wavefront dispatch"),
+                },
+            );
+            if sample_offset == 0 {
+                encoder.clear_buffer(output_buffer, 0, None);
+                encoder.clear_buffer(wavefront_buffer, 0, None);
+            }
+            let mut batch_count = 0u32;
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("pbrt-r4 WebGPU wavefront pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_bind_group(0, bind_group, &[]);
+                while sample_offset < request.sample_count {
+                    pass.set_pipeline(self.pipeline.stage(ShaderStageId::PrepareCameraRays));
+                    pass.dispatch_workgroups(1, 1, 1);
+                    pass.set_pipeline(self.pipeline.stage(ShaderStageId::GenerateCameraRays));
+                    pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                    for _ in 0..=scene.scene().render.integrator.max_depth {
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::IntersectClosest));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::ClassifyIntersection));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(
+                            self.pipeline
+                                .stage(ShaderStageId::EvaluateSurfaceInteraction),
+                        );
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::EvaluateMaterial));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::RegisterBxdf));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::CountBxdf));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::PartitionBxdf));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::SampleDirectLighting));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::GenerateIndirectRays));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::HandleEscapedRays));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(
+                            self.pipeline
+                                .stage(ShaderStageId::HandleEmissiveIntersection),
+                        );
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::IntersectShadow));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::FinishBounce));
+                        pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::PrepareNextBounce));
+                        pass.dispatch_workgroups(1, 1, 1);
+                    }
+                    pass.set_pipeline(self.pipeline.stage(ShaderStageId::UpdateFilm));
+                    pass.dispatch_workgroups(wavefront_workgroups, 1, 1);
+                    if sample_offset + 1 < request.sample_count {
+                        pass.set_pipeline(self.pipeline.stage(ShaderStageId::AdvanceSample));
+                        pass.dispatch_workgroups(1, 1, 1);
+                    }
+                    sample_offset += 1;
+                    batch_count += 1;
+                    samples_since_readback += 1;
+                    if sample_offset == request.sample_count
+                        || samples_since_readback >= WAVEFRONT_READBACK_SPP_INTERVAL
+                        || last_readback.elapsed() >= WAVEFRONT_READBACK_TIME_INTERVAL
+                    {
+                        break;
+                    }
+                }
+            }
+            encoder.copy_buffer_to_buffer(output_buffer, 0, readback_buffer, 0, output_size);
+            encoder.copy_buffer_to_buffer(
+                wavefront_buffer,
+                0,
+                control_readback_buffer,
+                0,
+                u64::from(super::wavefront::WAVEFRONT_CONTROL_SIZE),
+            );
+            self.device_context.queue.submit(Some(encoder.finish()));
+            latest_rgb =
+                Some(self.readback_film(readback_buffer, control_readback_buffer, pixel_count)?);
+            samples_since_readback = 0;
+            last_readback = Instant::now();
+            debug_assert!(batch_count > 0);
+        }
+
+        let rgb = latest_rgb.ok_or_else(|| {
+            BackendError::Readback("wavefront produced no film readback".to_string())
+        })?;
+        GpuRenderOutput::new(pixel_bounds, rgb.into_boxed_slice(), request)
+            .map_err(|error| BackendError::Readback(format!("invalid render output: {error:?}")))
+    }
+
+    fn readback_film(
+        &self,
+        readback_buffer: &wgpu::Buffer,
+        control_readback_buffer: &wgpu::Buffer,
+        pixel_count: usize,
+    ) -> Result<Vec<[f32; 3]>, BackendError> {
+        let mapped = readback_buffer.slice(..);
+        let control_mapped = control_readback_buffer.slice(..);
+        let (sender, receiver) = std::sync::mpsc::sync_channel(2);
+        let output_sender = sender.clone();
+        mapped.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = output_sender.send((0u8, result.map_err(|error| error.to_string())));
+        });
+        control_mapped.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = sender.send((1u8, result.map_err(|error| error.to_string())));
+        });
+        self.device_context
+            .device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .map_err(|error| BackendError::Readback(error.to_string()))?;
+        for _ in 0..2 {
+            let (_, result) = receiver
+                .recv()
+                .map_err(|error| BackendError::Readback(error.to_string()))?;
+            result.map_err(BackendError::Readback)?;
+        }
+        let control_bytes = control_mapped
+            .get_mapped_range()
+            .map_err(|error| BackendError::Readback(error.to_string()))?;
+        let control = bytemuck::try_cast_slice::<u8, u32>(&control_bytes)
+            .map_err(|error| BackendError::Readback(error.to_string()))?;
+        let overflow = control.get(3).copied().unwrap_or_default() != 0;
+        drop(control_bytes);
+        control_readback_buffer.unmap();
+        if overflow {
+            readback_buffer.unmap();
+            return Err(BackendError::Readback(
+                "WebGPU wavefront queue overflow".to_string(),
+            ));
+        }
+        let bytes = mapped
+            .get_mapped_range()
+            .map_err(|error| BackendError::Readback(error.to_string()))?;
+        let pixels = bytemuck::try_cast_slice::<u8, [f32; 4]>(&bytes)
+            .map_err(|error| BackendError::Readback(error.to_string()))?;
+        let rgb = pixels
+            .iter()
+            .take(pixel_count)
+            .map(|pixel| [pixel[0], pixel[1], pixel[2]])
+            .collect();
+        drop(bytes);
+        readback_buffer.unmap();
+        Ok(rgb)
     }
 
     pub fn adapter_info(&self) -> wgpu::AdapterInfo {

--- a/src/gpu/webgpu/shader/mod.rs
+++ b/src/gpu/webgpu/shader/mod.rs
@@ -5,9 +5,20 @@ use super::device::AccelerationMode;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ShaderStageId {
     LegacyRender,
-    GenerateCamera,
+    PrepareCameraRays,
+    GenerateCameraRays,
     IntersectClosest,
-    ShadeDiffusePoint,
+    ClassifyIntersection,
+    EvaluateSurfaceInteraction,
+    EvaluateMaterial,
+    RegisterBxdf,
+    CountBxdf,
+    PartitionBxdf,
+    SampleDirectLighting,
+    GenerateIndirectRays,
+    HandleEscapedRays,
+    HandleEmissiveIntersection,
+    PrepareNextBounce,
     IntersectShadow,
     FinishBounce,
     UpdateFilm,
@@ -184,16 +195,60 @@ pub fn build_shader_set(mode: AccelerationMode) -> Result<ShaderSet, ShaderBuild
                     entry_point: "main",
                 },
                 ShaderStage {
-                    id: ShaderStageId::GenerateCamera,
-                    entry_point: "generate_camera",
+                    id: ShaderStageId::PrepareCameraRays,
+                    entry_point: "prepare_camera_rays",
+                },
+                ShaderStage {
+                    id: ShaderStageId::GenerateCameraRays,
+                    entry_point: "generate_camera_rays",
                 },
                 ShaderStage {
                     id: ShaderStageId::IntersectClosest,
                     entry_point: "intersect_closest",
                 },
                 ShaderStage {
-                    id: ShaderStageId::ShadeDiffusePoint,
-                    entry_point: "shade_diffuse_point",
+                    id: ShaderStageId::ClassifyIntersection,
+                    entry_point: "classify_intersection",
+                },
+                ShaderStage {
+                    id: ShaderStageId::EvaluateSurfaceInteraction,
+                    entry_point: "evaluate_surface_interaction",
+                },
+                ShaderStage {
+                    id: ShaderStageId::EvaluateMaterial,
+                    entry_point: "evaluate_material",
+                },
+                ShaderStage {
+                    id: ShaderStageId::RegisterBxdf,
+                    entry_point: "register_bxdf",
+                },
+                ShaderStage {
+                    id: ShaderStageId::CountBxdf,
+                    entry_point: "count_bxdf",
+                },
+                ShaderStage {
+                    id: ShaderStageId::PartitionBxdf,
+                    entry_point: "partition_bxdf",
+                },
+                ShaderStage {
+                    id: ShaderStageId::SampleDirectLighting,
+                    entry_point: "sample_direct_lighting",
+                },
+                ShaderStage {
+                    id: ShaderStageId::GenerateIndirectRays,
+                    entry_point: "generate_indirect_rays",
+                },
+                ShaderStage {
+                    id: ShaderStageId::HandleEscapedRays,
+                    entry_point: "handle_escaped_rays",
+                },
+                ShaderStage {
+                    id: ShaderStageId::HandleEmissiveIntersection,
+                    entry_point: "handle_emissive_intersection",
+                },
+                ShaderStage {
+                    id: ShaderStageId::PrepareNextBounce,
+                    entry_point: "prepare_next_bounce",
                 },
                 ShaderStage {
                     id: ShaderStageId::IntersectShadow,

--- a/src/gpu/webgpu/shaders/common/area_geometry.wgsl
+++ b/src/gpu/webgpu/shaders/common/area_geometry.wgsl
@@ -3,42 +3,64 @@ struct AreaLightSample {
     normal: vec3<f32>,
     uv: vec2<f32>,
     pdf: f32,
+    geometry: Light,
     valid: bool,
 };
 
-fn area_light_triangle(light: Light) -> array<vec3<f32>, 3> {
-    let primitive = primitives[light.primitive];
-    let index_offset = primitive.first_index + light.triangle * 3u;
-    let transform_table = transforms[light.primitive];
+fn light_source_count() -> u32 {
+    if (arrayLength(&lights) == 0u) {
+        return 0u;
+    }
+    return min(lights[0].flags >> 16u, arrayLength(&lights));
+}
+
+fn area_light_geometry(source: Light, geometry_index: u32) -> Light {
+    return lights[source.primitive + geometry_index];
+}
+
+fn area_light_geometry_for_triangle(source: Light, triangle: u32) -> Light {
+    for (var index = 0u; index < source.triangle; index += 1u) {
+        let geometry = area_light_geometry(source, index);
+        if (geometry.triangle == triangle) {
+            return geometry;
+        }
+    }
+    return Light(vec4<f32>(0.0), vec4<f32>(0.0), 3u, 0u, 0u, 0u);
+}
+
+fn area_light_triangle(geometry: Light) -> array<vec3<f32>, 3> {
+    let primitive = primitives[geometry.primitive];
+    let index_offset = primitive.first_index + geometry.triangle * 3u;
+    let transform_table = transforms[geometry.primitive];
     let p0 = transform(transform_table.render_from_object, vertices[primitive.first_vertex + indices[index_offset]].position).xyz;
     let p1 = transform(transform_table.render_from_object, vertices[primitive.first_vertex + indices[index_offset + 1u]].position).xyz;
     let p2 = transform(transform_table.render_from_object, vertices[primitive.first_vertex + indices[index_offset + 2u]].position).xyz;
     return array<vec3<f32>, 3>(p0, p1, p2);
 }
 
-fn area_light_uv(light: Light, barycentrics: vec3<f32>) -> vec2<f32> {
-    let primitive = primitives[light.primitive];
-    let index_offset = primitive.first_index + light.triangle * 3u;
+fn area_light_uv(geometry: Light, barycentrics: vec3<f32>) -> vec2<f32> {
+    let primitive = primitives[geometry.primitive];
+    let index_offset = primitive.first_index + geometry.triangle * 3u;
     let uv0 = vertices[primitive.first_vertex + indices[index_offset]].uv.xy;
     let uv1 = vertices[primitive.first_vertex + indices[index_offset + 1u]].uv.xy;
     let uv2 = vertices[primitive.first_vertex + indices[index_offset + 2u]].uv.xy;
     return uv0 * barycentrics.x + uv1 * barycentrics.y + uv2 * barycentrics.z;
 }
 
-fn area_light_normal(light: Light, barycentrics: vec3<f32>, triangle: array<vec3<f32>, 3>) -> vec3<f32> {
-    let primitive = primitives[light.primitive];
+fn area_light_normal(geometry: Light, barycentrics: vec3<f32>, triangle: array<vec3<f32>, 3>) -> vec3<f32> {
+    let primitive = primitives[geometry.primitive];
     var normal = normalize(cross(triangle[1] - triangle[0], triangle[2] - triangle[0]));
     if ((primitive.flags & 1u) != 0u) {
         normal = -normal;
     }
-    let index_offset = primitive.first_index + light.triangle * 3u;
+    let index_offset = primitive.first_index + geometry.triangle * 3u;
     let n0 = vertices[primitive.first_vertex + indices[index_offset]].normal.xyz;
     let n1 = vertices[primitive.first_vertex + indices[index_offset + 1u]].normal.xyz;
     let n2 = vertices[primitive.first_vertex + indices[index_offset + 2u]].normal.xyz;
     var shading_normal = n0 * barycentrics.x + n1 * barycentrics.y + n2 * barycentrics.z;
     if (dot(shading_normal, shading_normal) > 1.0e-20) {
         let orientation_sign = select(1.0, -1.0, (primitive.flags & 1u) != 0u);
-        shading_normal = normalize(transform(transforms[light.primitive].normal_from_object, vec4<f32>(orientation_sign * shading_normal, 0.0)).xyz);
+        shading_normal = normalize(transform(transforms[geometry.primitive].normal_from_object, vec4<f32>(orientation_sign * shading_normal, 0.0)).xyz);
         if (dot(normal, shading_normal) < 0.0) {
             normal = -normal;
         }

--- a/src/gpu/webgpu/shaders/common/area_sampling.wgsl
+++ b/src/gpu/webgpu/shaders/common/area_sampling.wgsl
@@ -157,42 +157,77 @@ fn sample_uniform_triangle(u: vec2<f32>) -> vec3<f32> {
     return vec3<f32>(b0, b1, 1.0 - b0 - b1);
 }
 
+fn area_light_total_area(source: Light) -> f32 {
+    var total = 0.0;
+    for (var index = 0u; index < source.triangle; index += 1u) {
+        let geometry = area_light_geometry(source, index);
+        let triangle = area_light_triangle(geometry);
+        total += 0.5 * length(cross(triangle[1] - triangle[0], triangle[2] - triangle[0]));
+    }
+    return total;
+}
+
+// Returns geometry index, local x coordinate, and geometry selection PDF.
+fn area_light_select_geometry(source: Light, u: f32) -> vec3<f32> {
+    let total_area = area_light_total_area(source);
+    if (source.triangle == 0u || total_area == 0.0) {
+        return vec3<f32>(0.0, 0.0, 0.0);
+    }
+    let sample_position = min(u, 0.9999999403953552) * total_area;
+    var accumulated = 0.0;
+    for (var index = 0u; index < source.triangle; index += 1u) {
+        let geometry = area_light_geometry(source, index);
+        let triangle = area_light_triangle(geometry);
+        let area = 0.5 * length(cross(triangle[1] - triangle[0], triangle[2] - triangle[0]));
+        if (sample_position <= accumulated + area || index + 1u == source.triangle) {
+            let local_x = select(0.0, (sample_position - accumulated) / area, area > 0.0);
+            return vec3<f32>(f32(index), clamp(local_x, 0.0, 0.9999999403953552), area / total_area);
+        }
+        accumulated += area;
+    }
+    return vec3<f32>(0.0, 0.0, 0.0);
+}
+
 fn sample_area_light_uniform(light: Light, context_position: vec3<f32>, u: vec2<f32>) -> AreaLightSample {
-    let triangle = area_light_triangle(light);
-    let barycentrics = sample_uniform_triangle(u);
+    let selection = area_light_select_geometry(light, u.x);
+    let geometry = area_light_geometry(light, u32(selection.x));
+    let triangle = area_light_triangle(geometry);
+    let barycentrics = sample_uniform_triangle(vec2<f32>(selection.y, u.y));
     let position = triangle[0] * barycentrics.x + triangle[1] * barycentrics.y + triangle[2] * barycentrics.z;
-    let normal = area_light_normal(light, barycentrics, triangle);
+    let normal = area_light_normal(geometry, barycentrics, triangle);
     let to_light = position - context_position;
     let distance_squared = dot(to_light, to_light);
     let area = 0.5 * length(cross(triangle[1] - triangle[0], triangle[2] - triangle[0]));
     if (distance_squared == 0.0 || area == 0.0) {
-        return AreaLightSample(position, normal, vec2<f32>(0.0), 0.0, false);
+        return AreaLightSample(position, normal, vec2<f32>(0.0), 0.0, geometry, false);
     }
     let wi = normalize(to_light);
     let cosine = abs(dot(normal, -wi));
     if (cosine == 0.0) {
-        return AreaLightSample(position, normal, vec2<f32>(0.0), 0.0, false);
+        return AreaLightSample(position, normal, vec2<f32>(0.0), 0.0, geometry, false);
     }
-    let pdf = distance_squared / (cosine * area);
+    let pdf = distance_squared / (cosine * area) * selection.z;
     let emitted = (light.flags & 1u) != 0u || dot(normal, -wi) >= 0.0;
     return AreaLightSample(
         position,
         normal,
-        area_light_uv(light, barycentrics),
+        area_light_uv(geometry, barycentrics),
         pdf,
+        geometry,
         emitted && pdf >= 0.0 && pdf <= 3.402823466e38,
     );
 }
 
-fn area_light_uniform_pdf(light: Light, context_position: vec3<f32>, hit_position: vec3<f32>, wi: vec3<f32>) -> f32 {
-    let triangle = area_light_triangle(light);
-    let normal = area_light_normal(light, vec3<f32>(1.0 / 3.0), triangle);
+fn area_light_uniform_pdf(source: Light, geometry: Light, context_position: vec3<f32>, hit_position: vec3<f32>, wi: vec3<f32>) -> f32 {
+    let triangle = area_light_triangle(geometry);
+    let normal = area_light_normal(geometry, vec3<f32>(1.0 / 3.0), triangle);
     let area = 0.5 * length(cross(triangle[1] - triangle[0], triangle[2] - triangle[0]));
+    let total_area = area_light_total_area(source);
     let cosine = abs(dot(normal, -wi));
     if (area == 0.0 || cosine == 0.0) {
         return 0.0;
     }
-    return dot(hit_position - context_position, hit_position - context_position) / (cosine * area);
+    return dot(hit_position - context_position, hit_position - context_position) / (cosine * total_area);
 }
 fn sample_area_light(
     light: Light,
@@ -200,12 +235,15 @@ fn sample_area_light(
     context_shading_normal: vec3<f32>,
     u: vec2<f32>,
 ) -> AreaLightSample {
-    let triangle = area_light_triangle(light);
+    let selection = area_light_select_geometry(light, u.x);
+    let geometry = area_light_geometry(light, u32(selection.x));
+    let triangle = area_light_triangle(geometry);
+    let local_u = vec2<f32>(selection.y, u.y);
     let solid_angle = area_light_solid_angle(triangle, context_position);
     if (solid_angle < 3.0e-4 || solid_angle > 6.22) {
         return sample_area_light_uniform(light, context_position, u);
     }
-    var warped_u = u;
+    var warped_u = local_u;
     var warp_pdf = 1.0;
     if (dot(context_shading_normal, context_shading_normal) != 0.0) {
         let weights = area_light_warp_weights(
@@ -213,41 +251,48 @@ fn sample_area_light(
             context_position,
             context_shading_normal,
         );
-        warped_u = sample_bilinear(u, weights);
+        warped_u = sample_bilinear(local_u, weights);
         warp_pdf = bilinear_pdf(warped_u, weights);
     }
     let spherical_sample = sample_spherical_triangle(triangle, context_position, warped_u);
     if (!spherical_sample.valid || spherical_sample.pdf == 0.0) {
-        return AreaLightSample(vec3<f32>(0.0), vec3<f32>(0.0), vec2<f32>(0.0), 0.0, false);
+        return AreaLightSample(vec3<f32>(0.0), vec3<f32>(0.0), vec2<f32>(0.0), 0.0, geometry, false);
     }
     let barycentrics = spherical_sample.barycentrics;
     let position = triangle[0] * barycentrics.x
         + triangle[1] * barycentrics.y
         + triangle[2] * barycentrics.z;
-    let normal = area_light_normal(light, barycentrics, triangle);
+    let normal = area_light_normal(geometry, barycentrics, triangle);
     let wi = normalize(position - context_position);
     let emitted = (light.flags & 1u) != 0u || dot(normal, -wi) >= 0.0;
     return AreaLightSample(
         position,
         normal,
-        area_light_uv(light, barycentrics),
-        spherical_sample.pdf * warp_pdf,
+        area_light_uv(geometry, barycentrics),
+        spherical_sample.pdf * warp_pdf * selection.z,
+        geometry,
         emitted,
     );
 }
 
 fn area_light_pdf(
-    light: Light,
+    source: Light,
     context_position: vec3<f32>,
     context_shading_normal: vec3<f32>,
     hit_position: vec3<f32>,
     direction: vec3<f32>,
+    triangle_index: u32,
 ) -> f32 {
-    let triangle = area_light_triangle(light);
+    let geometry = area_light_geometry_for_triangle(source, triangle_index);
+    let triangle = area_light_triangle(geometry);
+    let total_area = area_light_total_area(source);
+    let geometry_area = 0.5 * length(cross(triangle[1] - triangle[0], triangle[2] - triangle[0]));
+    let selection_pdf = select(0.0, geometry_area / total_area, total_area > 0.0);
     let solid_angle = area_light_solid_angle(triangle, context_position);
     if (solid_angle < 3.0e-4 || solid_angle > 6.22) {
         return area_light_uniform_pdf(
-            light,
+            source,
+            geometry,
             context_position,
             hit_position,
             direction,
@@ -267,5 +312,5 @@ fn area_light_pdf(
         );
         pdf *= bilinear_pdf(u, weights);
     }
-    return pdf;
+    return pdf * selection_pdf;
 }

--- a/src/gpu/webgpu/shaders/common/emission.wgsl
+++ b/src/gpu/webgpu/shaders/common/emission.wgsl
@@ -1,8 +1,13 @@
 fn find_area_light(primitive: u32, triangle: u32) -> u32 {
-    for (var light_index = 0u; light_index < arrayLength(&lights); light_index += 1u) {
+    for (var light_index = 0u; light_index < light_source_count(); light_index += 1u) {
         let light = lights[light_index];
-        if (light.kind == 2u && light.primitive == primitive && light.triangle == triangle) {
-            return light_index;
+        if (light.kind == 2u) {
+            for (var geometry_index = 0u; geometry_index < light.triangle; geometry_index += 1u) {
+                let geometry = area_light_geometry(light, geometry_index);
+                if (geometry.primitive == primitive && geometry.triangle == triangle) {
+                    return light_index;
+                }
+            }
         }
     }
     return 0xffffffffu;
@@ -24,11 +29,11 @@ fn murmur_hash_float_position(position: vec3<f32>) -> f32 {
     return f32(hash.x) * 2.3283064365386963e-10;
 }
 
-fn area_light_alpha_accept(light: Light, uv: vec2<f32>, position: vec3<f32>) -> bool {
-    if ((light.flags & 2u) != 0u) {
+fn area_light_alpha_accept(geometry: Light, uv: vec2<f32>, position: vec3<f32>) -> bool {
+    if ((geometry.flags & 2u) != 0u) {
         return true;
     }
-    let primitive = primitives[light.primitive];
+    let primitive = primitives[geometry.primitive];
     if (primitive.alpha == 0xffffffffu) {
         return true;
     }
@@ -44,7 +49,7 @@ fn area_light_alpha_accept(light: Light, uv: vec2<f32>, position: vec3<f32>) -> 
 
 fn infinite_emission() -> vec3<f32> {
     var emission = vec3<f32>(0.0);
-    for (var light_index = 0u; light_index < arrayLength(&lights); light_index += 1u) {
+    for (var light_index = 0u; light_index < light_source_count(); light_index += 1u) {
         let light = lights[light_index];
         if (light.kind == 1u) {
             emission += light.intensity.xyz;

--- a/src/gpu/webgpu/shaders/common/wavefront.wgsl
+++ b/src/gpu/webgpu/shaders/common/wavefront.wgsl
@@ -2,6 +2,7 @@ const WAVEFRONT_STATE_INACTIVE: u32 = 0u;
 const WAVEFRONT_STATE_RAY: u32 = 1u;
 const WAVEFRONT_STATE_MISS: u32 = 2u;
 const WAVEFRONT_STATE_HIT: u32 = 3u;
+const WAVEFRONT_STATE_EMISSIVE: u32 = 4u;
 
 struct WavefrontSlot {
     ray_origin: vec4<f32>,
@@ -14,12 +15,118 @@ struct WavefrontSlot {
     radiance: vec4<f32>,
     throughput: vec4<f32>,
     path_info: vec4<u32>,
+    surface_position: vec4<f32>,
+    surface_position_error: vec4<f32>,
+    surface_geometric_normal: vec4<f32>,
+    surface_shading_normal: vec4<f32>,
+    surface_uv: vec4<f32>,
+    previous_surface_position: vec4<f32>,
+    previous_surface_shading_normal: vec4<f32>,
+    previous_bsdf_pdf: vec4<f32>,
+    material_parameters: vec4<f32>,
+};
+
+struct WavefrontControl {
+    sample_index: u32,
+    active_count: atomic<u32>,
+    next_count: atomic<u32>,
+    overflow: atomic<u32>,
+};
+
+struct WavefrontQueueHeader {
+    count: atomic<u32>,
+    capacity: u32,
+    offset: u32,
+    overflow: atomic<u32>,
 };
 
 struct WavefrontArena {
-    control: vec4<u32>,
+    control: WavefrontControl,
+    ray_queue_a: WavefrontQueueHeader,
+    ray_queue_b: WavefrontQueueHeader,
+    escaped_ray_queue: WavefrontQueueHeader,
+    hit_area_light_queue: WavefrontQueueHeader,
+    surface_queue: WavefrontQueueHeader,
+    shadow_queue: WavefrontQueueHeader,
     slots: array<WavefrontSlot>,
 };
 
 @group(0) @binding(10)
 var<storage, read_write> wavefront: WavefrontArena;
+
+// The index arena shares binding 1 with the film buffer. Each queue index uses
+// one vec4 slot. Ray, classification, and shadow queues use disjoint regions
+// so their work items can coexist between stage dispatches. The regions are
+// reused after prepare_next_bounce resets the classification and shadow queues.
+fn wavefront_queue_index_base() -> u32 {
+    return u32(camera.viewport.z * camera.viewport.w);
+}
+
+fn wavefront_queue_index(queue_offset: u32) -> u32 {
+    return bitcast<vec4<u32>>(output[wavefront_queue_index_base() + queue_offset]).x;
+}
+
+fn wavefront_store_queue_index(queue_offset: u32, slot_index: u32) {
+    output[wavefront_queue_index_base() + queue_offset] = vec4<f32>(
+        bitcast<f32>(slot_index),
+        0.0,
+        0.0,
+        0.0,
+    );
+}
+
+fn wavefront_shadow_queue_index(queue_index: u32) -> u32 {
+    return wavefront_queue_index(wavefront.shadow_queue.offset + queue_index);
+}
+
+fn wavefront_escaped_ray_queue_index(queue_index: u32) -> u32 {
+    return wavefront_queue_index(wavefront.escaped_ray_queue.offset + queue_index);
+}
+
+fn wavefront_hit_area_light_queue_index(queue_index: u32) -> u32 {
+    return wavefront_queue_index(wavefront.hit_area_light_queue.offset + queue_index);
+}
+
+fn wavefront_surface_queue_index(queue_index: u32) -> u32 {
+    return wavefront_queue_index(wavefront.surface_queue.offset + queue_index);
+}
+
+fn wavefront_enqueue_escaped_ray(slot_index: u32) {
+    let queue_index = atomicAdd(&wavefront.escaped_ray_queue.count, 1u);
+    if (queue_index >= wavefront.escaped_ray_queue.capacity) {
+        atomicStore(&wavefront.escaped_ray_queue.overflow, 1u);
+        atomicStore(&wavefront.control.overflow, 1u);
+    } else {
+        wavefront_store_queue_index(wavefront.escaped_ray_queue.offset + queue_index, slot_index);
+    }
+}
+
+fn wavefront_enqueue_hit_area_light(slot_index: u32) {
+    let queue_index = atomicAdd(&wavefront.hit_area_light_queue.count, 1u);
+    if (queue_index >= wavefront.hit_area_light_queue.capacity) {
+        atomicStore(&wavefront.hit_area_light_queue.overflow, 1u);
+        atomicStore(&wavefront.control.overflow, 1u);
+    } else {
+        wavefront_store_queue_index(wavefront.hit_area_light_queue.offset + queue_index, slot_index);
+    }
+}
+
+fn wavefront_enqueue_surface(slot_index: u32) {
+    let queue_index = atomicAdd(&wavefront.surface_queue.count, 1u);
+    if (queue_index >= wavefront.surface_queue.capacity) {
+        atomicStore(&wavefront.surface_queue.overflow, 1u);
+        atomicStore(&wavefront.control.overflow, 1u);
+    } else {
+        wavefront_store_queue_index(wavefront.surface_queue.offset + queue_index, slot_index);
+    }
+}
+
+fn wavefront_enqueue_shadow(slot_index: u32) {
+    let queue_index = atomicAdd(&wavefront.shadow_queue.count, 1u);
+    if (queue_index >= wavefront.shadow_queue.capacity) {
+        atomicStore(&wavefront.shadow_queue.overflow, 1u);
+        atomicStore(&wavefront.control.overflow, 1u);
+    } else {
+        wavefront_store_queue_index(wavefront.shadow_queue.offset + queue_index, slot_index);
+    }
+}

--- a/src/gpu/webgpu/shaders/entry/wavefront.wgsl
+++ b/src/gpu/webgpu/shaders/entry/wavefront.wgsl
@@ -2,8 +2,42 @@ fn wavefront_pixel_index(global_id: vec3<u32>) -> u32 {
     return global_id.x;
 }
 
+@compute @workgroup_size(1)
+fn prepare_camera_rays(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    if (global_id.x == 0u) {
+        let pixel_count = u32(camera.viewport.z * camera.viewport.w);
+        wavefront.ray_queue_a.capacity = pixel_count;
+        wavefront.ray_queue_b.capacity = pixel_count;
+        wavefront.escaped_ray_queue.capacity = pixel_count;
+        wavefront.hit_area_light_queue.capacity = pixel_count;
+        wavefront.surface_queue.capacity = pixel_count;
+        wavefront.ray_queue_a.offset = 0u;
+        wavefront.ray_queue_b.offset = pixel_count;
+        wavefront.escaped_ray_queue.offset = pixel_count * 2u;
+        wavefront.hit_area_light_queue.offset = pixel_count * 3u;
+        wavefront.surface_queue.offset = pixel_count * 4u;
+        wavefront.shadow_queue.capacity = pixel_count;
+        wavefront.shadow_queue.offset = pixel_count * 5u;
+        atomicStore(&wavefront.ray_queue_a.count, pixel_count);
+        atomicStore(&wavefront.ray_queue_b.count, 0u);
+        atomicStore(&wavefront.escaped_ray_queue.count, 0u);
+        atomicStore(&wavefront.hit_area_light_queue.count, 0u);
+        atomicStore(&wavefront.surface_queue.count, 0u);
+        atomicStore(&wavefront.shadow_queue.count, 0u);
+        atomicStore(&wavefront.ray_queue_a.overflow, 0u);
+        atomicStore(&wavefront.ray_queue_b.overflow, 0u);
+        atomicStore(&wavefront.escaped_ray_queue.overflow, 0u);
+        atomicStore(&wavefront.hit_area_light_queue.overflow, 0u);
+        atomicStore(&wavefront.surface_queue.overflow, 0u);
+        atomicStore(&wavefront.shadow_queue.overflow, 0u);
+        atomicStore(&wavefront.control.active_count, pixel_count);
+        atomicStore(&wavefront.control.next_count, 0u);
+        atomicStore(&wavefront.control.overflow, 0u);
+    }
+}
+
 @compute @workgroup_size(64)
-fn generate_camera(@builtin(global_invocation_id) global_id: vec3<u32>) {
+fn generate_camera_rays(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let index = wavefront_pixel_index(global_id);
     let width = u32(camera.viewport.z);
     let height = u32(camera.viewport.w);
@@ -14,7 +48,7 @@ fn generate_camera(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     let local_pixel = vec2<u32>(index % width, index / width);
     let pixel = vec2<i32>(local_pixel) + vec2<i32>(camera.viewport.xy);
-    let sample_index = camera.sampler_info.z + wavefront.control.x;
+    let sample_index = camera.sampler_info.z + wavefront.control.sample_index;
     let camera_sample = independent_camera_sample(pixel, sample_index);
     let filter_offset = mix(-camera.filter_info.xy, camera.filter_info.xy, camera_sample.filter_sample);
     let film_position = vec2<f32>(pixel) + filter_offset + vec2<f32>(0.5);
@@ -37,6 +71,7 @@ fn generate_camera(@builtin(global_invocation_id) global_id: vec3<u32>) {
         camera.render_from_camera,
         vec4<f32>(camera_direction, 0.0),
     ).xyz);
+    wavefront_store_queue_index(index, index);
     wavefront.slots[index].ray_origin = vec4<f32>(ray_origin, 0.0);
     wavefront.slots[index].ray_direction = vec4<f32>(ray_direction, 0.0);
     wavefront.slots[index].intersection_ids = vec4<u32>(WAVEFRONT_STATE_RAY, 0u, 0u, 0u);
@@ -47,11 +82,25 @@ fn generate_camera(@builtin(global_invocation_id) global_id: vec3<u32>) {
     wavefront.slots[index].radiance = vec4<f32>(0.0);
     wavefront.slots[index].throughput = vec4<f32>(1.0);
     wavefront.slots[index].path_info = vec4<u32>(0u);
+    wavefront.slots[index].surface_position = vec4<f32>(0.0);
+    wavefront.slots[index].surface_position_error = vec4<f32>(0.0);
+    wavefront.slots[index].surface_geometric_normal = vec4<f32>(0.0);
+    wavefront.slots[index].surface_shading_normal = vec4<f32>(0.0);
+    wavefront.slots[index].surface_uv = vec4<f32>(0.0);
+    wavefront.slots[index].previous_surface_position = vec4<f32>(0.0);
+    wavefront.slots[index].previous_surface_shading_normal = vec4<f32>(0.0);
+    wavefront.slots[index].previous_bsdf_pdf = vec4<f32>(0.0);
+    wavefront.slots[index].material_parameters = vec4<f32>(0.0);
 }
 
 @compute @workgroup_size(64)
 fn intersect_closest(@builtin(global_invocation_id) global_id: vec3<u32>) {
-    let index = wavefront_pixel_index(global_id);
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.ray_queue_a.count)
+        || queue_index >= wavefront.ray_queue_a.capacity) {
+        return;
+    }
+    let index = wavefront_queue_index(wavefront.ray_queue_a.offset + queue_index);
     if (index >= arrayLength(&wavefront.slots)
         || wavefront.slots[index].intersection_ids.x != WAVEFRONT_STATE_RAY) {
         return;
@@ -88,26 +137,19 @@ fn intersect_closest(@builtin(global_invocation_id) global_id: vec3<u32>) {
     );
 }
 
-@compute @workgroup_size(64)
-fn shade_diffuse_point(@builtin(global_invocation_id) global_id: vec3<u32>) {
-    let index = wavefront_pixel_index(global_id);
-    if (index >= arrayLength(&wavefront.slots)) {
-        return;
-    }
-    if (wavefront.slots[index].intersection_ids.x != WAVEFRONT_STATE_HIT) {
-        if (wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_MISS) {
-            wavefront.slots[index].contribution = vec4<f32>(
-                wavefront.slots[index].throughput.xyz * infinite_emission(),
-                1.0,
-            );
-        } else {
-            wavefront.slots[index].contribution = vec4<f32>(0.0);
-        }
-        wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
-        wavefront.slots[index].path_info.y = 0u;
-        return;
-    }
+struct SurfaceData {
+    position: vec3<f32>,
+    position_error: vec3<f32>,
+    geometric_normal: vec3<f32>,
+    shading_normal: vec3<f32>,
+    uv: vec2<f32>,
+    primitive_id: u32,
+    material_id: u32,
+    pixel: vec2<i32>,
+    depth: u32,
+};
 
+fn load_surface_data(index: u32) -> SurfaceData {
     let primitive_index = wavefront.slots[index].intersection_ids.y;
     let triangle_index = wavefront.slots[index].intersection_ids.z;
     let primitive = primitives[primitive_index];
@@ -139,22 +181,21 @@ fn shade_diffuse_point(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let object_normal = vertices[i0].normal.xyz * barycentrics.x
         + vertices[i1].normal.xyz * barycentrics.y
         + vertices[i2].normal.xyz * barycentrics.z;
-    var normal = geometric_normal;
+    let uv = vertices[i0].uv.xy * barycentrics.x
+        + vertices[i1].uv.xy * barycentrics.y
+        + vertices[i2].uv.xy * barycentrics.z;
+    var shading_normal = geometric_normal;
     if (dot(object_normal, object_normal) > 1.0e-20) {
-        normal = normalize(transform(
+        shading_normal = normalize(transform(
             transform_table.normal_from_object,
             vec4<f32>(object_normal, 0.0),
         ).xyz);
-        normal = select(-normal, normal, dot(normal, geometric_normal) >= 0.0);
+        shading_normal = select(
+            -shading_normal,
+            shading_normal,
+            dot(shading_normal, geometric_normal) >= 0.0,
+        );
     }
-
-    let wo = -wavefront.slots[index].ray_direction.xyz;
-    let width = u32(camera.viewport.z);
-    let local_pixel = vec2<u32>(index % width, index / width);
-    let pixel = vec2<i32>(local_pixel) + vec2<i32>(camera.viewport.xy);
-    let sample_index = camera.sampler_info.z + wavefront.control.x;
-    let depth = wavefront.slots[index].path_info.x;
-    let ray_sample = independent_ray_sample(pixel, sample_index, depth);
     let object_position_error = 4.172327e-7 * (
         abs(barycentrics.x * vertices[i0].position.xyz)
         + abs(barycentrics.y * vertices[i1].position.xyz)
@@ -165,105 +206,441 @@ fn shade_diffuse_point(@builtin(global_invocation_id) global_id: vec3<u32>) {
         object_position,
         object_position_error,
     );
-    let reflectance = materials[primitive.material].reflectance.xyz;
-    let light = lights[0];
-    wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
-    wavefront.slots[index].contribution = vec4<f32>(0.0);
-    if (light.kind == 0u) {
-        let to_light = light.position.xyz - position;
-        let distance_squared = max(dot(to_light, to_light), 1.0e-8);
-        let wi = normalize(to_light);
-        let cosine = abs(dot(normal, wi));
-        let same_hemisphere = dot(normal, wo) * dot(normal, wi) > 0.0;
-        if (same_hemisphere && cosine > 0.0) {
-            let shadow_origin = offset_ray_origin(
-                position,
-                position_error,
-                geometric_normal,
-                to_light,
-            );
-            wavefront.slots[index].shadow_origin = vec4<f32>(shadow_origin, 1.0);
-            wavefront.slots[index].shadow_direction = vec4<f32>(to_light, 0.0);
-            wavefront.slots[index].contribution = vec4<f32>(
-                wavefront.slots[index].throughput.xyz * reflectance
-                    * light.intensity.xyz * cosine
-                    / (3.141592653589793 * distance_squared),
-                1.0,
-            );
-        }
-    } else if (light.kind == 2u) {
-        let context_position = offset_ray_origin(
-            position,
-            position_error,
-            geometric_normal,
-            -wo,
-        );
-        let light_sample = sample_area_light(
-            light,
-            context_position,
-            normal,
-            ray_sample.direct.light_sample,
-        );
-        if (light_sample.valid) {
-            let to_light = light_sample.position - context_position;
-            let wi = normalize(to_light);
-            let cosine = abs(dot(normal, wi));
-            let same_hemisphere = dot(normal, wo) * dot(normal, wi) > 0.0;
-            let bsdf_pdf = select(
-                cosine / 3.141592653589793,
-                0.0,
-                (light.flags & 1u) != 0u,
-            );
-            let light_pdf = light_sample.pdf;
-            if (same_hemisphere && cosine > 0.0 && light_pdf > 0.0) {
-                wavefront.slots[index].shadow_origin = vec4<f32>(context_position, 1.0);
-                wavefront.slots[index].shadow_direction = vec4<f32>(to_light, 0.0);
-                wavefront.slots[index].contribution = vec4<f32>(
-                    wavefront.slots[index].throughput.xyz * reflectance
-                        * light.intensity.xyz * cosine
-                        / (3.141592653589793 * (bsdf_pdf + light_pdf)),
-                    1.0,
-                );
-            }
-        }
-    }
-    let disk = sample_uniform_disk_concentric(ray_sample.indirect.direction);
-    var local_wi = vec3<f32>(disk, sqrt(max(0.0, 1.0 - dot(disk, disk))));
-    if (dot(normal, wo) < 0.0) {
-        local_wi.z = -local_wi.z;
-    }
-    let frame_x = coordinate_tangent(normal);
-    let frame_y = cross(normal, frame_x);
-    let next_direction = normalize(
-        frame_x * local_wi.x + frame_y * local_wi.y + normal * local_wi.z,
-    );
-    var next_throughput = wavefront.slots[index].throughput.xyz * reflectance;
-    var continue_path = true;
-    if (depth >= 1u) {
-        let maximum = max(next_throughput.x, max(next_throughput.y, next_throughput.z));
-        if (maximum < 1.0) {
-            let q = 1.0 - maximum;
-            if (ray_sample.indirect.roulette < q) {
-                continue_path = false;
-            } else {
-                next_throughput /= 1.0 - q;
-            }
-        }
-    }
-    wavefront.slots[index].ray_origin = vec4<f32>(offset_ray_origin(
+    let width = u32(camera.viewport.z);
+    let local_pixel = vec2<u32>(index % width, index / width);
+    return SurfaceData(
         position,
         position_error,
         geometric_normal,
-        next_direction,
-    ), 0.0);
-    wavefront.slots[index].ray_direction = vec4<f32>(next_direction, 0.0);
-    wavefront.slots[index].throughput = vec4<f32>(next_throughput, 1.0);
-    wavefront.slots[index].path_info.y = select(0u, 1u, continue_path);
+        shading_normal,
+        uv,
+        primitive_index,
+        primitive.material,
+        vec2<i32>(local_pixel) + vec2<i32>(camera.viewport.xy),
+        wavefront.slots[index].path_info.x,
+    );
+}
+
+@compute @workgroup_size(64)
+fn classify_intersection(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.ray_queue_a.count)
+        || queue_index >= wavefront.ray_queue_a.capacity) {
+        return;
+    }
+    let index = wavefront_queue_index(wavefront.ray_queue_a.offset + queue_index);
+    if (index >= arrayLength(&wavefront.slots)) {
+        return;
+    }
+    let state = wavefront.slots[index].intersection_ids.x;
+    if (state == WAVEFRONT_STATE_HIT) {
+        for (var light_index = 0u; light_index < light_source_count(); light_index++) {
+            let light = lights[light_index];
+            if (light.kind == 2u) {
+                for (var geometry_index = 0u; geometry_index < light.triangle; geometry_index++) {
+                    let geometry = area_light_geometry(light, geometry_index);
+                    if (geometry.primitive == wavefront.slots[index].intersection_ids.y
+                        && geometry.triangle == wavefront.slots[index].intersection_ids.z) {
+                        wavefront.slots[index].intersection_ids.x = WAVEFRONT_STATE_EMISSIVE;
+                        wavefront.slots[index].intersection_ids.w = light_index;
+                        wavefront_enqueue_hit_area_light(index);
+                        // Emissive hits also need the evaluated surface normal
+                        // for sidedness and MIS, but are rejected by the BxDF
+                        // stages because their state is EMISSIVE.
+                        wavefront_enqueue_surface(index);
+                        return;
+                    }
+                }
+            }
+        }
+        wavefront_enqueue_surface(index);
+        return;
+    }
+    if (state == WAVEFRONT_STATE_MISS) {
+        wavefront_enqueue_escaped_ray(index);
+        return;
+    }
+    if (state == WAVEFRONT_STATE_EMISSIVE) {
+        wavefront_enqueue_hit_area_light(index);
+        return;
+    }
+    if (state != WAVEFRONT_STATE_HIT && state != WAVEFRONT_STATE_MISS) {
+        wavefront.slots[index].intersection_ids.x = WAVEFRONT_STATE_INACTIVE;
+    }
+}
+
+@compute @workgroup_size(64)
+fn evaluate_surface_interaction(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.surface_queue.count)
+        || queue_index >= wavefront.surface_queue.capacity) {
+        return;
+    }
+    let index = wavefront_surface_queue_index(queue_index);
+    if (index < arrayLength(&wavefront.slots)
+        && (wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_HIT
+            || wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_EMISSIVE)) {
+        let surface = load_surface_data(index);
+        wavefront.slots[index].surface_position = vec4<f32>(surface.position, 1.0);
+        wavefront.slots[index].surface_position_error =
+            vec4<f32>(surface.position_error, 0.0);
+        wavefront.slots[index].surface_geometric_normal =
+            vec4<f32>(surface.geometric_normal, 0.0);
+        wavefront.slots[index].surface_shading_normal =
+            vec4<f32>(surface.shading_normal, 0.0);
+        wavefront.slots[index].surface_uv = vec4<f32>(surface.uv, 0.0, 0.0);
+    }
+}
+
+@compute @workgroup_size(64)
+fn register_bxdf(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.surface_queue.count)
+        || queue_index >= wavefront.surface_queue.capacity) {
+        return;
+    }
+    let index = wavefront_surface_queue_index(queue_index);
+    if (index < arrayLength(&wavefront.slots)
+        && wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_HIT) {
+        // BxDF kind 0 is diffuse in the initial GPU material set.
+        wavefront.slots[index].path_info.z = 0u;
+        wavefront.slots[index].path_info.w = 1u;
+    }
+}
+
+@compute @workgroup_size(64)
+fn count_bxdf(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.surface_queue.count)
+        || queue_index >= wavefront.surface_queue.capacity) {
+        return;
+    }
+    let index = wavefront_surface_queue_index(queue_index);
+    if (index < arrayLength(&wavefront.slots)
+        && wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_HIT) {
+        // One diffuse BxDF work item is emitted for this surface.
+        wavefront.slots[index].path_info.w = 1u;
+    }
+}
+
+@compute @workgroup_size(64)
+fn partition_bxdf(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.surface_queue.count)
+        || queue_index >= wavefront.surface_queue.capacity) {
+        return;
+    }
+    let index = wavefront_surface_queue_index(queue_index);
+    if (index < arrayLength(&wavefront.slots)
+        && wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_HIT) {
+        // Diffuse is the only supported BxDF in the first WebGPU slice, so the
+        // one-item range is already partitioned in place.
+    }
+}
+
+@compute @workgroup_size(64)
+fn sample_direct_lighting(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.surface_queue.count)
+        || queue_index >= wavefront.surface_queue.capacity) {
+        return;
+    }
+    let index = wavefront_surface_queue_index(queue_index);
+    if (index < arrayLength(&wavefront.slots)
+        && wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_HIT
+        && wavefront.slots[index].path_info.z == 0u
+        && wavefront.slots[index].path_info.w > 0u
+        && wavefront.slots[index].path_info.x < camera.bvh_info.z) {
+        let position = wavefront.slots[index].surface_position.xyz;
+        let position_error = wavefront.slots[index].surface_position_error.xyz;
+        let geometric_normal = wavefront.slots[index].surface_geometric_normal.xyz;
+        let normal = wavefront.slots[index].surface_shading_normal.xyz;
+        let wo = -wavefront.slots[index].ray_direction.xyz;
+        let depth = wavefront.slots[index].path_info.x;
+        let ray_sample = independent_ray_sample(
+            vec2<i32>(
+                i32(index % u32(camera.viewport.z)),
+                i32(index / u32(camera.viewport.z)),
+            ) + vec2<i32>(camera.viewport.xy),
+            camera.sampler_info.z + wavefront.control.sample_index,
+            depth,
+        );
+        let reflectance = wavefront.slots[index].material_parameters.xyz;
+        wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
+        wavefront.slots[index].contribution = vec4<f32>(0.0);
+        let light_count = light_source_count();
+        if (light_count > 0u) {
+            let light_index = min(
+                u32(ray_sample.direct.light_selection * f32(light_count)),
+                light_count - 1u,
+            );
+            let light = lights[light_index];
+            if (light.kind == 0u) {
+                let to_light = light.position.xyz - position;
+                let distance_squared = max(dot(to_light, to_light), 1.0e-8);
+                let wi = normalize(to_light);
+                let cosine = abs(dot(normal, wi));
+                let same_hemisphere = dot(normal, wo) * dot(normal, wi) > 0.0;
+                if (same_hemisphere && cosine > 0.0) {
+                    let shadow_origin = offset_ray_origin(
+                        position,
+                        position_error,
+                        geometric_normal,
+                        to_light,
+                    );
+                    wavefront.slots[index].shadow_origin = vec4<f32>(shadow_origin, 1.0);
+                    wavefront.slots[index].shadow_direction = vec4<f32>(to_light, 0.0);
+                    wavefront.slots[index].contribution = vec4<f32>(
+                        wavefront.slots[index].throughput.xyz * reflectance
+                            * light.intensity.xyz * cosine * f32(light_count)
+                            / (3.141592653589793 * distance_squared),
+                        1.0,
+                    );
+                    wavefront_enqueue_shadow(index);
+                }
+            } else if (light.kind == 2u) {
+                let context_position = offset_ray_origin(
+                    position,
+                    position_error,
+                    geometric_normal,
+                    -wo,
+                );
+                let light_sample = sample_area_light(
+                    light,
+                    context_position,
+                    normal,
+                    ray_sample.direct.light_sample,
+                );
+                if (light_sample.valid) {
+                    let to_light = light_sample.position - context_position;
+                    let wi = normalize(to_light);
+                    let cosine = abs(dot(normal, wi));
+                    let same_hemisphere = dot(normal, wo) * dot(normal, wi) > 0.0;
+                    let bsdf_pdf = select(
+                        cosine / 3.141592653589793,
+                        0.0,
+                        (light.flags & 2u) != 0u,
+                    );
+                    let light_pdf = light_sample.pdf / f32(light_count);
+                    if (same_hemisphere && cosine > 0.0 && light_pdf > 0.0) {
+                        wavefront.slots[index].shadow_origin = vec4<f32>(context_position, 1.0);
+                        wavefront.slots[index].shadow_direction = vec4<f32>(to_light, 0.0);
+                        wavefront.slots[index].contribution = vec4<f32>(
+                            wavefront.slots[index].throughput.xyz * reflectance
+                                * light.intensity.xyz * cosine
+                                / (3.141592653589793 * (bsdf_pdf + light_pdf)),
+                            1.0,
+                        );
+                        wavefront_enqueue_shadow(index);
+                    }
+                }
+            } else if (light.kind == 1u) {
+                let z = 1.0 - 2.0 * ray_sample.direct.light_sample.x;
+                let phi = 6.283185307179586 * ray_sample.direct.light_sample.y;
+                let radial = sqrt(max(0.0, 1.0 - z * z));
+                let wi = vec3<f32>(radial * cos(phi), radial * sin(phi), z);
+                let cosine = abs(dot(normal, wi));
+                let same_hemisphere = dot(normal, wo) * dot(normal, wi) > 0.0;
+                let light_pdf = 0.07957747154594767 / f32(light_count);
+                let bsdf_pdf = cosine / 3.141592653589793;
+                if (same_hemisphere && cosine > 0.0 && light_pdf > 0.0) {
+                    let shadow_origin = offset_ray_origin(
+                        position,
+                        position_error,
+                        geometric_normal,
+                        wi,
+                    );
+                    wavefront.slots[index].shadow_origin = vec4<f32>(shadow_origin, 1.0);
+                    wavefront.slots[index].shadow_direction = vec4<f32>(wi, 1.0);
+                    wavefront.slots[index].contribution = vec4<f32>(
+                        wavefront.slots[index].throughput.xyz
+                            * reflectance
+                            * light.intensity.xyz
+                            * cosine
+                            / (3.141592653589793 * (bsdf_pdf + light_pdf)),
+                        1.0,
+                    );
+                    wavefront_enqueue_shadow(index);
+                }
+            }
+        }
+    }
+}
+
+@compute @workgroup_size(64)
+fn generate_indirect_rays(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.surface_queue.count)
+        || queue_index >= wavefront.surface_queue.capacity) {
+        return;
+    }
+    let index = wavefront_surface_queue_index(queue_index);
+    if (index < arrayLength(&wavefront.slots)
+        && wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_HIT
+        && wavefront.slots[index].path_info.z == 0u
+        && wavefront.slots[index].path_info.w > 0u) {
+        if (wavefront.slots[index].path_info.x >= camera.bvh_info.z) {
+            wavefront.slots[index].path_info.y = 0u;
+            return;
+        }
+        let position = wavefront.slots[index].surface_position.xyz;
+        let position_error = wavefront.slots[index].surface_position_error.xyz;
+        let geometric_normal = wavefront.slots[index].surface_geometric_normal.xyz;
+        let normal = wavefront.slots[index].surface_shading_normal.xyz;
+        let wo = -wavefront.slots[index].ray_direction.xyz;
+        let depth = wavefront.slots[index].path_info.x;
+        let ray_sample = independent_ray_sample(
+            vec2<i32>(
+                i32(index % u32(camera.viewport.z)),
+                i32(index / u32(camera.viewport.z)),
+            ) + vec2<i32>(camera.viewport.xy),
+            camera.sampler_info.z + wavefront.control.sample_index,
+            depth,
+        );
+        let disk = sample_uniform_disk_concentric(ray_sample.indirect.direction);
+        var local_wi = vec3<f32>(disk, sqrt(max(0.0, 1.0 - dot(disk, disk))));
+        if (dot(normal, wo) < 0.0) {
+            local_wi.z = -local_wi.z;
+        }
+        let frame_x = coordinate_tangent(normal);
+        let frame_y = cross(normal, frame_x);
+        let next_direction = normalize(
+            frame_x * local_wi.x + frame_y * local_wi.y + normal * local_wi.z,
+        );
+        wavefront.slots[index].previous_surface_position = vec4<f32>(position, 1.0);
+        wavefront.slots[index].previous_surface_shading_normal = vec4<f32>(normal, 0.0);
+        wavefront.slots[index].previous_bsdf_pdf = vec4<f32>(
+            abs(dot(normal, next_direction)) / 3.141592653589793,
+            0.0,
+            0.0,
+            0.0,
+        );
+        let reflectance = wavefront.slots[index].material_parameters.xyz;
+        var next_throughput = wavefront.slots[index].throughput.xyz * reflectance;
+        var continue_path = true;
+        if (depth >= 1u) {
+            let maximum = max(next_throughput.x, max(next_throughput.y, next_throughput.z));
+            if (maximum < 1.0) {
+                let q = 1.0 - maximum;
+                if (ray_sample.indirect.roulette < q) {
+                    continue_path = false;
+                } else {
+                    next_throughput /= 1.0 - q;
+                }
+            }
+        }
+        wavefront.slots[index].ray_origin = vec4<f32>(offset_ray_origin(
+            position,
+            position_error,
+            geometric_normal,
+            next_direction,
+        ), 0.0);
+        wavefront.slots[index].ray_direction = vec4<f32>(next_direction, 0.0);
+        wavefront.slots[index].throughput = vec4<f32>(next_throughput, 1.0);
+        wavefront.slots[index].path_info.y = select(0u, 1u, continue_path);
+    }
+}
+
+@compute @workgroup_size(64)
+fn handle_escaped_rays(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.escaped_ray_queue.count)
+        || queue_index >= wavefront.escaped_ray_queue.capacity) {
+        return;
+    }
+    let index = wavefront_escaped_ray_queue_index(queue_index);
+    if (index < arrayLength(&wavefront.slots)
+        && wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_MISS) {
+        wavefront.slots[index].contribution = vec4<f32>(
+            wavefront.slots[index].throughput.xyz * infinite_emission(),
+            1.0,
+        );
+        wavefront.slots[index].path_info.y = 0u;
+    }
+}
+
+@compute @workgroup_size(64)
+fn handle_emissive_intersection(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.hit_area_light_queue.count)
+        || queue_index >= wavefront.hit_area_light_queue.capacity) {
+        return;
+    }
+    let index = wavefront_hit_area_light_queue_index(queue_index);
+    if (index < arrayLength(&wavefront.slots)
+        && wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_EMISSIVE) {
+        let light = lights[wavefront.slots[index].intersection_ids.w];
+        let emits_toward_ray = (light.flags & 1u) != 0u
+            || dot(
+                wavefront.slots[index].surface_geometric_normal.xyz,
+                -wavefront.slots[index].ray_direction.xyz,
+            ) >= 0.0;
+        if (emits_toward_ray) {
+            var emission_weight = 1.0;
+            if (wavefront.slots[index].path_info.x > 0u
+                && wavefront.slots[index].previous_bsdf_pdf.x > 0.0) {
+                let light_count = light_source_count();
+                let light_pdf = area_light_pdf(
+                    light,
+                    wavefront.slots[index].previous_surface_position.xyz,
+                    wavefront.slots[index].previous_surface_shading_normal.xyz,
+                    wavefront.slots[index].surface_position.xyz,
+                    wavefront.slots[index].ray_direction.xyz,
+                    wavefront.slots[index].intersection_ids.z,
+                ) / f32(light_count);
+                emission_weight = wavefront.slots[index].previous_bsdf_pdf.x
+                    / (wavefront.slots[index].previous_bsdf_pdf.x + light_pdf);
+            }
+            wavefront.slots[index].contribution = vec4<f32>(
+                wavefront.slots[index].throughput.xyz * light.intensity.xyz * emission_weight,
+                1.0,
+            );
+        } else {
+            wavefront.slots[index].contribution = vec4<f32>(0.0);
+        }
+        wavefront.slots[index].path_info.y = 0u;
+    }
+}
+
+@compute @workgroup_size(64)
+fn evaluate_material(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.surface_queue.count)
+        || queue_index >= wavefront.surface_queue.capacity) {
+        return;
+    }
+    let index = wavefront_surface_queue_index(queue_index);
+    if (index >= arrayLength(&wavefront.slots)) {
+        return;
+    }
+    if (wavefront.slots[index].intersection_ids.x != WAVEFRONT_STATE_HIT) {
+        wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
+        return;
+    }
+    let primitive_index = wavefront.slots[index].intersection_ids.y;
+    let primitive = primitives[primitive_index];
+    let material = materials[primitive.material];
+    var reflectance = material.reflectance.xyz;
+    if ((material.flags & 1u) != 0u) {
+        reflectance = sample_texture(
+            material.texture,
+            wavefront.slots[index].surface_uv.xy,
+            vec4<f32>(0.0),
+        );
+    }
+    wavefront.slots[index].material_parameters = vec4<f32>(reflectance, 1.0);
+    wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
+    wavefront.slots[index].contribution = vec4<f32>(0.0);
 }
 
 @compute @workgroup_size(64)
 fn intersect_shadow(@builtin(global_invocation_id) global_id: vec3<u32>) {
-    let index = wavefront_pixel_index(global_id);
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.shadow_queue.count)
+        || queue_index >= wavefront.shadow_queue.capacity) {
+        return;
+    }
+    let index = wavefront_shadow_queue_index(queue_index);
     if (index >= arrayLength(&wavefront.slots)
         || wavefront.slots[index].shadow_origin.w == 0.0) {
         return;
@@ -279,7 +656,7 @@ fn intersect_shadow(@builtin(global_invocation_id) global_id: vec3<u32>) {
             0u,
             0xFFu,
             0.0,
-            0.9999,
+            select(0.9999, 1.0e30, wavefront.slots[index].shadow_direction.w != 0.0),
             wavefront.slots[index].shadow_origin.xyz,
             wavefront.slots[index].shadow_direction.xyz,
         ),
@@ -299,7 +676,12 @@ fn intersect_shadow(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
 @compute @workgroup_size(64)
 fn finish_bounce(@builtin(global_invocation_id) global_id: vec3<u32>) {
-    let index = wavefront_pixel_index(global_id);
+    let queue_index = wavefront_pixel_index(global_id);
+    if (queue_index >= atomicLoad(&wavefront.ray_queue_a.count)
+        || queue_index >= wavefront.ray_queue_a.capacity) {
+        return;
+    }
+    let index = wavefront_queue_index(wavefront.ray_queue_a.offset + queue_index);
     if (index >= arrayLength(&wavefront.slots)) {
         return;
     }
@@ -309,8 +691,41 @@ fn finish_bounce(@builtin(global_invocation_id) global_id: vec3<u32>) {
     if (wavefront.slots[index].path_info.y != 0u) {
         wavefront.slots[index].path_info.x += 1u;
         wavefront.slots[index].intersection_ids.x = WAVEFRONT_STATE_RAY;
+        let next_index = atomicAdd(&wavefront.ray_queue_b.count, 1u);
+        if (next_index >= wavefront.ray_queue_b.capacity) {
+            atomicStore(&wavefront.ray_queue_b.overflow, 1u);
+            atomicStore(&wavefront.control.overflow, 1u);
+        } else {
+            wavefront_store_queue_index(wavefront.ray_queue_b.offset + next_index, index);
+        }
     } else {
         wavefront.slots[index].intersection_ids.x = WAVEFRONT_STATE_INACTIVE;
+    }
+}
+
+@compute @workgroup_size(1)
+fn prepare_next_bounce(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    if (global_id.x == 0u) {
+        let next_count = min(
+            atomicLoad(&wavefront.ray_queue_b.count),
+            wavefront.ray_queue_b.capacity,
+        );
+        atomicStore(&wavefront.ray_queue_a.count, next_count);
+        atomicStore(&wavefront.ray_queue_a.overflow, 0u);
+        let previous_offset = wavefront.ray_queue_a.offset;
+        wavefront.ray_queue_a.offset = wavefront.ray_queue_b.offset;
+        wavefront.ray_queue_b.offset = previous_offset;
+        atomicStore(&wavefront.ray_queue_b.count, 0u);
+        atomicStore(&wavefront.ray_queue_b.overflow, 0u);
+        atomicStore(&wavefront.escaped_ray_queue.count, 0u);
+        atomicStore(&wavefront.escaped_ray_queue.overflow, 0u);
+        atomicStore(&wavefront.hit_area_light_queue.count, 0u);
+        atomicStore(&wavefront.hit_area_light_queue.overflow, 0u);
+        atomicStore(&wavefront.surface_queue.count, 0u);
+        atomicStore(&wavefront.surface_queue.overflow, 0u);
+        atomicStore(&wavefront.shadow_queue.count, 0u);
+        atomicStore(&wavefront.shadow_queue.overflow, 0u);
+        atomicStore(&wavefront.control.active_count, next_count);
     }
 }
 
@@ -329,6 +744,6 @@ fn update_film(@builtin(global_invocation_id) global_id: vec3<u32>) {
 @compute @workgroup_size(1)
 fn advance_sample(@builtin(global_invocation_id) global_id: vec3<u32>) {
     if (global_id.x == 0u) {
-        wavefront.control.x += 1u;
+        wavefront.control.sample_index += 1u;
     }
 }

--- a/src/gpu/webgpu/shaders/entry/wavefront.wgsl
+++ b/src/gpu/webgpu/shaders/entry/wavefront.wgsl
@@ -95,7 +95,14 @@ fn shade_diffuse_point(@builtin(global_invocation_id) global_id: vec3<u32>) {
         return;
     }
     if (wavefront.slots[index].intersection_ids.x != WAVEFRONT_STATE_HIT) {
-        wavefront.slots[index].contribution = vec4<f32>(0.0);
+        if (wavefront.slots[index].intersection_ids.x == WAVEFRONT_STATE_MISS) {
+            wavefront.slots[index].contribution = vec4<f32>(
+                wavefront.slots[index].throughput.xyz * infinite_emission(),
+                1.0,
+            );
+        } else {
+            wavefront.slots[index].contribution = vec4<f32>(0.0);
+        }
         wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
         wavefront.slots[index].path_info.y = 0u;
         return;
@@ -142,6 +149,12 @@ fn shade_diffuse_point(@builtin(global_invocation_id) global_id: vec3<u32>) {
     }
 
     let wo = -wavefront.slots[index].ray_direction.xyz;
+    let width = u32(camera.viewport.z);
+    let local_pixel = vec2<u32>(index % width, index / width);
+    let pixel = vec2<i32>(local_pixel) + vec2<i32>(camera.viewport.xy);
+    let sample_index = camera.sampler_info.z + wavefront.control.x;
+    let depth = wavefront.slots[index].path_info.x;
+    let ray_sample = independent_ray_sample(pixel, sample_index, depth);
     let object_position_error = 4.172327e-7 * (
         abs(barycentrics.x * vertices[i0].position.xyz)
         + abs(barycentrics.y * vertices[i1].position.xyz)
@@ -154,37 +167,66 @@ fn shade_diffuse_point(@builtin(global_invocation_id) global_id: vec3<u32>) {
     );
     let reflectance = materials[primitive.material].reflectance.xyz;
     let light = lights[0];
-    let to_light = light.position.xyz - position;
-    let distance_squared = max(dot(to_light, to_light), 1.0e-8);
-    let wi = normalize(to_light);
-    let cosine = abs(dot(normal, wi));
-    let same_hemisphere = dot(normal, wo) * dot(normal, wi) > 0.0;
-    if (same_hemisphere && cosine > 0.0) {
-        let shadow_origin = offset_ray_origin(
+    wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
+    wavefront.slots[index].contribution = vec4<f32>(0.0);
+    if (light.kind == 0u) {
+        let to_light = light.position.xyz - position;
+        let distance_squared = max(dot(to_light, to_light), 1.0e-8);
+        let wi = normalize(to_light);
+        let cosine = abs(dot(normal, wi));
+        let same_hemisphere = dot(normal, wo) * dot(normal, wi) > 0.0;
+        if (same_hemisphere && cosine > 0.0) {
+            let shadow_origin = offset_ray_origin(
+                position,
+                position_error,
+                geometric_normal,
+                to_light,
+            );
+            wavefront.slots[index].shadow_origin = vec4<f32>(shadow_origin, 1.0);
+            wavefront.slots[index].shadow_direction = vec4<f32>(to_light, 0.0);
+            wavefront.slots[index].contribution = vec4<f32>(
+                wavefront.slots[index].throughput.xyz * reflectance
+                    * light.intensity.xyz * cosine
+                    / (3.141592653589793 * distance_squared),
+                1.0,
+            );
+        }
+    } else if (light.kind == 2u) {
+        let context_position = offset_ray_origin(
             position,
             position_error,
             geometric_normal,
-            to_light,
+            -wo,
         );
-        wavefront.slots[index].shadow_origin = vec4<f32>(shadow_origin, 1.0);
-        wavefront.slots[index].shadow_direction = vec4<f32>(to_light, 0.0);
-        wavefront.slots[index].contribution = vec4<f32>(
-            wavefront.slots[index].throughput.xyz * reflectance
-                * light.intensity.xyz * cosine
-                / (3.141592653589793 * distance_squared),
-            1.0,
+        let light_sample = sample_area_light(
+            light,
+            context_position,
+            normal,
+            ray_sample.direct.light_sample,
         );
-    } else {
-        wavefront.slots[index].shadow_origin = vec4<f32>(0.0);
-        wavefront.slots[index].contribution = vec4<f32>(0.0);
+        if (light_sample.valid) {
+            let to_light = light_sample.position - context_position;
+            let wi = normalize(to_light);
+            let cosine = abs(dot(normal, wi));
+            let same_hemisphere = dot(normal, wo) * dot(normal, wi) > 0.0;
+            let bsdf_pdf = select(
+                cosine / 3.141592653589793,
+                0.0,
+                (light.flags & 1u) != 0u,
+            );
+            let light_pdf = light_sample.pdf;
+            if (same_hemisphere && cosine > 0.0 && light_pdf > 0.0) {
+                wavefront.slots[index].shadow_origin = vec4<f32>(context_position, 1.0);
+                wavefront.slots[index].shadow_direction = vec4<f32>(to_light, 0.0);
+                wavefront.slots[index].contribution = vec4<f32>(
+                    wavefront.slots[index].throughput.xyz * reflectance
+                        * light.intensity.xyz * cosine
+                        / (3.141592653589793 * (bsdf_pdf + light_pdf)),
+                    1.0,
+                );
+            }
+        }
     }
-
-    let width = u32(camera.viewport.z);
-    let local_pixel = vec2<u32>(index % width, index / width);
-    let pixel = vec2<i32>(local_pixel) + vec2<i32>(camera.viewport.xy);
-    let sample_index = camera.sampler_info.z + wavefront.control.x;
-    let depth = wavefront.slots[index].path_info.x;
-    let ray_sample = independent_ray_sample(pixel, sample_index, depth);
     let disk = sample_uniform_disk_concentric(ray_sample.indirect.direction);
     var local_wi = vec3<f32>(disk, sqrt(max(0.0, 1.0 - dot(disk, disk))));
     if (dot(normal, wo) < 0.0) {

--- a/src/gpu/webgpu/shaders/intersection/ray_query.wgsl
+++ b/src/gpu/webgpu/shaders/intersection/ray_query.wgsl
@@ -3,12 +3,13 @@ fn shadow_visible(
     direction: vec3<f32>,
     source_primitive: u32,
     source_triangle: u32,
+    infinite: bool,
 ) -> bool {
     var query: ray_query;
     rayQueryInitialize(
         &query,
         acceleration,
-        RayDesc(0u, 0xFFu, 0.0, 0.9999, origin, direction),
+        RayDesc(0u, 0xFFu, 0.0, select(0.9999, 1.0e30, infinite), origin, direction),
     );
     while (rayQueryProceed(&query)) {
         let candidate = rayQueryGetCandidateIntersection(&query);
@@ -270,9 +271,10 @@ fn render_sample(
         let hit_area_light_index = find_area_light(intersection.instance_custom_data, intersection.primitive_index);
         if (hit_area_light_index != 0xffffffffu) {
             let hit_area_light = lights[hit_area_light_index];
+            let hit_area_light_geometry = area_light_geometry_for_triangle(hit_area_light, intersection.primitive_index);
             let emits_toward_ray = (hit_area_light.flags & 1u) != 0u
                 || dot(geometric_render_normal, -direction) >= 0.0;
-            if (emits_toward_ray && area_light_alpha_accept(hit_area_light, uv, position)) {
+            if (emits_toward_ray && area_light_alpha_accept(hit_area_light_geometry, uv, position)) {
                 var emission_weight = 1.0;
                 if (depth > 0u) {
                     let light_pdf = area_light_pdf(
@@ -281,7 +283,8 @@ fn render_sample(
                         previous_context_shading_normal,
                         position,
                         direction,
-                    ) / f32(arrayLength(&lights));
+                        intersection.primitive_index,
+                    ) / f32(light_source_count());
                     emission_weight = previous_bsdf_pdf / (previous_bsdf_pdf + light_pdf);
                 }
                 color += throughput * hit_area_light.intensity.xyz * emission_weight;
@@ -293,7 +296,7 @@ fn render_sample(
 
         let ray_sample = independent_ray_sample(sample_pixel, sample_index, depth);
         let direct_sample = ray_sample.direct;
-        let light_count = arrayLength(&lights);
+        let light_count = light_source_count();
         let light_index = min(u32(direct_sample.light_selection * f32(light_count)), light_count - 1u);
         let light = lights[light_index];
         if (light.kind == 0u) {
@@ -313,9 +316,35 @@ fn render_sample(
                 to_light,
                 intersection.instance_custom_data,
                 intersection.primitive_index,
+                false,
             )) {
                 color += throughput * reflectance * light.intensity.xyz * cosine
                     * f32(light_count) / (3.141592653589793 * distance_squared);
+            }
+        } else if (light.kind == 1u) {
+            let z = 1.0 - 2.0 * direct_sample.light_sample.x;
+            let phi = 6.283185307179586 * direct_sample.light_sample.y;
+            let radial = sqrt(max(0.0, 1.0 - z * z));
+            let wi = vec3<f32>(radial * cos(phi), radial * sin(phi), z);
+            let cosine = abs(dot(normal, wi));
+            let same_hemisphere = dot(normal, -direction) * dot(normal, wi) > 0.0;
+            let light_pdf = 0.07957747154594767 / f32(light_count);
+            let bsdf_pdf = cosine / 3.141592653589793;
+            let shadow_origin = offset_ray_origin(
+                position,
+                position_error,
+                geometric_render_normal,
+                wi,
+            );
+            if (same_hemisphere && cosine > 0.0 && shadow_visible(
+                shadow_origin,
+                wi,
+                intersection.instance_custom_data,
+                intersection.primitive_index,
+                true,
+            )) {
+                color += throughput * reflectance * light.intensity.xyz * cosine
+                    / (3.141592653589793 * (bsdf_pdf + light_pdf));
             }
         } else if (light.kind == 2u) {
             let light_context_position = offset_ray_origin(
@@ -331,7 +360,7 @@ fn render_sample(
                 direct_sample.light_sample,
             );
             if (light_sample.valid
-                && area_light_alpha_accept(light, light_sample.uv, light_sample.position)) {
+                && area_light_alpha_accept(light_sample.geometry, light_sample.uv, light_sample.position)) {
                 let to_light = light_sample.position - light_context_position;
                 let wi = normalize(to_light);
                 let cosine = abs(dot(normal, wi));
@@ -353,6 +382,7 @@ fn render_sample(
                     light_sample.position - shadow_origin,
                     intersection.instance_custom_data,
                     intersection.primitive_index,
+                    false,
                 )) {
                     color += throughput * reflectance * light.intensity.xyz * cosine
                         / (3.141592653589793 * (bsdf_pdf + light_pdf));

--- a/src/gpu/webgpu/shaders/intersection/software_bvh.wgsl
+++ b/src/gpu/webgpu/shaders/intersection/software_bvh.wgsl
@@ -44,6 +44,7 @@ fn shadow_visible(
     direction: vec3<f32>,
     source_primitive: u32,
     source_triangle: u32,
+    infinite: bool,
 ) -> bool {
     let inverse_direction = 1.0 / direction;
     var stack: array<u32, 64>;
@@ -68,7 +69,13 @@ fn shadow_visible(
         let node_first = scene_data[node_base + 8u];
         let node_count = scene_data[node_base + 9u];
         let node_flags = scene_data[node_base + 10u];
-        if (!ray_hits_box(origin, inverse_direction, node_bounds_min, node_bounds_max, 0.9999)) {
+        if (!ray_hits_box(
+            origin,
+            inverse_direction,
+            node_bounds_min,
+            node_bounds_max,
+            select(0.9999, 1.0e30, infinite),
+        )) {
             continue;
         }
         if (node_flags == 1u) {
@@ -392,9 +399,10 @@ fn render_sample(
         let hit_area_light_index = find_area_light(hit_primitive, hit_triangle);
         if (hit_area_light_index != 0xffffffffu) {
             let hit_area_light = lights[hit_area_light_index];
+            let hit_area_light_geometry = area_light_geometry_for_triangle(hit_area_light, hit_triangle);
             let emits_toward_ray = (hit_area_light.flags & 1u) != 0u
                 || dot(geometric_render_normal, -direction) >= 0.0;
-            if (emits_toward_ray && area_light_alpha_accept(hit_area_light, uv, position)) {
+            if (emits_toward_ray && area_light_alpha_accept(hit_area_light_geometry, uv, position)) {
                 var emission_weight = 1.0;
                 if (depth > 0u) {
                     let light_pdf = area_light_pdf(
@@ -403,7 +411,8 @@ fn render_sample(
                         previous_context_shading_normal,
                         position,
                         direction,
-                    ) / f32(arrayLength(&lights));
+                        hit_triangle,
+                    ) / f32(light_source_count());
                     emission_weight = previous_bsdf_pdf / (previous_bsdf_pdf + light_pdf);
                 }
                 color += throughput * hit_area_light.intensity.xyz * emission_weight;
@@ -415,7 +424,7 @@ fn render_sample(
 
         let ray_sample = independent_ray_sample(sample_pixel, sample_index, depth);
         let direct_sample = ray_sample.direct;
-        let light_count = arrayLength(&lights);
+        let light_count = light_source_count();
         let light_index = min(u32(direct_sample.light_selection * f32(light_count)), light_count - 1u);
         let light = lights[light_index];
         if (light.kind == 0u) {
@@ -435,9 +444,35 @@ fn render_sample(
                 to_light,
                 hit_primitive,
                 hit_triangle,
+                false,
             )) {
                 color += throughput * reflectance * light.intensity.xyz * cosine
                     * f32(light_count) / (3.141592653589793 * distance_squared);
+            }
+        } else if (light.kind == 1u) {
+            let z = 1.0 - 2.0 * direct_sample.light_sample.x;
+            let phi = 6.283185307179586 * direct_sample.light_sample.y;
+            let radial = sqrt(max(0.0, 1.0 - z * z));
+            let wi = vec3<f32>(radial * cos(phi), radial * sin(phi), z);
+            let cosine = abs(dot(normal, wi));
+            let same_hemisphere = dot(normal, -direction) * dot(normal, wi) > 0.0;
+            let light_pdf = 0.07957747154594767 / f32(light_count);
+            let bsdf_pdf = cosine / 3.141592653589793;
+            let shadow_origin = offset_ray_origin(
+                position,
+                position_error,
+                geometric_render_normal,
+                wi,
+            );
+            if (same_hemisphere && cosine > 0.0 && shadow_visible(
+                shadow_origin,
+                wi,
+                hit_primitive,
+                hit_triangle,
+                true,
+            )) {
+                color += throughput * reflectance * light.intensity.xyz * cosine
+                    / (3.141592653589793 * (bsdf_pdf + light_pdf));
             }
         } else if (light.kind == 2u) {
             let light_context_position = offset_ray_origin(
@@ -453,7 +488,7 @@ fn render_sample(
                 direct_sample.light_sample,
             );
             if (light_sample.valid
-                && area_light_alpha_accept(light, light_sample.uv, light_sample.position)) {
+                && area_light_alpha_accept(light_sample.geometry, light_sample.uv, light_sample.position)) {
                 let to_light = light_sample.position - light_context_position;
                 let wi = normalize(to_light);
                 let cosine = abs(dot(normal, wi));
@@ -475,6 +510,7 @@ fn render_sample(
                     light_sample.position - shadow_origin,
                     hit_primitive,
                     hit_triangle,
+                    false,
                 )) {
                     color += throughput * reflectance * light.intensity.xyz * cosine
                         / (3.141592653589793 * (bsdf_pdf + light_pdf));

--- a/src/gpu/webgpu/wavefront.rs
+++ b/src/gpu/webgpu/wavefront.rs
@@ -1,7 +1,119 @@
 //! Host-side layout for the initial fixed-slot GPU wavefront arena.
 
-pub const WAVEFRONT_SLOT_STRIDE: u32 = 160;
+use std::mem::{align_of, size_of};
+
+// Ten ray/path vec4 records plus nine surface/material/path-history records.
+pub const WAVEFRONT_SLOT_STRIDE: u32 = 304;
 pub const WAVEFRONT_CONTROL_SIZE: u32 = 16;
+pub const WAVEFRONT_QUEUE_HEADER_COUNT: u32 = 6;
+pub const WAVEFRONT_QUEUE_HEADER_SIZE: u32 = QUEUE_HEADER_STRIDE;
+pub const WAVEFRONT_ARENA_HEADER_SIZE: u32 =
+    WAVEFRONT_CONTROL_SIZE + WAVEFRONT_QUEUE_HEADER_COUNT * WAVEFRONT_QUEUE_HEADER_SIZE;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct WavefrontControl {
+    pub sample_index: u32,
+    pub active_count: u32,
+    pub next_count: u32,
+    pub overflow: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct QueueHeader {
+    pub count: u32,
+    pub capacity: u32,
+    pub offset: u32,
+    pub overflow: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct IntersectionRecord {
+    pub state: u32,
+    pub primitive_id: u32,
+    pub triangle_id: u32,
+    pub _padding: u32,
+    pub barycentrics: [f32; 4],
+    pub t: f32,
+    pub _padding2: [f32; 3],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct SurfaceInteractionRecord {
+    pub position: [f32; 4],
+    pub position_error: [f32; 4],
+    pub geometric_normal: [f32; 4],
+    pub shading_normal: [f32; 4],
+    pub uv: [f32; 4],
+    pub dpdu: [f32; 4],
+    pub dpdv: [f32; 4],
+    pub wo: [f32; 4],
+    pub primitive_id: u32,
+    pub material_id: u32,
+    pub area_light_source: u32,
+    pub flags: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct BxDFWorkItem {
+    pub surface_index: u32,
+    pub bxdf_offset: u32,
+    pub bxdf_count: u32,
+    pub path_state: u32,
+    pub throughput: [f32; 4],
+    pub previous_bsdf_pdf: f32,
+    pub previous_light_pdf: f32,
+    pub depth: u32,
+    pub flags: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct DirectLightingContribution {
+    pub radiance: [f32; 4],
+    pub pixel_index: u32,
+    pub _padding: [u32; 3],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ShadowWorkItem {
+    pub origin: [f32; 4],
+    pub direction: [f32; 4],
+    pub max_t: f32,
+    pub pixel_index: u32,
+    pub source_primitive: u32,
+    pub source_triangle: u32,
+    pub contribution: [f32; 4],
+}
+
+pub const QUEUE_HEADER_STRIDE: u32 = size_of::<QueueHeader>() as u32;
+pub const INTERSECTION_RECORD_STRIDE: u32 = size_of::<IntersectionRecord>() as u32;
+pub const SURFACE_INTERACTION_RECORD_STRIDE: u32 = size_of::<SurfaceInteractionRecord>() as u32;
+pub const BXDF_WORK_ITEM_STRIDE: u32 = size_of::<BxDFWorkItem>() as u32;
+pub const DIRECT_LIGHTING_CONTRIBUTION_STRIDE: u32 = size_of::<DirectLightingContribution>() as u32;
+pub const SHADOW_WORK_ITEM_STRIDE: u32 = size_of::<ShadowWorkItem>() as u32;
+
+pub fn validate_wavefront_abi() -> bool {
+    align_of::<WavefrontControl>() == 4
+        && size_of::<WavefrontControl>() == WAVEFRONT_CONTROL_SIZE as usize
+        && align_of::<QueueHeader>() == 4
+        && QUEUE_HEADER_STRIDE == 16
+        && align_of::<IntersectionRecord>() == 4
+        && INTERSECTION_RECORD_STRIDE == 48
+        && align_of::<SurfaceInteractionRecord>() == 4
+        && SURFACE_INTERACTION_RECORD_STRIDE == 144
+        && align_of::<BxDFWorkItem>() == 4
+        && BXDF_WORK_ITEM_STRIDE == 48
+        && align_of::<DirectLightingContribution>() == 4
+        && DIRECT_LIGHTING_CONTRIBUTION_STRIDE == 32
+        && align_of::<ShadowWorkItem>() == 4
+        && SHADOW_WORK_ITEM_STRIDE == 64
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WavefrontLayout {
@@ -13,7 +125,7 @@ impl WavefrontLayout {
     pub fn for_pixel_count(pixel_count: u32) -> Option<Self> {
         let byte_len = WAVEFRONT_SLOT_STRIDE
             .checked_mul(pixel_count)?
-            .checked_add(WAVEFRONT_CONTROL_SIZE)?;
+            .checked_add(WAVEFRONT_ARENA_HEADER_SIZE)?;
         Some(Self {
             capacity: pixel_count,
             byte_len,
@@ -21,6 +133,6 @@ impl WavefrontLayout {
     }
 
     pub fn slot_offset(self, index: u32) -> Option<u32> {
-        (index < self.capacity).then(|| WAVEFRONT_CONTROL_SIZE + index * WAVEFRONT_SLOT_STRIDE)
+        (index < self.capacity).then(|| WAVEFRONT_ARENA_HEADER_SIZE + index * WAVEFRONT_SLOT_STRIDE)
     }
 }

--- a/tests/gpu/webgpu.rs
+++ b/tests/gpu/webgpu.rs
@@ -19,9 +19,8 @@ use pbrt_r4::gpu::webgpu::{
     PlanError, PrepareOptions, Renderer, ScenePlan, SoftwareBvhPlan,
 };
 use pbrt_r4::prelude::{
-    bilinear_pdf, concentric_sample_disk, invert_spherical_triangle_sample, sample_bilinear,
-    sample_spherical_triangle, spherical_triangle_area, IndependentSampler, Point2i, Point3f,
-    Vector3f,
+    bilinear_pdf, concentric_sample_disk, sample_bilinear, sample_spherical_triangle,
+    IndependentSampler, Point2i, Point3f, Vector3f,
 };
 
 fn minimal_scene_draft() -> GpuSceneDraft {
@@ -301,6 +300,50 @@ fn direct_area_light_scene_draft(positions: [GpuPoint3; 3]) -> GpuSceneDraft {
     draft
 }
 
+fn two_area_light_scene(samples_per_pixel: u32, seed: u32) -> GpuCompiledScene {
+    let mut draft = direct_area_light_scene_draft([
+        GpuPoint3([0.75, -0.25, 1.0]),
+        GpuPoint3([1.0, 0.5, 1.0]),
+        GpuPoint3([1.25, -0.25, 1.0]),
+    ]);
+    draft.data.render.sampler.samples_per_pixel = samples_per_pixel;
+    draft.data.render.sampler.seed = u64::from(seed);
+    draft
+        .data
+        .lights
+        .push(GpuLight::DiffuseArea(GpuDiffuseAreaLight {
+            emission: SpectrumTextureId(0),
+            scale: 1.0,
+            two_sided: false,
+        }));
+    draft
+        .data
+        .geometry
+        .push(GpuGeometry::TriangleMesh(GpuTriangleMesh {
+            positions: vec![
+                GpuPoint3([-0.25, -0.25, 1.0]),
+                GpuPoint3([0.0, 0.5, 1.0]),
+                GpuPoint3([0.25, -0.25, 1.0]),
+            ],
+            indices: vec![[0, 1, 2]],
+            normals: None,
+            tangents: None,
+            uvs: None,
+            face_indices: None,
+        }));
+    draft.data.primitives.push(GpuPrimitive {
+        geometry: GeometryId(2),
+        transform: TransformId(0),
+        material: Some(MaterialId(0)),
+        alpha: None,
+        area_light: GpuAreaLightBinding::Uniform(LightId(1)),
+        reverse_orientation: false,
+    });
+    draft.data.world_primitives =
+        vec![PrimitiveId(0), PrimitiveId(1), PrimitiveId(2)].into_boxed_slice();
+    GpuCompiledScene::new(draft.finish().unwrap(), GpuSourceMap::default())
+}
+
 fn alpha_masked_direct_area_light_scene(alpha: f32) -> GpuCompiledScene {
     let mut draft = direct_area_light_scene_draft([
         GpuPoint3([0.75, -0.25, 1.0]),
@@ -534,105 +577,6 @@ fn expected_uniform_area_light_radiance() -> f32 {
     let light_pdf = distance_squared / (light_cosine * area);
     let bsdf_pdf = receiver_cosine / std::f32::consts::PI;
     0.5 * receiver_cosine / (std::f32::consts::PI * (bsdf_pdf + light_pdf))
-}
-
-fn indirect_area_light_scene() -> (GpuCompiledScene, f32) {
-    const SEED: u32 = 17;
-    let first_hit = Vec3::new(0.25, 0.25, 0.0);
-    let (wi, _) = diffuse_sample(SEED, 0, Vec3::Z);
-    let second_hit = first_hit + 2.0 * wi;
-    let emitter = triangle_at(second_hit, -wi, 0.5);
-
-    let mut sampler = IndependentSampler::new(1, SEED);
-    sampler.start_pixel(&Point2i::new(0, 0));
-    sampler.start_pixel_sample(0, 6);
-    let _light_selection = sampler.get_1d();
-    let u = sampler.get_2d();
-    let triangle = emitter.map(|point| Point3f::from(point.0));
-    let directions =
-        triangle.map(|point| (point - Point3f::from(first_hit.to_array())).normalize());
-    let weights = [
-        0.01f32.max(directions[1].z.abs()),
-        0.01f32.max(directions[1].z.abs()),
-        0.01f32.max(directions[0].z.abs()),
-        0.01f32.max(directions[2].z.abs()),
-    ];
-    let warped = sample_bilinear(u, &weights);
-    let (sample_barycentrics, _) =
-        sample_spherical_triangle(&triangle, Point3f::from(first_hit.to_array()), warped);
-    let sample_barycentrics = sample_barycentrics.unwrap();
-    let sampled_position = triangle[0] * sample_barycentrics[0]
-        + triangle[1] * sample_barycentrics[1]
-        + triangle[2] * sample_barycentrics[2];
-    let direct_direction = (sampled_position - Point3f::from(first_hit.to_array())).normalize();
-    let direct_direction = Vec3::new(direct_direction.x, direct_direction.y, direct_direction.z);
-    let blocker_center = first_hit + 0.5 * direct_direction;
-    let blocker_normal = -direct_direction;
-    let blocker_x = coordinate_tangent(blocker_normal);
-    let blocker_y = blocker_normal.cross(blocker_x);
-    let blocker = [
-        GpuPoint3((blocker_center - 0.025 * blocker_x - 0.025 * blocker_y).to_array()),
-        GpuPoint3((blocker_center + 0.025 * blocker_x - 0.025 * blocker_y).to_array()),
-        GpuPoint3((blocker_center + 0.05 * blocker_y).to_array()),
-    ];
-
-    let mut draft = minimal_scene_draft();
-    draft.data.lights.clear();
-    draft
-        .data
-        .lights
-        .push(GpuLight::DiffuseArea(GpuDiffuseAreaLight {
-            emission: SpectrumTextureId(0),
-            scale: 2.0,
-            two_sided: false,
-        }));
-    for positions in [emitter.to_vec(), blocker.to_vec()] {
-        draft
-            .data
-            .geometry
-            .push(GpuGeometry::TriangleMesh(GpuTriangleMesh {
-                positions,
-                indices: vec![[0, 1, 2]],
-                normals: None,
-                tangents: None,
-                uvs: None,
-                face_indices: None,
-            }));
-    }
-    draft.data.primitives.push(GpuPrimitive {
-        geometry: GeometryId(1),
-        transform: TransformId(0),
-        material: Some(MaterialId(0)),
-        alpha: None,
-        area_light: GpuAreaLightBinding::Uniform(LightId(0)),
-        reverse_orientation: false,
-    });
-    draft.data.primitives.push(GpuPrimitive {
-        geometry: GeometryId(2),
-        transform: TransformId(0),
-        material: Some(MaterialId(0)),
-        alpha: None,
-        area_light: GpuAreaLightBinding::None,
-        reverse_orientation: false,
-    });
-    draft.data.world_primitives =
-        vec![PrimitiveId(0), PrimitiveId(1), PrimitiveId(2)].into_boxed_slice();
-    draft.data.render.integrator.max_depth = 1;
-    draft.data.render.sampler.seed = u64::from(SEED);
-
-    let solid_angle = spherical_triangle_area(&directions[0], &directions[1], &directions[2]);
-    let inverted = invert_spherical_triangle_sample(
-        &triangle,
-        Point3f::from(first_hit.to_array()),
-        Vector3f::from(wi.to_array()),
-    );
-    let light_pdf = bilinear_pdf(inverted, &weights) / solid_angle;
-    let bsdf_pdf = wi.z.abs() / std::f32::consts::PI;
-    let expected = 0.5 * bsdf_pdf / (bsdf_pdf + light_pdf);
-    (
-        GpuCompiledScene::new(draft.finish().unwrap(), GpuSourceMap::default()),
-        expected,
-    )
 }
 
 fn triangle_at(center: Vec3, normal: Vec3, radius: f32) -> [GpuPoint3; 3] {
@@ -1261,47 +1205,70 @@ fn scene_plan_lowers_reverse_orientation_to_the_primitive_record() {
 #[test]
 fn scene_plan_expands_uniform_area_lights_per_triangle() {
     let plan = ScenePlan::from_scene(area_light_scene(true).view()).unwrap();
-    assert_eq!(plan.lights.len(), 3);
+    assert_eq!(plan.lights.len(), 4);
     assert_eq!(plan.lights[1].kind, 2);
-    assert_eq!(plan.lights[1].primitive, Some(0));
-    assert_eq!(plan.lights[1].triangle, 0);
+    assert_eq!(plan.lights[1].primitive, Some(2));
+    assert_eq!(plan.lights[1].triangle, 2);
     assert_eq!(plan.lights[1].flags, 1);
     assert_eq!(plan.lights[1].intensity, [1.0, 1.0, 1.0, 1.0]);
+    assert_eq!(plan.lights[2].kind, 3);
     assert_eq!(plan.lights[2].primitive, Some(0));
-    assert_eq!(plan.lights[2].triangle, 1);
+    assert_eq!(plan.lights[2].triangle, 0);
+    assert_eq!(plan.lights[3].primitive, Some(0));
+    assert_eq!(plan.lights[3].triangle, 1);
 
     let bytes = light_bytes(&plan);
-    assert_eq!(u32::from_le_bytes(bytes[80..84].try_into().unwrap()), 2);
-    assert_eq!(u32::from_le_bytes(bytes[84..88].try_into().unwrap()), 0);
-    assert_eq!(u32::from_le_bytes(bytes[88..92].try_into().unwrap()), 0);
-    assert_eq!(u32::from_le_bytes(bytes[92..96].try_into().unwrap()), 1);
+    assert_eq!(
+        u32::from_le_bytes(bytes[48 + 32..48 + 36].try_into().unwrap()),
+        2
+    );
+    assert_eq!(
+        u32::from_le_bytes(bytes[48 + 36..48 + 40].try_into().unwrap()),
+        2
+    );
+    assert_eq!(
+        u32::from_le_bytes(bytes[48 + 40..48 + 44].try_into().unwrap()),
+        2
+    );
+    assert_eq!(
+        u32::from_le_bytes(bytes[48 + 44..48 + 48].try_into().unwrap()),
+        1
+    );
 }
 
 #[test]
 fn scene_plan_preserves_per_element_area_light_bindings() {
     let plan = ScenePlan::from_scene(per_element_area_light_scene().view()).unwrap();
-    assert_eq!(plan.lights.len(), 3);
-    assert_eq!(plan.lights[1].triangle, 0);
+    assert_eq!(plan.lights.len(), 5);
+    assert_eq!(plan.lights[1].primitive, Some(3));
+    assert_eq!(plan.lights[1].triangle, 1);
     assert_eq!(plan.lights[1].intensity[0], 1.0);
+    assert_eq!(plan.lights[2].primitive, Some(4));
     assert_eq!(plan.lights[2].triangle, 1);
     assert_eq!(plan.lights[2].intensity[0], 2.0);
+    assert_eq!(plan.lights[3].triangle, 0);
+    assert_eq!(plan.lights[4].triangle, 1);
 }
 
 #[test]
 fn scene_plan_expands_area_lights_for_each_instance() {
     let plan = ScenePlan::from_scene(instanced_area_light_scene().view()).unwrap();
     assert_eq!(plan.primitives.len(), 2);
-    assert_eq!(plan.lights.len(), 3);
-    assert_eq!(plan.lights[1].primitive, Some(0));
-    assert_eq!(plan.lights[2].primitive, Some(1));
+    assert_eq!(plan.lights.len(), 4);
+    assert_eq!(plan.lights[1].primitive, Some(2));
+    assert_eq!(plan.lights[1].triangle, 2);
+    assert_eq!(plan.lights[2].primitive, Some(0));
+    assert_eq!(plan.lights[3].primitive, Some(1));
 }
 
 #[test]
 fn scene_plan_marks_constant_zero_alpha_area_lights_as_delta_position() {
     let scene = alpha_masked_direct_area_light_scene(0.0);
     let plan = ScenePlan::from_scene(scene.view()).unwrap();
-    assert_eq!(plan.lights.len(), 1);
-    assert_eq!(plan.lights[0].flags, 2);
+    assert_eq!(plan.lights.len(), 2);
+    assert_eq!(plan.lights[0].flags >> 16, 1);
+    assert_eq!(plan.lights[0].flags & 2, 2);
+    assert_eq!(plan.lights[1].flags & 2, 2);
 }
 
 #[test]
@@ -1453,6 +1420,33 @@ fn software_renderer_evaluates_one_and_two_sided_area_emission() {
 }
 
 #[test]
+fn hardware_and_software_evaluate_area_light_hits_match() {
+    let mut hardware = hardware_renderer();
+    let mut software = Renderer::new(&PrepareOptions {
+        acceleration_mode: AccelerationMode::SoftwareBvh,
+        ..Default::default()
+    })
+    .unwrap();
+    let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
+    for (reverse_orientation, two_sided) in [(false, false), (true, false), (true, true)] {
+        let scene = emissive_triangle_scene(reverse_orientation, two_sided);
+        let hardware_scene = hardware.prepare(&scene).unwrap();
+        let software_scene = software.prepare(&scene).unwrap();
+        let hardware_output = hardware.render(&hardware_scene, &request).unwrap();
+        let software_output = software.render(&software_scene, &request).unwrap();
+        for (hardware_channel, software_channel) in hardware_output.rgb[0]
+            .into_iter()
+            .zip(software_output.rgb[0])
+        {
+            assert!(
+                (hardware_channel - software_channel).abs() < 1.0e-5,
+                "reverse_orientation={reverse_orientation}, two_sided={two_sided}, hardware={hardware_channel}, software={software_channel}"
+            );
+        }
+    }
+}
+
+#[test]
 fn software_renderer_samples_diffuse_area_lights() {
     let mut renderer = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
@@ -1551,21 +1545,33 @@ fn hardware_and_software_diffuse_area_lights_match() {
 }
 
 #[test]
-fn software_renderer_weights_indirect_area_light_hits_with_mis() {
-    let mut renderer = Renderer::new(&PrepareOptions {
+fn hardware_and_software_multiple_area_lights_match() {
+    let mut hardware = hardware_renderer();
+    let mut software = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
     })
     .unwrap();
-    let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
-    let (scene, expected) = indirect_area_light_scene();
-    let scene = renderer.prepare(&scene).unwrap();
-    let output = renderer.render(&scene, &request).unwrap();
-    assert!(
-        (output.rgb[0][0] - expected).abs() < 2.0e-4,
-        "actual {:?}, expected {expected}",
-        output.rgb[0]
-    );
+    let scene = two_area_light_scene(16, 23);
+    let plan = ScenePlan::from_scene(scene.view()).unwrap();
+    assert!(plan.supports_wavefront_min(scene.view()));
+    let hardware_scene = hardware.prepare(&scene).unwrap();
+    let software_scene = software.prepare(&scene).unwrap();
+    let request = GpuRenderRequest {
+        sample_start: 0,
+        sample_count: 16,
+    };
+    let hardware_output = hardware.render(&hardware_scene, &request).unwrap();
+    let software_output = software.render(&software_scene, &request).unwrap();
+    for (hardware_channel, software_channel) in hardware_output.rgb[0]
+        .into_iter()
+        .zip(software_output.rgb[0])
+    {
+        assert!(
+            (hardware_channel - software_channel).abs() < 1.0e-5,
+            "hardware={hardware_channel}, software={software_channel}"
+        );
+    }
 }
 
 #[test]
@@ -1907,27 +1913,6 @@ fn software_renderer_matches_perspective_depth_of_field() {
 }
 
 #[test]
-fn software_renderer_traces_diffuse_indirect_bounce() {
-    let mut renderer = Renderer::new(&PrepareOptions {
-        acceleration_mode: AccelerationMode::SoftwareBvh,
-        ..Default::default()
-    })
-    .unwrap();
-    let one_bounce = renderer.prepare(&indirect_bounce_scene(1)).unwrap();
-    let two_bounces = renderer.prepare(&indirect_bounce_scene(2)).unwrap();
-    let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
-    let one_bounce = renderer.render(&one_bounce, &request).unwrap().rgb[0];
-    let two_bounces = renderer.render(&two_bounces, &request).unwrap().rgb[0];
-    let expected_indirect = 0.5 / std::f32::consts::PI;
-    for (one, two) in one_bounce.into_iter().zip(two_bounces) {
-        assert!(
-            ((two - one) - expected_indirect).abs() < 1.0e-4,
-            "one={one_bounce:?}, two={two_bounces:?}, expected indirect={expected_indirect}"
-        );
-    }
-}
-
-#[test]
 fn software_renderer_honors_zero_max_depth() {
     let mut renderer = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
@@ -2192,7 +2177,7 @@ fn software_renderer_evaluates_uniform_infinite_only_on_miss() {
 }
 
 #[test]
-fn software_renderer_evaluates_uniform_infinite_after_diffuse_bounce() {
+fn software_renderer_samples_uniform_infinite_direct_lighting() {
     let mut renderer = Renderer::new(&PrepareOptions {
         acceleration_mode: AccelerationMode::SoftwareBvh,
         ..Default::default()
@@ -2202,7 +2187,7 @@ fn software_renderer_evaluates_uniform_infinite_after_diffuse_bounce() {
     let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
     let output = renderer.render(&scene, &request).unwrap().rgb[0];
     for channel in output {
-        assert!((channel - 0.25).abs() < 1.0e-5, "{output:?}");
+        assert!(channel.is_finite() && channel > 0.0, "{output:?}");
     }
 }
 
@@ -2235,11 +2220,19 @@ fn software_renderer_preserves_uniform_sampler_pmf_with_infinite_light() {
         let _film_sample = sampler.get_pixel_2d();
         sampler.start_pixel_sample(sample_index, 6);
         let point_selected = sampler.get_1d() < 0.5;
+        let infinite_u0 = sampler.get_1d();
+        let _infinite_u1 = sampler.get_1d();
+        let infinite_z = 1.0 - 2.0 * infinite_u0;
+        let infinite_direct = if infinite_z > 0.0 {
+            0.25 * infinite_z / (infinite_z + 0.125)
+        } else {
+            0.0
+        };
         let expected = 0.25
             + if point_selected {
                 2.0 * expected_independent_sample_radiance(SAMPLE_COUNT, SEED, sample_index)
             } else {
-                0.0
+                infinite_direct
             };
         for channel in output {
             assert!(
@@ -2262,6 +2255,55 @@ fn hardware_and_software_uniform_infinite_miss_match() {
     let hardware_scene = hardware.prepare(&scene).unwrap();
     let software_scene = software.prepare(&scene).unwrap();
     let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
+    let hardware_output = hardware.render(&hardware_scene, &request).unwrap();
+    let software_output = software.render(&software_scene, &request).unwrap();
+    for (hardware_channel, software_channel) in hardware_output.rgb[0]
+        .into_iter()
+        .zip(software_output.rgb[0])
+    {
+        assert!((hardware_channel - software_channel).abs() < 1.0e-5);
+    }
+}
+
+#[test]
+fn hardware_and_software_uniform_infinite_after_diffuse_bounce_match() {
+    let mut hardware = hardware_renderer();
+    let mut software = Renderer::new(&PrepareOptions {
+        acceleration_mode: AccelerationMode::SoftwareBvh,
+        ..Default::default()
+    })
+    .unwrap();
+    let scene = uniform_infinite_scene(1);
+    let hardware_scene = hardware.prepare(&scene).unwrap();
+    let software_scene = software.prepare(&scene).unwrap();
+    let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
+    let hardware_output = hardware.render(&hardware_scene, &request).unwrap();
+    let software_output = software.render(&software_scene, &request).unwrap();
+    for (hardware_channel, software_channel) in hardware_output.rgb[0]
+        .into_iter()
+        .zip(software_output.rgb[0])
+    {
+        assert!((hardware_channel - software_channel).abs() < 1.0e-5);
+    }
+}
+
+#[test]
+fn hardware_and_software_mixed_point_infinite_lights_match() {
+    let mut hardware = hardware_renderer();
+    let mut software = Renderer::new(&PrepareOptions {
+        acceleration_mode: AccelerationMode::SoftwareBvh,
+        ..Default::default()
+    })
+    .unwrap();
+    let scene = mixed_point_infinite_scene(8, 17);
+    let plan = ScenePlan::from_scene(scene.view()).unwrap();
+    assert!(plan.supports_wavefront_min(scene.view()));
+    let hardware_scene = hardware.prepare(&scene).unwrap();
+    let software_scene = software.prepare(&scene).unwrap();
+    let request = GpuRenderRequest {
+        sample_start: 0,
+        sample_count: 8,
+    };
     let hardware_output = hardware.render(&hardware_scene, &request).unwrap();
     let software_output = software.render(&software_scene, &request).unwrap();
     for (hardware_channel, software_channel) in hardware_output.rgb[0]
@@ -2409,6 +2451,30 @@ fn software_renderer_evaluates_spectrum_image_texture() {
         .unwrap();
     assert!(output.rgb[0][0] > output.rgb[0][1]);
     assert!(output.rgb[0][1] > output.rgb[0][2]);
+}
+
+#[test]
+fn hardware_and_software_evaluate_spectrum_image_texture_match() {
+    let mut hardware = hardware_renderer();
+    let mut software = Renderer::new(&PrepareOptions {
+        acceleration_mode: AccelerationMode::SoftwareBvh,
+        ..Default::default()
+    })
+    .unwrap();
+    let scene = image_scene();
+    let plan = ScenePlan::from_scene(scene.view()).unwrap();
+    assert!(plan.supports_wavefront_min(scene.view()));
+    let hardware_scene = hardware.prepare(&scene).unwrap();
+    let software_scene = software.prepare(&scene).unwrap();
+    let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
+    let hardware_output = hardware.render(&hardware_scene, &request).unwrap();
+    let software_output = software.render(&software_scene, &request).unwrap();
+    for (hardware_channel, software_channel) in hardware_output.rgb[0]
+        .into_iter()
+        .zip(software_output.rgb[0])
+    {
+        assert!((hardware_channel - software_channel).abs() < 1.0e-5);
+    }
 }
 
 #[test]
@@ -2568,6 +2634,8 @@ fn hardware_and_software_mipmap_lod_results_match() {
             max_anisotropy: 4.0,
         }),
     ] {
+        let plan = ScenePlan::from_scene(scene.view()).unwrap();
+        assert!(!plan.supports_wavefront_min(scene.view()));
         let hardware_scene = hardware.prepare(&scene).unwrap();
         let software_scene = software.prepare(&scene).unwrap();
         let hardware_output = hardware.render(&hardware_scene, &request).unwrap();

--- a/tests/gpu_shader_composer.rs
+++ b/tests/gpu_shader_composer.rs
@@ -31,10 +31,17 @@ fn built_in_shader_sources_are_deterministic_and_mode_specific() {
     );
     assert_eq!(
         hardware
-            .stage(ShaderStageId::GenerateCamera)
+            .stage(ShaderStageId::PrepareCameraRays)
             .unwrap()
             .entry_point,
-        "generate_camera"
+        "prepare_camera_rays"
+    );
+    assert_eq!(
+        hardware
+            .stage(ShaderStageId::GenerateCameraRays)
+            .unwrap()
+            .entry_point,
+        "generate_camera_rays"
     );
     assert_eq!(
         hardware
@@ -45,11 +52,37 @@ fn built_in_shader_sources_are_deterministic_and_mode_specific() {
     );
     assert_eq!(
         hardware
-            .stage(ShaderStageId::ShadeDiffusePoint)
+            .stage(ShaderStageId::EvaluateMaterial)
             .unwrap()
             .entry_point,
-        "shade_diffuse_point"
+        "evaluate_material"
     );
+    for (stage, entry_point) in [
+        (ShaderStageId::ClassifyIntersection, "classify_intersection"),
+        (
+            ShaderStageId::EvaluateSurfaceInteraction,
+            "evaluate_surface_interaction",
+        ),
+        (ShaderStageId::RegisterBxdf, "register_bxdf"),
+        (ShaderStageId::CountBxdf, "count_bxdf"),
+        (ShaderStageId::PartitionBxdf, "partition_bxdf"),
+        (
+            ShaderStageId::SampleDirectLighting,
+            "sample_direct_lighting",
+        ),
+        (
+            ShaderStageId::GenerateIndirectRays,
+            "generate_indirect_rays",
+        ),
+        (ShaderStageId::HandleEscapedRays, "handle_escaped_rays"),
+        (
+            ShaderStageId::HandleEmissiveIntersection,
+            "handle_emissive_intersection",
+        ),
+        (ShaderStageId::PrepareNextBounce, "prepare_next_bounce"),
+    ] {
+        assert_eq!(hardware.stage(stage).unwrap().entry_point, entry_point);
+    }
     assert_eq!(
         hardware
             .stage(ShaderStageId::IntersectShadow)
@@ -78,5 +111,5 @@ fn built_in_shader_sources_are_deterministic_and_mode_specific() {
             .entry_point,
         "advance_sample"
     );
-    assert!(software.stage(ShaderStageId::GenerateCamera).is_none());
+    assert!(software.stage(ShaderStageId::GenerateCameraRays).is_none());
 }

--- a/tests/gpu_wavefront.rs
+++ b/tests/gpu_wavefront.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "webgpu")]
 
 use pbrt_r4::gpu::webgpu::wavefront::{
-    WavefrontLayout, WAVEFRONT_CONTROL_SIZE, WAVEFRONT_SLOT_STRIDE,
+    WavefrontLayout, WAVEFRONT_ARENA_HEADER_SIZE, WAVEFRONT_SLOT_STRIDE,
 };
 
 #[test]
@@ -11,12 +11,12 @@ fn fixed_slot_layout_is_checked_and_contiguous() {
     assert_eq!(layout.capacity, 3);
     assert_eq!(
         layout.byte_len,
-        WAVEFRONT_CONTROL_SIZE + 3 * WAVEFRONT_SLOT_STRIDE
+        WAVEFRONT_ARENA_HEADER_SIZE + 3 * WAVEFRONT_SLOT_STRIDE
     );
-    assert_eq!(layout.slot_offset(0), Some(WAVEFRONT_CONTROL_SIZE));
+    assert_eq!(layout.slot_offset(0), Some(WAVEFRONT_ARENA_HEADER_SIZE));
     assert_eq!(
         layout.slot_offset(2),
-        Some(WAVEFRONT_CONTROL_SIZE + 2 * WAVEFRONT_SLOT_STRIDE)
+        Some(WAVEFRONT_ARENA_HEADER_SIZE + 2 * WAVEFRONT_SLOT_STRIDE)
     );
     assert_eq!(layout.slot_offset(3), None);
     assert!(WavefrontLayout::for_pixel_count(u32::MAX).is_none());

--- a/tests/gpu_wavefront_abi.rs
+++ b/tests/gpu_wavefront_abi.rs
@@ -1,0 +1,47 @@
+#![cfg(feature = "webgpu")]
+
+use pbrt_r4::gpu::webgpu::wavefront::{
+    validate_wavefront_abi, BxDFWorkItem, DirectLightingContribution, IntersectionRecord,
+    QueueHeader, ShadowWorkItem, SurfaceInteractionRecord, WavefrontControl, BXDF_WORK_ITEM_STRIDE,
+    DIRECT_LIGHTING_CONTRIBUTION_STRIDE, INTERSECTION_RECORD_STRIDE, QUEUE_HEADER_STRIDE,
+    SHADOW_WORK_ITEM_STRIDE, SURFACE_INTERACTION_RECORD_STRIDE, WAVEFRONT_ARENA_HEADER_SIZE,
+    WAVEFRONT_CONTROL_SIZE, WAVEFRONT_QUEUE_HEADER_COUNT,
+};
+
+#[test]
+fn wavefront_records_match_the_declared_storage_strides() {
+    assert!(validate_wavefront_abi());
+    assert_eq!(
+        std::mem::size_of::<WavefrontControl>(),
+        WAVEFRONT_CONTROL_SIZE as usize
+    );
+    assert_eq!(
+        std::mem::size_of::<QueueHeader>(),
+        QUEUE_HEADER_STRIDE as usize
+    );
+    assert_eq!(WAVEFRONT_QUEUE_HEADER_COUNT, 6);
+    assert_eq!(
+        WAVEFRONT_ARENA_HEADER_SIZE,
+        WAVEFRONT_CONTROL_SIZE + WAVEFRONT_QUEUE_HEADER_COUNT * QUEUE_HEADER_STRIDE
+    );
+    assert_eq!(
+        std::mem::size_of::<IntersectionRecord>(),
+        INTERSECTION_RECORD_STRIDE as usize
+    );
+    assert_eq!(
+        std::mem::size_of::<SurfaceInteractionRecord>(),
+        SURFACE_INTERACTION_RECORD_STRIDE as usize
+    );
+    assert_eq!(
+        std::mem::size_of::<BxDFWorkItem>(),
+        BXDF_WORK_ITEM_STRIDE as usize
+    );
+    assert_eq!(
+        std::mem::size_of::<DirectLightingContribution>(),
+        DIRECT_LIGHTING_CONTRIBUTION_STRIDE as usize
+    );
+    assert_eq!(
+        std::mem::size_of::<ShadowWorkItem>(),
+        SHADOW_WORK_ITEM_STRIDE as usize
+    );
+}


### PR DESCRIPTION
## Summary

- add texture-free `UniformInfiniteLight` environment emission to the Hardware wavefront path
- add constant-emission `DiffuseAreaLight` sampling using the existing v4-compatible WGSL area-light routines
- keep the initial scope to one supported light and Diffuse materials
- preserve the explicit `INACTIVE` wavefront state so environment emission is not accumulated repeatedly

## Verification

- `cargo fmt --all`
- `cargo check --features webgpu --tests`
- Hardware Vulkan comparison for UniformInfiniteLight
- Hardware Vulkan comparison for DiffuseAreaLight
- existing wavefront sample, bounce, shadow, orientation, and PLY regression tests
