### PR TITLE
Remove redundant GPU IR type prefixes

### DIFF
--- a/src/cmd/pbrt.rs
+++ b/src/cmd/pbrt.rs
@@ -7,7 +7,7 @@ use pbrt_r4::base::filter::Filter;
 use pbrt_r4::displays::SequentialDisplay;
 use pbrt_r4::displays::TevDisplay;
 #[cfg(feature = "webgpu")]
-use pbrt_r4::gpu::ir::{GpuRenderConfig, GpuRenderRequest};
+use pbrt_r4::gpu::ir::{RenderConfig, RenderRequest};
 #[cfg(feature = "webgpu")]
 use pbrt_r4::gpu::webgpu::{PrepareOptions, Renderer};
 #[cfg(feature = "webgpu")]
@@ -682,9 +682,9 @@ fn render_gpu_scene(input_path: &Path, opts: &CommandOptions) -> i32 {
         }
     };
     let render = compiled.view().render;
-    let mut render_config = GpuRenderConfig::default();
+    let mut render_config = RenderConfig::default();
     render_config.sampler.samples_per_pixel = render.sampler.samples_per_pixel;
-    let request = match GpuRenderRequest::new(&render_config, 0, render.sampler.samples_per_pixel) {
+    let request = match RenderRequest::new(&render_config, 0, render.sampler.samples_per_pixel) {
         Ok(request) => request,
         Err(error) => {
             error!("invalid GPU render request: {:?}", error);

--- a/src/gpu/compiler/diagnostics.rs
+++ b/src/gpu/compiler/diagnostics.rs
@@ -1,27 +1,27 @@
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GpuSourceLocation {
+pub struct SourceLocation {
     pub filename: String,
     pub line: u32,
     pub column: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum GpuCompileError {
+pub enum CompileError {
     UnsupportedShape {
         name: String,
-        source: GpuSourceLocation,
+        source: SourceLocation,
     },
     UnsupportedSceneFeature {
         feature: &'static str,
-        source: GpuSourceLocation,
+        source: SourceLocation,
     },
     MissingParameter {
         parameter: &'static str,
-        source: GpuSourceLocation,
+        source: SourceLocation,
     },
     InvalidParameter {
         parameter: &'static str,
         detail: String,
-        source: GpuSourceLocation,
+        source: SourceLocation,
     },
 }

--- a/src/gpu/compiler/light.rs
+++ b/src/gpu/compiler/light.rs
@@ -1,9 +1,9 @@
 use super::{
     build_mip_storage, compile_rgb_spectrum, compile_transform, encode_mip_storage,
     finite_parameter, gpu_color_encoding, invalid_parameter, light_source_location, raw_encoding,
-    raw_linear_pixels, DiffuseAreaLight, GpuCompileError, GpuSourceLocation, ImageChannels,
-    ImageFilter, ImageResource, ImageWrapMode, Index, Light, LightSceneEntity, PointLight,
-    SceneBuilder, SpectrumResource, SpectrumTexture, TextureMapping, Transform, TransformId,
+    raw_linear_pixels, CompileError, DiffuseAreaLight, ImageChannels, ImageFilter, ImageResource,
+    ImageWrapMode, Index, Light, LightSceneEntity, PointLight, SceneBuilder, SourceLocation,
+    SpectrumResource, SpectrumTexture, TextureMapping, Transform, TransformId,
     UniformInfiniteLight,
 };
 use crate::gpu::ir::{ImageId, LightId, SpectrumTextureId, SpectrumType, TextureMappingId};
@@ -18,7 +18,7 @@ pub fn compile_light(
     transforms: &mut Vec<Transform>,
     spectra: &mut Vec<SpectrumResource>,
     lights: &mut Vec<Light>,
-) -> Result<(), GpuCompileError> {
+) -> Result<(), CompileError> {
     let source = light_source_location(light);
     let transform_id = TransformId(transforms.len() as Index);
     transforms.push(compile_transform(&light.base.render_from_object, &source)?);
@@ -26,7 +26,7 @@ pub fn compile_light(
         "point" => ("I", 1.0),
         "infinite" => ("L", 1.0),
         _ => {
-            return Err(GpuCompileError::UnsupportedSceneFeature {
+            return Err(CompileError::UnsupportedSceneFeature {
                 feature: "non-point/non-infinite light",
                 source,
             })
@@ -63,22 +63,22 @@ pub fn compile_area_light(
     images: &mut Vec<ImageResource>,
     texture_mappings: &mut Vec<TextureMapping>,
     lights: &mut Vec<Light>,
-    source: &GpuSourceLocation,
-) -> Result<LightId, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<LightId, CompileError> {
     if area.base.name != "diffuse" {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "non-diffuse area light",
             source: source.clone(),
         });
     }
     if area.base.params.get_floats_ref("power").is_some() {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "area light power normalization",
             source: source.clone(),
         });
     }
     if area.base.params.get_textures_ref("L").is_some() {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "textured area light emission",
             source: source.clone(),
         });
@@ -124,8 +124,8 @@ fn compile_area_light_image(
     images: &mut Vec<ImageResource>,
     texture_mappings: &mut Vec<TextureMapping>,
     spectrum_textures: &mut Vec<SpectrumTexture>,
-    source: &GpuSourceLocation,
-) -> Result<SpectrumTextureId, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<SpectrumTextureId, CompileError> {
     let encoding = if Path::new(filename)
         .extension()
         .and_then(|extension| extension.to_str())
@@ -135,13 +135,13 @@ fn compile_area_light_image(
     } else {
         ColorEncoding::parse("linear")
     }
-    .map_err(|error| GpuCompileError::InvalidParameter {
+    .map_err(|error| CompileError::InvalidParameter {
         parameter: "filename",
         detail: error.msg,
         source: source.clone(),
     })?;
     let raw = read_raw_image_with_encoding(filename, encoding).map_err(|error| {
-        GpuCompileError::InvalidParameter {
+        CompileError::InvalidParameter {
             parameter: "filename",
             detail: error.msg,
             source: source.clone(),

--- a/src/gpu/compiler/light.rs
+++ b/src/gpu/compiler/light.rs
@@ -1,12 +1,12 @@
 use super::{
     build_mip_storage, compile_rgb_spectrum, compile_transform, encode_mip_storage,
     finite_parameter, gpu_color_encoding, invalid_parameter, light_source_location, raw_encoding,
-    raw_linear_pixels, GpuCompileError, GpuDiffuseAreaLight, GpuImageChannels, GpuImageFilter,
-    GpuImageResource, GpuImageWrapMode, GpuIndex, GpuLight, GpuPointLight, GpuSourceLocation,
-    GpuSpectrumResource, GpuSpectrumTexture, GpuTextureMapping, GpuTransform,
-    GpuUniformInfiniteLight, LightSceneEntity, SceneBuilder, TransformId,
+    raw_linear_pixels, DiffuseAreaLight, GpuCompileError, GpuSourceLocation, ImageChannels,
+    ImageFilter, ImageResource, ImageWrapMode, Index, Light, LightSceneEntity, PointLight,
+    SceneBuilder, SpectrumResource, SpectrumTexture, TextureMapping, Transform, TransformId,
+    UniformInfiniteLight,
 };
-use crate::gpu::ir::{GpuSpectrumType, ImageId, LightId, SpectrumTextureId, TextureMappingId};
+use crate::gpu::ir::{ImageId, LightId, SpectrumTextureId, SpectrumType, TextureMappingId};
 use crate::parser::scene_builder::path_resolver::make_absolute_path;
 use crate::parser::scene_builder::AreaLightSceneEntity;
 use crate::util::imageio::{read_raw_image_with_encoding, ColorEncoding};
@@ -15,12 +15,12 @@ use std::path::Path;
 pub fn compile_light(
     _builder: &SceneBuilder,
     light: &LightSceneEntity,
-    transforms: &mut Vec<GpuTransform>,
-    spectra: &mut Vec<GpuSpectrumResource>,
-    lights: &mut Vec<GpuLight>,
+    transforms: &mut Vec<Transform>,
+    spectra: &mut Vec<SpectrumResource>,
+    lights: &mut Vec<Light>,
 ) -> Result<(), GpuCompileError> {
     let source = light_source_location(light);
-    let transform_id = TransformId(transforms.len() as GpuIndex);
+    let transform_id = TransformId(transforms.len() as Index);
     transforms.push(compile_transform(&light.base.render_from_object, &source)?);
     let (spectrum_name, default_scale) = match light.base.base.name.as_str() {
         "point" => ("I", 1.0),
@@ -41,12 +41,12 @@ pub fn compile_light(
     )?;
     let scale = finite_parameter(&light.base.base.params, "scale", default_scale, &source)?;
     match light.base.base.name.as_str() {
-        "point" => lights.push(GpuLight::Point(GpuPointLight {
+        "point" => lights.push(Light::Point(PointLight {
             render_from_light: transform_id,
             intensity: spectrum,
             scale,
         })),
-        "infinite" => lights.push(GpuLight::UniformInfinite(GpuUniformInfiniteLight {
+        "infinite" => lights.push(Light::UniformInfinite(UniformInfiniteLight {
             radiance: spectrum,
             scale,
         })),
@@ -58,11 +58,11 @@ pub fn compile_light(
 pub fn compile_area_light(
     builder: &SceneBuilder,
     area: &AreaLightSceneEntity,
-    spectra: &mut Vec<GpuSpectrumResource>,
-    spectrum_textures: &mut Vec<GpuSpectrumTexture>,
-    images: &mut Vec<GpuImageResource>,
-    texture_mappings: &mut Vec<GpuTextureMapping>,
-    lights: &mut Vec<GpuLight>,
+    spectra: &mut Vec<SpectrumResource>,
+    spectrum_textures: &mut Vec<SpectrumTexture>,
+    images: &mut Vec<ImageResource>,
+    texture_mappings: &mut Vec<TextureMapping>,
+    lights: &mut Vec<Light>,
     source: &GpuSourceLocation,
 ) -> Result<LightId, GpuCompileError> {
     if area.base.name != "diffuse" {
@@ -87,8 +87,8 @@ pub fn compile_area_light(
     let filename = params.get_one_filename("filename", "");
     let emission_texture = if filename.is_empty() {
         let emission = compile_rgb_spectrum(&params, "L", [1.0, 1.0, 1.0], source, spectra)?;
-        let emission_texture = SpectrumTextureId(spectrum_textures.len() as GpuIndex);
-        spectrum_textures.push(GpuSpectrumTexture::Constant { value: emission });
+        let emission_texture = SpectrumTextureId(spectrum_textures.len() as Index);
+        spectrum_textures.push(SpectrumTexture::Constant { value: emission });
         emission_texture
     } else {
         if params.get_points_ref("L").is_some()
@@ -110,8 +110,8 @@ pub fn compile_area_light(
         )?
     };
     let scale = finite_parameter(&area.base.params, "scale", 1.0, source)?;
-    let light_id = LightId(lights.len() as GpuIndex);
-    lights.push(GpuLight::DiffuseArea(GpuDiffuseAreaLight {
+    let light_id = LightId(lights.len() as Index);
+    lights.push(Light::DiffuseArea(DiffuseAreaLight {
         emission: emission_texture,
         scale,
         two_sided: area.base.params.get_one_bool("twosided", false),
@@ -121,9 +121,9 @@ pub fn compile_area_light(
 
 fn compile_area_light_image(
     filename: &str,
-    images: &mut Vec<GpuImageResource>,
-    texture_mappings: &mut Vec<GpuTextureMapping>,
-    spectrum_textures: &mut Vec<GpuSpectrumTexture>,
+    images: &mut Vec<ImageResource>,
+    texture_mappings: &mut Vec<TextureMapping>,
+    spectrum_textures: &mut Vec<SpectrumTexture>,
     source: &GpuSourceLocation,
 ) -> Result<SpectrumTextureId, GpuCompileError> {
     let encoding = if Path::new(filename)
@@ -166,31 +166,31 @@ fn compile_area_light_image(
     let (linear_storage, mip_levels) = build_mip_storage(&pixels, width, height, 3);
     let encoding = raw_encoding(&raw);
     let storage = encode_mip_storage(&linear_storage, &raw.data, encoding, 3);
-    let image = ImageId(images.len() as GpuIndex);
-    images.push(GpuImageResource {
+    let image = ImageId(images.len() as Index);
+    images.push(ImageResource {
         resolution: [width, height],
-        channels: GpuImageChannels::Rgb,
+        channels: ImageChannels::Rgb,
         storage,
         mip_levels,
         color_encoding: gpu_color_encoding(encoding),
     });
-    let mapping = TextureMappingId(texture_mappings.len() as GpuIndex);
-    texture_mappings.push(GpuTextureMapping::Uv {
+    let mapping = TextureMappingId(texture_mappings.len() as Index);
+    texture_mappings.push(TextureMapping::Uv {
         su: 1.0,
         sv: -1.0,
         du: 0.0,
         dv: 1.0,
     });
-    let texture = SpectrumTextureId(spectrum_textures.len() as GpuIndex);
-    spectrum_textures.push(GpuSpectrumTexture::Image {
+    let texture = SpectrumTextureId(spectrum_textures.len() as Index);
+    spectrum_textures.push(SpectrumTexture::Image {
         image,
         mapping,
         scale: 1.0,
         invert: false,
-        swrap: GpuImageWrapMode::Clamp,
-        twrap: GpuImageWrapMode::Clamp,
-        filter: GpuImageFilter::Bilinear,
-        spectrum_type: GpuSpectrumType::Illuminant,
+        swrap: ImageWrapMode::Clamp,
+        twrap: ImageWrapMode::Clamp,
+        filter: ImageFilter::Bilinear,
+        spectrum_type: SpectrumType::Illuminant,
     });
     Ok(texture)
 }

--- a/src/gpu/compiler/mod.rs
+++ b/src/gpu/compiler/mod.rs
@@ -28,36 +28,36 @@ mod diagnostics;
 mod light;
 mod source_map;
 
-pub use diagnostics::{GpuCompileError, GpuSourceLocation};
-pub use source_map::{GpuResourceKind, GpuSourceEntry, GpuSourceMap};
+pub use diagnostics::{CompileError, SourceLocation};
+pub use source_map::{ResourceKind, SourceEntry, SourceMap};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum GpuSceneBuildError {
-    Compile(GpuCompileError),
+pub enum SceneBuildError {
+    Compile(CompileError),
     Validation(IrValidationErrors),
 }
 
-impl From<GpuCompileError> for GpuSceneBuildError {
-    fn from(error: GpuCompileError) -> Self {
+impl From<CompileError> for SceneBuildError {
+    fn from(error: CompileError) -> Self {
         Self::Compile(error)
     }
 }
 
-impl From<IrValidationErrors> for GpuSceneBuildError {
+impl From<IrValidationErrors> for SceneBuildError {
     fn from(errors: IrValidationErrors) -> Self {
         Self::Validation(errors)
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuCompiledScene {
+pub struct CompiledScene {
     ir: Arc<SceneIr>,
-    source_map: Arc<GpuSourceMap>,
+    source_map: Arc<SourceMap>,
     requirements: Arc<super::ir::Requirements>,
 }
 
-impl GpuCompiledScene {
-    pub fn new(ir: SceneIr, source_map: GpuSourceMap) -> Self {
+impl CompiledScene {
+    pub fn new(ir: SceneIr, source_map: SourceMap) -> Self {
         let requirements = ir.requirements();
         Self {
             ir: Arc::new(ir),
@@ -68,7 +68,7 @@ impl GpuCompiledScene {
 
     fn with_source_map(
         ir: SceneIr,
-        source_map: GpuSourceMap,
+        source_map: SourceMap,
         requirements: super::ir::Requirements,
     ) -> Self {
         Self {
@@ -86,7 +86,7 @@ impl GpuCompiledScene {
         self.ir.view()
     }
 
-    pub fn source_map(&self) -> &GpuSourceMap {
+    pub fn source_map(&self) -> &SourceMap {
         &self.source_map
     }
 
@@ -99,7 +99,7 @@ impl SceneBuilder {
     /// Compiles the currently supported subset of scene entities into the
     /// backend-independent GPU IR. Unsupported semantics are reported rather
     /// than silently omitted or delegated to the CPU renderer.
-    pub fn build_gpu_ir(&self) -> Result<GpuCompiledScene, GpuSceneBuildError> {
+    pub fn build_gpu_ir(&self) -> Result<CompiledScene, SceneBuildError> {
         let mut transforms = Vec::new();
         let mut geometry = Vec::new();
         let mut spectra = vec![SpectrumResource::Constant { value: 0.5 }];
@@ -211,7 +211,7 @@ impl SceneBuilder {
                 let transform_id = compile_instance_transform(
                     &instance.render_from_instance,
                     &mut transforms,
-                    &GpuSourceLocation {
+                    &SourceLocation {
                         filename: instance.loc.filename.clone(),
                         line: instance.loc.line,
                         column: instance.loc.column,
@@ -251,11 +251,7 @@ impl SceneBuilder {
         let source_map = source_map(self, &ir);
         let mut requirements = ir.requirements();
         attach_requirement_sources(&mut requirements, ir.view(), &source_map);
-        Ok(GpuCompiledScene::with_source_map(
-            ir,
-            source_map,
-            requirements,
-        ))
+        Ok(CompiledScene::with_source_map(ir, source_map, requirements))
     }
 }
 
@@ -275,7 +271,7 @@ fn compile_image_texture(
     texture: &crate::parser::scene_builder::TextureSceneEntity,
     images: &mut Vec<ImageResource>,
     texture_mappings: &mut Vec<TextureMapping>,
-) -> Result<CompiledImageTexture, GpuCompileError> {
+) -> Result<CompiledImageTexture, CompileError> {
     let source = texture_source_location(texture);
     let params = make_absolute_path(&texture.base.params, &builder.seen_work_dirs);
     let filename = params.get_one_filename("filename", "");
@@ -300,13 +296,13 @@ fn compile_image_texture(
     } else {
         ColorEncoding::parse(&encoding_name)
     }
-    .map_err(|error| GpuCompileError::InvalidParameter {
+    .map_err(|error| CompileError::InvalidParameter {
         parameter: "encoding",
         detail: error.msg,
         source: source.clone(),
     })?;
     let raw = read_raw_image_with_encoding(&filename, encoding).map_err(|error| {
-        GpuCompileError::InvalidParameter {
+        CompileError::InvalidParameter {
             parameter: "filename",
             detail: error.msg,
             source: source.clone(),
@@ -425,10 +421,7 @@ fn float_image_channel(channels: usize, pixels: &[Float]) -> super::ir::FloatIma
     }
 }
 
-fn image_channels(
-    channels: usize,
-    source: &GpuSourceLocation,
-) -> Result<ImageChannels, GpuCompileError> {
+fn image_channels(channels: usize, source: &SourceLocation) -> Result<ImageChannels, CompileError> {
     match channels {
         1 => Ok(ImageChannels::R),
         2 => Ok(ImageChannels::Rg),
@@ -494,14 +487,14 @@ fn build_image_storage(
     width: u32,
     height: u32,
     channels: ImageChannels,
-    source: &GpuSourceLocation,
+    source: &SourceLocation,
 ) -> Result<
     (
         super::ir::TexelStorage,
         Box<[super::ir::MipLevel]>,
         super::ir::ColorEncoding,
     ),
-    GpuCompileError,
+    CompileError,
 > {
     let channel_count = channels.count();
     let linear_pixels = raw_linear_pixels(raw, source)?;
@@ -550,8 +543,8 @@ fn encode_mip_storage(
 
 fn raw_linear_pixels(
     raw: &crate::util::imageio::read_image::RawImage,
-    source: &GpuSourceLocation,
-) -> Result<Vec<Float>, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<Vec<Float>, CompileError> {
     let count = usize::try_from(raw.resolution.x)
         .ok()
         .and_then(|width| {
@@ -618,7 +611,7 @@ fn compile_textures(
         Vec<Option<super::ir::FloatTextureId>>,
         Vec<Option<super::ir::SpectrumTextureId>>,
     ),
-    GpuCompileError,
+    CompileError,
 > {
     let mut float_ids = vec![None; builder.float_textures.len()];
     for (index, texture) in builder.float_textures.iter().enumerate() {
@@ -640,7 +633,7 @@ fn compile_textures(
             continue;
         }
         if texture.base.name != "constant" {
-            return Err(GpuCompileError::UnsupportedSceneFeature {
+            return Err(CompileError::UnsupportedSceneFeature {
                 feature: "non-constant float texture",
                 source,
             });
@@ -681,7 +674,7 @@ fn compile_textures(
             continue;
         }
         if texture.base.name != "constant" {
-            return Err(GpuCompileError::UnsupportedSceneFeature {
+            return Err(CompileError::UnsupportedSceneFeature {
                 feature: "non-constant spectrum texture",
                 source,
             });
@@ -727,7 +720,7 @@ fn compile_shape(
     materials: &mut Vec<Material>,
     primitives: &mut Vec<Primitive>,
     lights: &mut Vec<Light>,
-) -> Result<super::ir::PrimitiveId, GpuCompileError> {
+) -> Result<super::ir::PrimitiveId, CompileError> {
     let source = source_location(shape);
     if !matches!(
         shape.base.name.as_str(),
@@ -740,7 +733,7 @@ fn compile_shape(
             | "cylinder"
             | "disk"
     ) {
-        return Err(GpuCompileError::UnsupportedShape {
+        return Err(CompileError::UnsupportedShape {
             name: shape.base.name.clone(),
             source,
         });
@@ -872,8 +865,8 @@ fn compile_shape(
 fn ply_mesh(
     builder: &SceneBuilder,
     params: &ParameterDictionary,
-    source: &GpuSourceLocation,
-) -> Result<TriangleMesh, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<TriangleMesh, CompileError> {
     let params = make_absolute_path(params, &builder.seen_work_dirs);
     let filename = params.get_one_string("filename", "");
     if filename.is_empty() {
@@ -884,13 +877,13 @@ fn ply_mesh(
         ));
     }
     let mesh =
-        TriQuadMesh::read_ply(&filename).map_err(|error| GpuCompileError::InvalidParameter {
+        TriQuadMesh::read_ply(&filename).map_err(|error| CompileError::InvalidParameter {
             parameter: "filename",
             detail: error.msg,
             source: source.clone(),
         })?;
     if !mesh.quad_indices.is_empty() {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "PLY quad faces in GPU geometry",
             source: source.clone(),
         });
@@ -912,7 +905,7 @@ fn ply_mesh(
                 to_gpu_float(point[2], source)?,
             ]))
         })
-        .collect::<Result<Vec<_>, GpuCompileError>>()?;
+        .collect::<Result<Vec<_>, CompileError>>()?;
     let indices = mesh
         .tri_indices
         .chunks_exact(3)
@@ -929,7 +922,7 @@ fn ply_mesh(
                         to_gpu_float(normal[2], source)?,
                     ]))
                 })
-                .collect::<Result<Vec<_>, GpuCompileError>>()?,
+                .collect::<Result<Vec<_>, CompileError>>()?,
         )
     } else {
         None
@@ -944,7 +937,7 @@ fn ply_mesh(
                         to_gpu_float(uv[1], source)?,
                     ]))
                 })
-                .collect::<Result<Vec<_>, GpuCompileError>>()?,
+                .collect::<Result<Vec<_>, CompileError>>()?,
         )
     } else {
         None
@@ -957,7 +950,7 @@ fn ply_mesh(
                     Index::try_from(*index)
                         .map_err(|_| invalid_parameter("face_indices", "negative index", source))
                 })
-                .collect::<Result<Vec<_>, GpuCompileError>>()?,
+                .collect::<Result<Vec<_>, CompileError>>()?,
         )
     } else {
         None
@@ -980,8 +973,8 @@ fn displaced_ply_mesh(
     float_textures: &[FloatTexture],
     float_texture_ids: &[Option<super::ir::FloatTextureId>],
     images: &[ImageResource],
-    source: &GpuSourceLocation,
-) -> Result<DisplacedTriangleMesh, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<DisplacedTriangleMesh, CompileError> {
     let texture_name = params
         .get_textures_ref("displacement")
         .and_then(|names| names.first().cloned())
@@ -1083,8 +1076,8 @@ fn float_texture_bounds(
     texture_id: super::ir::FloatTextureId,
     float_textures: &[FloatTexture],
     images: &[ImageResource],
-    source: &GpuSourceLocation,
-) -> Result<(Float, Float), GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<(Float, Float), CompileError> {
     let texture = float_textures
         .get(texture_id.0 as usize)
         .ok_or_else(|| invalid_parameter("displacement", "texture ID is invalid", source))?;
@@ -1135,8 +1128,8 @@ fn float_texture_bounds(
 fn image_float_channel_values(
     image: &ImageResource,
     channel: super::ir::FloatImageChannel,
-    source: &GpuSourceLocation,
-) -> Result<Vec<Float>, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<Vec<Float>, CompileError> {
     let channel_count = image.channels.count();
     let selected = match channel {
         super::ir::FloatImageChannel::Channel0 => 0,
@@ -1225,8 +1218,8 @@ fn image_float_channel_values(
 fn curve_mesh(
     params: &ParameterDictionary,
     child_params: &[ParameterDictionary],
-    source: &GpuSourceLocation,
-) -> Result<CurveMesh, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<CurveMesh, CompileError> {
     let grouped = params.get_points("P").is_empty();
     let first_params = if grouped {
         child_params
@@ -1258,8 +1251,8 @@ fn curve_mesh(
 fn curve_segment(
     params: &ParameterDictionary,
     curve_type: CurveType,
-    source: &GpuSourceLocation,
-) -> Result<CurveSegment, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<CurveSegment, CompileError> {
     let points = params.get_points("P");
     if points.len() != 12 {
         return Err(invalid_parameter(
@@ -1339,8 +1332,8 @@ fn curve_segment(
 fn compile_instance_transform(
     render_from_instance: &RenderFromObject,
     transforms: &mut Vec<Transform>,
-    source: &GpuSourceLocation,
-) -> Result<TransformId, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<TransformId, CompileError> {
     let transform = compile_transform(render_from_instance, source)?;
     let id = TransformId(transforms.len() as Index);
     transforms.push(transform);
@@ -1349,8 +1342,8 @@ fn compile_instance_transform(
 
 fn compile_transform(
     render_from_object: &RenderFromObject,
-    source: &GpuSourceLocation,
-) -> Result<Transform, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<Transform, CompileError> {
     Ok(match render_from_object {
         RenderFromObject::Static(transform) => {
             Transform::Static(static_transform(transform, source)?)
@@ -1373,19 +1366,19 @@ fn bounds_for_primitives(
     primitive_ids: &[super::ir::PrimitiveId],
     primitives: &[Primitive],
     geometry: &[Geometry],
-) -> Result<Bounds3, GpuCompileError> {
+) -> Result<Bounds3, CompileError> {
     let mut min = [f32::INFINITY; 3];
     let mut max = [f32::NEG_INFINITY; 3];
     for primitive_id in primitive_ids {
         let primitive = primitives.get(primitive_id.0 as usize).ok_or_else(|| {
-            GpuCompileError::InvalidParameter {
+            CompileError::InvalidParameter {
                 parameter: "ObjectBegin",
                 detail: "compiled primitive reference is out of bounds".to_owned(),
                 source: empty_source(),
             }
         })?;
         let shape_geometry = geometry.get(primitive.geometry.0 as usize).ok_or_else(|| {
-            GpuCompileError::InvalidParameter {
+            CompileError::InvalidParameter {
                 parameter: "Shape",
                 detail: "compiled geometry reference is out of bounds".to_owned(),
                 source: empty_source(),
@@ -1443,7 +1436,7 @@ fn bounds_for_primitives(
             max: Point3(max),
         })
     } else {
-        Err(GpuCompileError::InvalidParameter {
+        Err(CompileError::InvalidParameter {
             parameter: "ObjectBegin",
             detail: "instance definition must contain at least one supported shape".to_owned(),
             source: empty_source(),
@@ -1464,8 +1457,8 @@ fn extend_bounds_with_radius(min: &mut [f32; 3], max: &mut [f32; 3], point: [f32
 
 fn bilinear_mesh(
     params: &ParameterDictionary,
-    source: &GpuSourceLocation,
-) -> Result<BilinearPatchMesh, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<BilinearPatchMesh, CompileError> {
     let raw_positions = params.get_points("P");
     if raw_positions.is_empty() || raw_positions.len() % 3 != 0 {
         return Err(invalid_parameter(
@@ -1483,7 +1476,7 @@ fn bilinear_mesh(
                 to_gpu_float(point[2], source)?,
             ]))
         })
-        .collect::<Result<Vec<_>, GpuCompileError>>()?;
+        .collect::<Result<Vec<_>, CompileError>>()?;
     let raw_indices = params.get_ints("indices");
     if raw_indices.is_empty() || raw_indices.len() % 4 != 0 {
         return Err(invalid_parameter(
@@ -1502,7 +1495,7 @@ fn bilinear_mesh(
             }
             Ok(result)
         })
-        .collect::<Result<Vec<[Index; 4]>, GpuCompileError>>()?;
+        .collect::<Result<Vec<[Index; 4]>, CompileError>>()?;
     Ok(BilinearPatchMesh {
         positions,
         indices,
@@ -1515,8 +1508,8 @@ fn bilinear_mesh(
 fn quadric(
     params: &ParameterDictionary,
     name: &'static str,
-    source: &GpuSourceLocation,
-) -> Result<Quadric, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<Quadric, CompileError> {
     let radius = finite_parameter(params, "radius", 1.0, source)?;
     let z_min = finite_parameter(params, "zmin", -1.0, source)?;
     let z_max = finite_parameter(params, "zmax", 1.0, source)?;
@@ -1549,8 +1542,8 @@ fn finite_parameter(
     params: &ParameterDictionary,
     name: &'static str,
     default: Float,
-    source: &GpuSourceLocation,
-) -> Result<Float, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<Float, CompileError> {
     let value = params.get_one_float(name, default) as f32;
     value
         .is_finite()
@@ -1562,8 +1555,8 @@ fn vector3_parameter(
     params: &ParameterDictionary,
     name: &'static str,
     default: [Float; 3],
-    source: &GpuSourceLocation,
-) -> Result<Vector3, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<Vector3, CompileError> {
     let values = params.get_points(name);
     let values = if values.is_empty() {
         default
@@ -1587,14 +1580,14 @@ fn compile_rgb_spectrum(
     params: &ParameterDictionary,
     name: &'static str,
     default: [Float; 3],
-    source: &GpuSourceLocation,
+    source: &SourceLocation,
     spectra: &mut Vec<SpectrumResource>,
-) -> Result<SpectrumId, GpuCompileError> {
+) -> Result<SpectrumId, CompileError> {
     if params.get_textures_ref(name).is_some()
         || params.get_spectrums_ref(name).is_some()
         || params.get_sampled_spectra_ref(name).is_some()
     {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "textured or sampled light spectrum",
             source: source.clone(),
         });
@@ -1631,7 +1624,7 @@ fn compile_material(
     spectrum_texture_ids: &[Option<super::ir::SpectrumTextureId>],
     images: &mut Vec<ImageResource>,
     materials: &mut Vec<Material>,
-) -> Result<MaterialId, GpuCompileError> {
+) -> Result<MaterialId, CompileError> {
     if shape.material_is_default
         && shape.material_index == usize::MAX
         && shape.material_name.is_none()
@@ -1657,9 +1650,9 @@ fn compile_material(
         )
     })?;
     if material.base.name != "diffuse" {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "non-diffuse material",
-            source: GpuSourceLocation {
+            source: SourceLocation {
                 filename: material.base.loc.filename.clone(),
                 line: material.base.loc.line,
                 column: material.base.loc.column,
@@ -1752,8 +1745,8 @@ fn material_texture_id(
     texture_names: Option<&[String]>,
     texture_ids: &[Option<super::ir::FloatTextureId>],
     parameter: &'static str,
-    source: &GpuSourceLocation,
-) -> Result<Option<super::ir::FloatTextureId>, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<Option<super::ir::FloatTextureId>, CompileError> {
     let Some(texture_name) = texture_names.and_then(|names| names.first()) else {
         return Ok(None);
     };
@@ -1774,8 +1767,8 @@ fn compile_normal_map_image(
     builder: &SceneBuilder,
     material: &crate::parser::scene_builder::MaterialSceneEntity,
     images: &mut Vec<ImageResource>,
-    source: &GpuSourceLocation,
-) -> Result<Option<super::ir::ImageId>, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<Option<super::ir::ImageId>, CompileError> {
     let params = make_absolute_path(&material.base.params, &builder.seen_work_dirs);
     let filename = params.get_one_filename("normalmap", "");
     if filename.is_empty() {
@@ -1815,11 +1808,11 @@ fn compile_normal_map_image(
 
 fn triangle_mesh(
     params: &ParameterDictionary,
-    source: &GpuSourceLocation,
-) -> Result<TriangleMesh, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<TriangleMesh, CompileError> {
     let positions = params.get_points("P");
     if positions.is_empty() {
-        return Err(GpuCompileError::MissingParameter {
+        return Err(CompileError::MissingParameter {
             parameter: "P",
             source: source.clone(),
         });
@@ -1844,7 +1837,7 @@ fn triangle_mesh(
 
     let raw_indices = params.get_ints("indices");
     if raw_indices.is_empty() {
-        return Err(GpuCompileError::MissingParameter {
+        return Err(CompileError::MissingParameter {
             parameter: "indices",
             source: source.clone(),
         });
@@ -1883,8 +1876,8 @@ fn triangle_mesh(
 fn optional_vec2(
     values: Vec<Float>,
     parameter: &'static str,
-    source: &GpuSourceLocation,
-) -> Result<Option<Vec<Point2>>, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<Option<Vec<Point2>>, CompileError> {
     if values.is_empty() {
         return Ok(None);
     }
@@ -1910,8 +1903,8 @@ fn optional_vec2(
 fn optional_vec3(
     values: Vec<Float>,
     parameter: &'static str,
-    source: &GpuSourceLocation,
-) -> Result<Option<Vec<Normal3>>, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<Option<Vec<Normal3>>, CompileError> {
     if values.is_empty() {
         return Ok(None);
     }
@@ -1937,8 +1930,8 @@ fn optional_vec3(
 
 fn static_transform(
     transform: &CpuTransform,
-    source: &GpuSourceLocation,
-) -> Result<StaticTransform, GpuCompileError> {
+    source: &SourceLocation,
+) -> Result<StaticTransform, CompileError> {
     Ok(StaticTransform {
         render_from_object: matrix(transform.m, source)?,
         object_from_render: matrix(transform.minv, source)?,
@@ -1946,7 +1939,7 @@ fn static_transform(
     })
 }
 
-fn matrix(matrix: CpuMatrix4x4, source: &GpuSourceLocation) -> Result<Matrix4x4, GpuCompileError> {
+fn matrix(matrix: CpuMatrix4x4, source: &SourceLocation) -> Result<Matrix4x4, CompileError> {
     let mut result = [[0.0; 4]; 4];
     for (row, values) in result.iter_mut().enumerate() {
         for (column, value) in values.iter_mut().enumerate() {
@@ -1959,34 +1952,34 @@ fn matrix(matrix: CpuMatrix4x4, source: &GpuSourceLocation) -> Result<Matrix4x4,
 fn render_config(
     builder: &SceneBuilder,
     transforms: &mut Vec<Transform>,
-) -> Result<RenderConfig, GpuCompileError> {
+) -> Result<RenderConfig, CompileError> {
     let source = empty_source();
     if builder.camera_name != "perspective" {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "non-perspective camera",
             source: source.clone(),
         });
     }
     if builder.sampler_name != "independent" {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "non-independent sampler",
             source: source.clone(),
         });
     }
     if builder.film_name != "rgb" {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "non-rgb film",
             source: source.clone(),
         });
     }
     if builder.filter_name != "box" {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "non-box filter",
             source: source.clone(),
         });
     }
     if builder.integrator_name != "volpath" {
-        return Err(GpuCompileError::UnsupportedSceneFeature {
+        return Err(CompileError::UnsupportedSceneFeature {
             feature: "non-volpath integrator",
             source,
         });
@@ -2224,8 +2217,8 @@ fn render_config(
     })
 }
 
-fn empty_source() -> GpuSourceLocation {
-    GpuSourceLocation {
+fn empty_source() -> SourceLocation {
+    SourceLocation {
         filename: String::new(),
         line: 0,
         column: 0,
@@ -2233,7 +2226,7 @@ fn empty_source() -> GpuSourceLocation {
 }
 
 #[derive(Default)]
-struct GpuSourceGroups {
+struct SourceGroups {
     shapes: Vec<SourceId>,
     float_textures: Vec<SourceId>,
     spectrum_textures: Vec<SourceId>,
@@ -2243,9 +2236,9 @@ struct GpuSourceGroups {
     instances: Vec<SourceId>,
 }
 
-fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
+fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> SourceMap {
     let mut locations = Vec::new();
-    let mut groups = GpuSourceGroups::default();
+    let mut groups = SourceGroups::default();
     for shape in &builder.shapes {
         add_source(&mut locations, &mut groups.shapes, source_location(shape));
     }
@@ -2264,7 +2257,7 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
         add_source(
             &mut locations,
             &mut groups.instance_definitions,
-            GpuSourceLocation {
+            SourceLocation {
                 filename: definition.loc.filename.clone(),
                 line: definition.loc.line,
                 column: definition.loc.column,
@@ -2280,7 +2273,7 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
             add_source(
                 &mut locations,
                 &mut groups.instances,
-                GpuSourceLocation {
+                SourceLocation {
                     filename: instance.loc.filename.clone(),
                     line: instance.loc.line,
                     column: instance.loc.column,
@@ -2304,7 +2297,7 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
     }
     for material in &builder.materials {
         groups.materials.push(SourceId(locations.len() as Index));
-        locations.push(GpuSourceLocation {
+        locations.push(SourceLocation {
             filename: material.base.loc.filename.clone(),
             line: material.base.loc.line,
             column: material.base.loc.column,
@@ -2324,13 +2317,13 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
         };
         add_resource(
             &mut resources,
-            GpuResourceKind::Primitive,
+            ResourceKind::Primitive,
             index as Index,
             source,
         );
         add_resource(
             &mut resources,
-            GpuResourceKind::Geometry,
+            ResourceKind::Geometry,
             primitive.geometry.0,
             source,
         );
@@ -2339,24 +2332,19 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
         {
             add_resource(
                 &mut resources,
-                GpuResourceKind::Geometry,
+                ResourceKind::Geometry,
                 mesh.base_mesh.0,
                 source,
             );
         }
         add_resource(
             &mut resources,
-            GpuResourceKind::Transform,
+            ResourceKind::Transform,
             primitive.transform.0,
             source,
         );
         if let Some(material) = primitive.material {
-            add_resource(
-                &mut resources,
-                GpuResourceKind::Material,
-                material.0,
-                source,
-            );
+            add_resource(&mut resources, ResourceKind::Material, material.0, source);
             if let Some(super::ir::Material::Diffuse(material)) =
                 ir.view().materials.get(material.0 as usize)
             {
@@ -2370,7 +2358,7 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
                     add_float_texture_resources(&mut resources, ir.view(), texture, source);
                 }
                 if let Some(image) = material.normal_map {
-                    add_resource(&mut resources, GpuResourceKind::Image, image.0, source);
+                    add_resource(&mut resources, ResourceKind::Image, image.0, source);
                 }
             }
         }
@@ -2380,7 +2368,7 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
         match &primitive.area_light {
             super::ir::AreaLightBinding::None => {}
             super::ir::AreaLightBinding::Uniform(light) => {
-                add_resource(&mut resources, GpuResourceKind::Light, light.0, source);
+                add_resource(&mut resources, ResourceKind::Light, light.0, source);
                 if let Some(super::ir::Light::DiffuseArea(light)) =
                     ir.view().lights.get(light.0 as usize)
                 {
@@ -2394,7 +2382,7 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
             }
             super::ir::AreaLightBinding::PerElement(lights) => {
                 for light in lights {
-                    add_resource(&mut resources, GpuResourceKind::Light, light.0, source);
+                    add_resource(&mut resources, ResourceKind::Light, light.0, source);
                 }
             }
         }
@@ -2405,15 +2393,15 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
         };
         add_resource(
             &mut resources,
-            GpuResourceKind::FloatTexture,
+            ResourceKind::FloatTexture,
             index as Index,
             source,
         );
         if let super::ir::FloatTexture::Image { image, mapping, .. } = texture {
-            add_resource(&mut resources, GpuResourceKind::Image, image.0, source);
+            add_resource(&mut resources, ResourceKind::Image, image.0, source);
             add_resource(
                 &mut resources,
-                GpuResourceKind::TextureMapping,
+                ResourceKind::TextureMapping,
                 mapping.0,
                 source,
             );
@@ -2425,15 +2413,15 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
         };
         add_resource(
             &mut resources,
-            GpuResourceKind::SpectrumTexture,
+            ResourceKind::SpectrumTexture,
             index as Index,
             source,
         );
         if let super::ir::SpectrumTexture::Image { image, mapping, .. } = texture {
-            add_resource(&mut resources, GpuResourceKind::Image, image.0, source);
+            add_resource(&mut resources, ResourceKind::Image, image.0, source);
             add_resource(
                 &mut resources,
-                GpuResourceKind::TextureMapping,
+                ResourceKind::TextureMapping,
                 mapping.0,
                 source,
             );
@@ -2441,16 +2429,11 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
     }
     for (index, light) in ir.view().lights.iter().enumerate() {
         if let Some(&source) = groups.lights.get(index) {
-            add_resource(
-                &mut resources,
-                GpuResourceKind::Light,
-                index as Index,
-                source,
-            );
+            add_resource(&mut resources, ResourceKind::Light, index as Index, source);
             if let super::ir::Light::Point(point) = light {
                 add_resource(
                     &mut resources,
-                    GpuResourceKind::Transform,
+                    ResourceKind::Transform,
                     point.render_from_light.0,
                     source,
                 );
@@ -2460,7 +2443,7 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
     for (index, source) in groups.instance_definitions.iter().copied().enumerate() {
         add_resource(
             &mut resources,
-            GpuResourceKind::InstanceDefinition,
+            ResourceKind::InstanceDefinition,
             index as Index,
             source,
         );
@@ -2471,28 +2454,28 @@ fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
         };
         add_resource(
             &mut resources,
-            GpuResourceKind::Instance,
+            ResourceKind::Instance,
             index as Index,
             source,
         );
         add_resource(
             &mut resources,
-            GpuResourceKind::Transform,
+            ResourceKind::Transform,
             instance.transform.0,
             source,
         );
     }
     resources.sort_by_key(|entry| (entry.kind, entry.index));
-    GpuSourceMap {
+    SourceMap {
         locations: locations.into_boxed_slice(),
         resources: resources.into_boxed_slice(),
     }
 }
 
 fn add_source(
-    locations: &mut Vec<GpuSourceLocation>,
+    locations: &mut Vec<SourceLocation>,
     group: &mut Vec<SourceId>,
-    location: GpuSourceLocation,
+    location: SourceLocation,
 ) {
     let id = SourceId(locations.len() as Index);
     locations.push(location);
@@ -2500,8 +2483,8 @@ fn add_source(
 }
 
 fn add_resource(
-    resources: &mut Vec<GpuSourceEntry>,
-    kind: GpuResourceKind,
+    resources: &mut Vec<SourceEntry>,
+    kind: ResourceKind,
     index: Index,
     source: SourceId,
 ) {
@@ -2511,7 +2494,7 @@ fn add_resource(
     {
         return;
     }
-    resources.push(GpuSourceEntry {
+    resources.push(SourceEntry {
         kind,
         index,
         source,
@@ -2519,49 +2502,34 @@ fn add_resource(
 }
 
 fn add_float_texture_resources(
-    resources: &mut Vec<GpuSourceEntry>,
+    resources: &mut Vec<SourceEntry>,
     view: super::ir::SceneView<'_>,
     texture: super::ir::FloatTextureId,
     source: SourceId,
 ) {
-    add_resource(resources, GpuResourceKind::FloatTexture, texture.0, source);
+    add_resource(resources, ResourceKind::FloatTexture, texture.0, source);
     if let Some(super::ir::FloatTexture::Image { image, mapping, .. }) =
         view.float_textures.get(texture.0 as usize)
     {
-        add_resource(resources, GpuResourceKind::Image, image.0, source);
-        add_resource(
-            resources,
-            GpuResourceKind::TextureMapping,
-            mapping.0,
-            source,
-        );
+        add_resource(resources, ResourceKind::Image, image.0, source);
+        add_resource(resources, ResourceKind::TextureMapping, mapping.0, source);
     }
 }
 
 fn add_spectrum_texture_resources(
-    resources: &mut Vec<GpuSourceEntry>,
+    resources: &mut Vec<SourceEntry>,
     view: super::ir::SceneView<'_>,
     texture: super::ir::SpectrumTextureId,
     source: SourceId,
 ) {
-    add_resource(
-        resources,
-        GpuResourceKind::SpectrumTexture,
-        texture.0,
-        source,
-    );
+    add_resource(resources, ResourceKind::SpectrumTexture, texture.0, source);
     match view.spectrum_textures.get(texture.0 as usize) {
         Some(super::ir::SpectrumTexture::Constant { value }) => {
-            add_resource(resources, GpuResourceKind::Spectrum, value.0, source);
+            add_resource(resources, ResourceKind::Spectrum, value.0, source);
         }
         Some(super::ir::SpectrumTexture::Image { image, mapping, .. }) => {
-            add_resource(resources, GpuResourceKind::Image, image.0, source);
-            add_resource(
-                resources,
-                GpuResourceKind::TextureMapping,
-                mapping.0,
-                source,
-            );
+            add_resource(resources, ResourceKind::Image, image.0, source);
+            add_resource(resources, ResourceKind::TextureMapping, mapping.0, source);
         }
         None => {}
     }
@@ -2570,7 +2538,7 @@ fn add_spectrum_texture_resources(
 fn attach_requirement_sources(
     requirements: &mut super::ir::Requirements,
     view: super::ir::SceneView<'_>,
-    source_map: &GpuSourceMap,
+    source_map: &SourceMap,
 ) {
     for required in requirements.features.iter_mut() {
         let mut sources = source_map
@@ -2588,110 +2556,110 @@ fn attach_requirement_sources(
 
 fn requirement_resource_matches(
     feature: Feature,
-    entry: &GpuSourceEntry,
+    entry: &SourceEntry,
     view: super::ir::SceneView<'_>,
 ) -> bool {
     match feature {
         Feature::TriangleMesh => {
-            entry.kind == GpuResourceKind::Geometry
+            entry.kind == ResourceKind::Geometry
                 && matches!(
                     view.geometry.get(entry.index as usize),
                     Some(super::ir::Geometry::TriangleMesh(_))
                 )
         }
         Feature::BilinearPatch => {
-            entry.kind == GpuResourceKind::Geometry
+            entry.kind == ResourceKind::Geometry
                 && matches!(
                     view.geometry.get(entry.index as usize),
                     Some(super::ir::Geometry::BilinearPatchMesh(_))
                 )
         }
         Feature::Curve => {
-            entry.kind == GpuResourceKind::Geometry
+            entry.kind == ResourceKind::Geometry
                 && matches!(
                     view.geometry.get(entry.index as usize),
                     Some(super::ir::Geometry::CurveMesh(_))
                 )
         }
         Feature::Quadric => {
-            entry.kind == GpuResourceKind::Geometry
+            entry.kind == ResourceKind::Geometry
                 && matches!(
                     view.geometry.get(entry.index as usize),
                     Some(super::ir::Geometry::Quadric(_))
                 )
         }
         Feature::DisplacedTriangle => {
-            entry.kind == GpuResourceKind::Geometry
+            entry.kind == ResourceKind::Geometry
                 && matches!(
                     view.geometry.get(entry.index as usize),
                     Some(super::ir::Geometry::DisplacedTriangleMesh(_))
                 )
         }
         Feature::FloatConstantTexture => {
-            entry.kind == GpuResourceKind::FloatTexture
+            entry.kind == ResourceKind::FloatTexture
                 && matches!(
                     view.float_textures.get(entry.index as usize),
                     Some(super::ir::FloatTexture::Constant { .. })
                 )
         }
         Feature::FloatImageTexture => {
-            entry.kind == GpuResourceKind::FloatTexture
+            entry.kind == ResourceKind::FloatTexture
                 && matches!(
                     view.float_textures.get(entry.index as usize),
                     Some(super::ir::FloatTexture::Image { .. })
                 )
         }
         Feature::SpectrumConstantTexture => {
-            entry.kind == GpuResourceKind::SpectrumTexture
+            entry.kind == ResourceKind::SpectrumTexture
                 && matches!(
                     view.spectrum_textures.get(entry.index as usize),
                     Some(super::ir::SpectrumTexture::Constant { .. })
                 )
         }
         Feature::SpectrumImageTexture => {
-            entry.kind == GpuResourceKind::SpectrumTexture
+            entry.kind == ResourceKind::SpectrumTexture
                 && matches!(
                     view.spectrum_textures.get(entry.index as usize),
                     Some(super::ir::SpectrumTexture::Image { .. })
                 )
         }
         Feature::DiffuseMaterial => {
-            entry.kind == GpuResourceKind::Material
+            entry.kind == ResourceKind::Material
                 && matches!(
                     view.materials.get(entry.index as usize),
                     Some(super::ir::Material::Diffuse(_))
                 )
         }
         Feature::PointLight => {
-            entry.kind == GpuResourceKind::Light
+            entry.kind == ResourceKind::Light
                 && matches!(
                     view.lights.get(entry.index as usize),
                     Some(super::ir::Light::Point(_))
                 )
         }
         Feature::DiffuseAreaLight => {
-            entry.kind == GpuResourceKind::Light
+            entry.kind == ResourceKind::Light
                 && matches!(
                     view.lights.get(entry.index as usize),
                     Some(super::ir::Light::DiffuseArea(_))
                 )
         }
         Feature::UniformInfiniteLight => {
-            entry.kind == GpuResourceKind::Light
+            entry.kind == ResourceKind::Light
                 && matches!(
                     view.lights.get(entry.index as usize),
                     Some(super::ir::Light::UniformInfinite(_))
                 )
         }
         Feature::StaticTransform => {
-            entry.kind == GpuResourceKind::Transform
+            entry.kind == ResourceKind::Transform
                 && matches!(
                     view.transforms.get(entry.index as usize),
                     Some(super::ir::Transform::Static(_))
                 )
         }
         Feature::AnimatedTransform => {
-            entry.kind == GpuResourceKind::Transform
+            entry.kind == ResourceKind::Transform
                 && matches!(
                     view.transforms.get(entry.index as usize),
                     Some(super::ir::Transform::Animated(_))
@@ -2706,7 +2674,7 @@ fn requirement_resource_matches(
     }
 }
 
-fn to_gpu_float(value: Float, source: &GpuSourceLocation) -> Result<Float, GpuCompileError> {
+fn to_gpu_float(value: Float, source: &SourceLocation) -> Result<Float, CompileError> {
     let value = value as f32;
     value.is_finite().then_some(value).ok_or_else(|| {
         invalid_parameter(
@@ -2717,16 +2685,16 @@ fn to_gpu_float(value: Float, source: &GpuSourceLocation) -> Result<Float, GpuCo
     })
 }
 
-fn source_location(shape: &ShapeSceneEntity) -> GpuSourceLocation {
-    GpuSourceLocation {
+fn source_location(shape: &ShapeSceneEntity) -> SourceLocation {
+    SourceLocation {
         filename: shape.base.loc.filename.clone(),
         line: shape.base.loc.line,
         column: shape.base.loc.column,
     }
 }
 
-fn light_source_location(light: &LightSceneEntity) -> GpuSourceLocation {
-    GpuSourceLocation {
+fn light_source_location(light: &LightSceneEntity) -> SourceLocation {
+    SourceLocation {
         filename: light.base.base.loc.filename.clone(),
         line: light.base.base.loc.line,
         column: light.base.base.loc.column,
@@ -2735,16 +2703,16 @@ fn light_source_location(light: &LightSceneEntity) -> GpuSourceLocation {
 
 fn texture_source_location(
     texture: &crate::parser::scene_builder::TextureSceneEntity,
-) -> GpuSourceLocation {
-    GpuSourceLocation {
+) -> SourceLocation {
+    SourceLocation {
         filename: texture.base.loc.filename.clone(),
         line: texture.base.loc.line,
         column: texture.base.loc.column,
     }
 }
 
-fn unsupported_feature(shape: &ShapeSceneEntity, feature: &'static str) -> GpuCompileError {
-    GpuCompileError::UnsupportedSceneFeature {
+fn unsupported_feature(shape: &ShapeSceneEntity, feature: &'static str) -> CompileError {
+    CompileError::UnsupportedSceneFeature {
         feature,
         source: source_location(shape),
     }
@@ -2753,9 +2721,9 @@ fn unsupported_feature(shape: &ShapeSceneEntity, feature: &'static str) -> GpuCo
 fn invalid_parameter(
     parameter: &'static str,
     detail: &str,
-    source: &GpuSourceLocation,
-) -> GpuCompileError {
-    GpuCompileError::InvalidParameter {
+    source: &SourceLocation,
+) -> CompileError {
+    CompileError::InvalidParameter {
         parameter,
         detail: detail.to_owned(),
         source: source.clone(),

--- a/src/gpu/compiler/mod.rs
+++ b/src/gpu/compiler/mod.rs
@@ -1,17 +1,15 @@
 //! Host-side construction boundary for GPU IR.
 
 use super::ir::{
-    GeometryId, GpuAnimatedTransform, GpuBilinearPatchMesh, GpuBounds2, GpuBounds2i, GpuBounds3,
-    GpuBoxFilter, GpuCurveMesh, GpuCurveSegment, GpuCurveType, GpuDiffuseAreaLight,
-    GpuDiffuseMaterial, GpuDisplacedTriangleMesh, GpuFeature, GpuFloat, GpuFloatTexture,
-    GpuGeometry, GpuImageChannels, GpuImageFilter, GpuImageResource, GpuImageWrapMode,
-    GpuIndependentSampler, GpuIndex, GpuInstance, GpuInstanceDefinition, GpuIrValidationErrors,
-    GpuLight, GpuLightSampler, GpuMaterial, GpuMatrix3x3, GpuMatrix4x4, GpuNormal3,
-    GpuPerspectiveCamera, GpuPoint2, GpuPoint3, GpuPointLight, GpuPrimitive, GpuQuadric,
-    GpuRenderConfig, GpuRgbFilm, GpuSceneData, GpuSceneDraft, GpuSceneIr, GpuSceneView,
-    GpuSpectrumResource, GpuSpectrumTexture, GpuStaticTransform, GpuTextureMapping, GpuTransform,
-    GpuTriangleMesh, GpuUniformInfiniteLight, GpuVector2, GpuVector3, GpuWavefrontVolPath,
-    InstanceDefinitionId, InstanceId, MaterialId, MinMaxNodeId, SourceId, SpectrumId, TransformId,
+    AnimatedTransform, BilinearPatchMesh, Bounds2, Bounds2i, Bounds3, BoxFilter, CurveMesh,
+    CurveSegment, CurveType, DiffuseAreaLight, DiffuseMaterial, DisplacedTriangleMesh, Feature,
+    Float, FloatTexture, Geometry, GeometryId, ImageChannels, ImageFilter, ImageResource,
+    ImageWrapMode, IndependentSampler, Index, Instance, InstanceDefinition, InstanceDefinitionId,
+    InstanceId, IrValidationErrors, Light, LightSampler, Material, MaterialId, Matrix3x3,
+    Matrix4x4, MinMaxNodeId, Normal3, PerspectiveCamera, Point2, Point3, PointLight, Primitive,
+    Quadric, RenderConfig, RgbFilm, SceneData, SceneDraft, SceneIr, SceneView, SourceId,
+    SpectrumId, SpectrumResource, SpectrumTexture, StaticTransform, TextureMapping, Transform,
+    TransformId, TriangleMesh, UniformInfiniteLight, Vector2, Vector3, WavefrontVolPath,
     CURRENT_IR_VERSION,
 };
 use crate::paramdict::ParameterDictionary;
@@ -19,11 +17,10 @@ use crate::parser::scene_builder::path_resolver::make_absolute_path;
 use crate::parser::scene_builder::{
     LightSceneEntity, RenderFromObject, SceneBuilder, ShapeSceneEntity,
 };
-use crate::util::base::Float;
 use crate::util::imageio::read_image::RawImageData;
 use crate::util::imageio::{read_raw_image_with_encoding, ColorEncoding};
 use crate::util::mesh::TriQuadMesh;
-use crate::util::transform::{Matrix4x4, Transform};
+use crate::util::transform::{Matrix4x4 as CpuMatrix4x4, Transform as CpuTransform};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -37,7 +34,7 @@ pub use source_map::{GpuResourceKind, GpuSourceEntry, GpuSourceMap};
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum GpuSceneBuildError {
     Compile(GpuCompileError),
-    Validation(GpuIrValidationErrors),
+    Validation(IrValidationErrors),
 }
 
 impl From<GpuCompileError> for GpuSceneBuildError {
@@ -46,21 +43,21 @@ impl From<GpuCompileError> for GpuSceneBuildError {
     }
 }
 
-impl From<GpuIrValidationErrors> for GpuSceneBuildError {
-    fn from(errors: GpuIrValidationErrors) -> Self {
+impl From<IrValidationErrors> for GpuSceneBuildError {
+    fn from(errors: IrValidationErrors) -> Self {
         Self::Validation(errors)
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct GpuCompiledScene {
-    ir: Arc<GpuSceneIr>,
+    ir: Arc<SceneIr>,
     source_map: Arc<GpuSourceMap>,
-    requirements: Arc<super::ir::GpuRequirements>,
+    requirements: Arc<super::ir::Requirements>,
 }
 
 impl GpuCompiledScene {
-    pub fn new(ir: GpuSceneIr, source_map: GpuSourceMap) -> Self {
+    pub fn new(ir: SceneIr, source_map: GpuSourceMap) -> Self {
         let requirements = ir.requirements();
         Self {
             ir: Arc::new(ir),
@@ -70,9 +67,9 @@ impl GpuCompiledScene {
     }
 
     fn with_source_map(
-        ir: GpuSceneIr,
+        ir: SceneIr,
         source_map: GpuSourceMap,
-        requirements: super::ir::GpuRequirements,
+        requirements: super::ir::Requirements,
     ) -> Self {
         Self {
             ir: Arc::new(ir),
@@ -81,11 +78,11 @@ impl GpuCompiledScene {
         }
     }
 
-    pub fn scene(&self) -> &GpuSceneIr {
+    pub fn scene(&self) -> &SceneIr {
         &self.ir
     }
 
-    pub fn view(&self) -> GpuSceneView<'_> {
+    pub fn view(&self) -> SceneView<'_> {
         self.ir.view()
     }
 
@@ -93,7 +90,7 @@ impl GpuCompiledScene {
         &self.source_map
     }
 
-    pub fn requirements(&self) -> super::ir::GpuRequirements {
+    pub fn requirements(&self) -> super::ir::Requirements {
         (*self.requirements).clone()
     }
 }
@@ -105,8 +102,8 @@ impl SceneBuilder {
     pub fn build_gpu_ir(&self) -> Result<GpuCompiledScene, GpuSceneBuildError> {
         let mut transforms = Vec::new();
         let mut geometry = Vec::new();
-        let mut spectra = vec![GpuSpectrumResource::Constant { value: 0.5 }];
-        let mut spectrum_textures = vec![GpuSpectrumTexture::Constant {
+        let mut spectra = vec![SpectrumResource::Constant { value: 0.5 }];
+        let mut spectrum_textures = vec![SpectrumTexture::Constant {
             value: SpectrumId(0),
         }];
         let mut float_textures = Vec::new();
@@ -120,7 +117,7 @@ impl SceneBuilder {
             &mut images,
             &mut texture_mappings,
         )?;
-        let mut materials = vec![GpuMaterial::Diffuse(GpuDiffuseMaterial {
+        let mut materials = vec![Material::Diffuse(DiffuseMaterial {
             reflectance: super::ir::SpectrumTextureId(0),
             displacement: None,
             normal_map: None,
@@ -178,7 +175,7 @@ impl SceneBuilder {
         let mut definitions: Vec<_> = self.instance_definitions.iter().collect();
         definitions.sort_by(|(left, _), (right, _)| left.cmp(right));
         for (name, definition) in definitions {
-            let definition_id = InstanceDefinitionId(instance_definitions.len() as GpuIndex);
+            let definition_id = InstanceDefinitionId(instance_definitions.len() as Index);
             let mut definition_primitives = Vec::new();
             for shape in definition.shapes.iter().chain(&definition.animated_shapes) {
                 let primitive = compile_shape(
@@ -201,7 +198,7 @@ impl SceneBuilder {
             }
             let local_bounds =
                 bounds_for_primitives(&definition_primitives, &primitives, &geometry)?;
-            instance_definitions.push(GpuInstanceDefinition {
+            instance_definitions.push(InstanceDefinition {
                 primitives: definition_primitives,
                 instances: Vec::new(),
                 local_bounds,
@@ -220,8 +217,8 @@ impl SceneBuilder {
                         column: instance.loc.column,
                     },
                 )?;
-                let instance_id = InstanceId(instances.len() as GpuIndex);
-                instances.push(GpuInstance {
+                let instance_id = InstanceId(instances.len() as Index);
+                instances.push(Instance {
                     definition: definition_id,
                     transform: transform_id,
                 });
@@ -230,9 +227,9 @@ impl SceneBuilder {
         }
 
         let render = render_config(self, &mut transforms)?;
-        let draft = GpuSceneDraft {
+        let draft = SceneDraft {
             version: CURRENT_IR_VERSION,
-            data: GpuSceneData {
+            data: SceneData {
                 transforms,
                 spectra,
                 float_textures,
@@ -265,19 +262,19 @@ impl SceneBuilder {
 struct CompiledImageTexture {
     image: super::ir::ImageId,
     mapping: super::ir::TextureMappingId,
-    scale: GpuFloat,
+    scale: Float,
     invert: bool,
-    swrap: GpuImageWrapMode,
-    twrap: GpuImageWrapMode,
-    filter: GpuImageFilter,
-    channel: super::ir::GpuFloatImageChannel,
+    swrap: ImageWrapMode,
+    twrap: ImageWrapMode,
+    filter: ImageFilter,
+    channel: super::ir::FloatImageChannel,
 }
 
 fn compile_image_texture(
     builder: &SceneBuilder,
     texture: &crate::parser::scene_builder::TextureSceneEntity,
-    images: &mut Vec<GpuImageResource>,
-    texture_mappings: &mut Vec<GpuTextureMapping>,
+    images: &mut Vec<ImageResource>,
+    texture_mappings: &mut Vec<TextureMapping>,
 ) -> Result<CompiledImageTexture, GpuCompileError> {
     let source = texture_source_location(texture);
     let params = make_absolute_path(&texture.base.params, &builder.seen_work_dirs);
@@ -326,13 +323,13 @@ fn compile_image_texture(
             &source,
         ));
     }
-    let image = super::ir::ImageId(images.len() as GpuIndex);
+    let image = super::ir::ImageId(images.len() as Index);
     let pixels = raw.data_f32();
     let channels = image_channels(raw.channels, &source)?;
     let channel = float_image_channel(raw.channels, &pixels);
     let (storage, mip_levels, color_encoding) =
         build_image_storage(&raw, width, height, channels, &source)?;
-    images.push(GpuImageResource {
+    images.push(ImageResource {
         resolution: [width, height],
         channels,
         storage,
@@ -342,26 +339,26 @@ fn compile_image_texture(
     let mapping_name = params.get_one_string("mapping", "uv");
     let texture_from_render = matrix(texture.render_from_texture.m, &source)?;
     let mapping = match mapping_name.as_str() {
-        "uv" => GpuTextureMapping::Uv {
+        "uv" => TextureMapping::Uv {
             su: finite_parameter(&params, "uscale", 1.0, &source)?,
             sv: finite_parameter(&params, "vscale", 1.0, &source)?,
             du: finite_parameter(&params, "udelta", 0.0, &source)?,
             dv: finite_parameter(&params, "vdelta", 0.0, &source)?,
         },
-        "spherical" => GpuTextureMapping::Spherical {
+        "spherical" => TextureMapping::Spherical {
             texture_from_render,
         },
-        "cylindrical" => GpuTextureMapping::Cylindrical {
+        "cylindrical" => TextureMapping::Cylindrical {
             texture_from_render,
         },
-        "planar" => GpuTextureMapping::Planar {
+        "planar" => TextureMapping::Planar {
             texture_from_render,
             vs: vector3_parameter(&params, "v1", [1.0, 0.0, 0.0], &source)?,
             vt: vector3_parameter(&params, "v2", [0.0, 1.0, 0.0], &source)?,
             ds: finite_parameter(&params, "udelta", 0.0, &source)?,
             dt: finite_parameter(&params, "vdelta", 0.0, &source)?,
         },
-        "3d" | "transform3d" => GpuTextureMapping::Transform3D {
+        "3d" | "transform3d" => TextureMapping::Transform3D {
             texture_from_render,
         },
         _ => {
@@ -372,13 +369,13 @@ fn compile_image_texture(
             ))
         }
     };
-    let mapping_id = super::ir::TextureMappingId(texture_mappings.len() as GpuIndex);
+    let mapping_id = super::ir::TextureMappingId(texture_mappings.len() as Index);
     texture_mappings.push(mapping);
     let filter_name = params.get_one_string("filter", "bilinear");
     let filter = match filter_name.as_str() {
-        "point" => GpuImageFilter::Point,
-        "bilinear" => GpuImageFilter::Bilinear,
-        "trilinear" => GpuImageFilter::Trilinear,
+        "point" => ImageFilter::Point,
+        "bilinear" => ImageFilter::Bilinear,
+        "trilinear" => ImageFilter::Trilinear,
         "ewa" | "EWA" => {
             let max_anisotropy = finite_parameter(&params, "maxanisotropy", 8.0, &source)?;
             if max_anisotropy < 1.0 {
@@ -388,7 +385,7 @@ fn compile_image_texture(
                     &source,
                 ));
             }
-            GpuImageFilter::Ewa { max_anisotropy }
+            ImageFilter::Ewa { max_anisotropy }
         }
         _ => return Err(invalid_parameter("filter", "unknown image filter", &source)),
     };
@@ -396,10 +393,10 @@ fn compile_image_texture(
     let swrap_name = params.get_one_string("swrap", &wrap);
     let twrap_name = params.get_one_string("twrap", &wrap);
     let parse_wrap = |name: &str| match name {
-        "black" => Ok(GpuImageWrapMode::Black),
-        "clamp" => Ok(GpuImageWrapMode::Clamp),
-        "repeat" => Ok(GpuImageWrapMode::Repeat),
-        "octahedralsphere" => Ok(GpuImageWrapMode::OctahedralSphere),
+        "black" => Ok(ImageWrapMode::Black),
+        "clamp" => Ok(ImageWrapMode::Clamp),
+        "repeat" => Ok(ImageWrapMode::Repeat),
+        "octahedralsphere" => Ok(ImageWrapMode::OctahedralSphere),
         _ => Err(invalid_parameter(
             "wrap",
             "unknown image wrap mode",
@@ -418,25 +415,25 @@ fn compile_image_texture(
     })
 }
 
-fn float_image_channel(channels: usize, pixels: &[Float]) -> super::ir::GpuFloatImageChannel {
+fn float_image_channel(channels: usize, pixels: &[Float]) -> super::ir::FloatImageChannel {
     match channels {
-        1 | 2 => super::ir::GpuFloatImageChannel::Channel0,
+        1 | 2 => super::ir::FloatImageChannel::Channel0,
         4 if pixels.chunks_exact(4).any(|pixel| pixel[3] != 1.0) => {
-            super::ir::GpuFloatImageChannel::Alpha
+            super::ir::FloatImageChannel::Alpha
         }
-        _ => super::ir::GpuFloatImageChannel::RgbAverage,
+        _ => super::ir::FloatImageChannel::RgbAverage,
     }
 }
 
 fn image_channels(
     channels: usize,
     source: &GpuSourceLocation,
-) -> Result<GpuImageChannels, GpuCompileError> {
+) -> Result<ImageChannels, GpuCompileError> {
     match channels {
-        1 => Ok(GpuImageChannels::R),
-        2 => Ok(GpuImageChannels::Rg),
-        3 => Ok(GpuImageChannels::Rgb),
-        4 => Ok(GpuImageChannels::Rgba),
+        1 => Ok(ImageChannels::R),
+        2 => Ok(ImageChannels::Rg),
+        3 => Ok(ImageChannels::Rgb),
+        4 => Ok(ImageChannels::Rgba),
         _ => Err(invalid_parameter(
             "filename",
             "GPU image supports only one to four channels",
@@ -450,7 +447,7 @@ fn build_mip_storage(
     width: u32,
     height: u32,
     channels: usize,
-) -> (Vec<Float>, Box<[super::ir::GpuMipLevel]>) {
+) -> (Vec<Float>, Box<[super::ir::MipLevel]>) {
     let mut storage = Vec::from(base);
     let mut levels = Vec::new();
     let mut level_width = width;
@@ -458,7 +455,7 @@ fn build_mip_storage(
     let mut level = base.to_vec();
     loop {
         let offset = storage.len() - level.len();
-        levels.push(super::ir::GpuMipLevel {
+        levels.push(super::ir::MipLevel {
             resolution: [level_width, level_height],
             texel_offset: offset as u64,
             texel_count: level.len() as u64,
@@ -496,13 +493,13 @@ fn build_image_storage(
     raw: &crate::util::imageio::read_image::RawImage,
     width: u32,
     height: u32,
-    channels: GpuImageChannels,
+    channels: ImageChannels,
     source: &GpuSourceLocation,
 ) -> Result<
     (
-        super::ir::GpuTexelStorage,
-        Box<[super::ir::GpuMipLevel]>,
-        super::ir::GpuColorEncoding,
+        super::ir::TexelStorage,
+        Box<[super::ir::MipLevel]>,
+        super::ir::ColorEncoding,
     ),
     GpuCompileError,
 > {
@@ -520,19 +517,19 @@ fn encode_mip_storage(
     source_data: &RawImageData,
     encoding: ColorEncoding,
     channel_count: usize,
-) -> super::ir::GpuTexelStorage {
+) -> super::ir::TexelStorage {
     match source_data {
         RawImageData::F32(_) => {
-            super::ir::GpuTexelStorage::F32(linear_storage.to_vec().into_boxed_slice())
+            super::ir::TexelStorage::F32(linear_storage.to_vec().into_boxed_slice())
         }
-        RawImageData::F16(_) => super::ir::GpuTexelStorage::F16(
+        RawImageData::F16(_) => super::ir::TexelStorage::F16(
             linear_storage
                 .iter()
                 .map(|value| half::f16::from_f32(*value).to_bits())
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
         ),
-        RawImageData::U8 { .. } => super::ir::GpuTexelStorage::U8(
+        RawImageData::U8 { .. } => super::ir::TexelStorage::U8(
             linear_storage
                 .iter()
                 .enumerate()
@@ -601,21 +598,21 @@ fn raw_encoding(raw: &crate::util::imageio::read_image::RawImage) -> ColorEncodi
     }
 }
 
-fn gpu_color_encoding(encoding: ColorEncoding) -> super::ir::GpuColorEncoding {
+fn gpu_color_encoding(encoding: ColorEncoding) -> super::ir::ColorEncoding {
     match encoding {
-        ColorEncoding::Linear => super::ir::GpuColorEncoding::Linear,
-        ColorEncoding::SRgb => super::ir::GpuColorEncoding::Srgb,
-        ColorEncoding::Gamma(exponent) => super::ir::GpuColorEncoding::Gamma { exponent },
+        ColorEncoding::Linear => super::ir::ColorEncoding::Linear,
+        ColorEncoding::SRgb => super::ir::ColorEncoding::Srgb,
+        ColorEncoding::Gamma(exponent) => super::ir::ColorEncoding::Gamma { exponent },
     }
 }
 
 fn compile_textures(
     builder: &SceneBuilder,
-    spectra: &mut Vec<GpuSpectrumResource>,
-    float_textures: &mut Vec<GpuFloatTexture>,
-    spectrum_textures: &mut Vec<GpuSpectrumTexture>,
-    images: &mut Vec<GpuImageResource>,
-    texture_mappings: &mut Vec<GpuTextureMapping>,
+    spectra: &mut Vec<SpectrumResource>,
+    float_textures: &mut Vec<FloatTexture>,
+    spectrum_textures: &mut Vec<SpectrumTexture>,
+    images: &mut Vec<ImageResource>,
+    texture_mappings: &mut Vec<TextureMapping>,
 ) -> Result<
     (
         Vec<Option<super::ir::FloatTextureId>>,
@@ -628,8 +625,8 @@ fn compile_textures(
         let source = texture_source_location(texture);
         if texture.base.name == "imagemap" {
             let info = compile_image_texture(builder, texture, images, texture_mappings)?;
-            let id = super::ir::FloatTextureId(float_textures.len() as GpuIndex);
-            float_textures.push(GpuFloatTexture::Image {
+            let id = super::ir::FloatTextureId(float_textures.len() as Index);
+            float_textures.push(FloatTexture::Image {
                 image: info.image,
                 mapping: info.mapping,
                 scale: info.scale,
@@ -659,8 +656,8 @@ fn compile_textures(
                 ))
             }
         };
-        let id = super::ir::FloatTextureId(float_textures.len() as GpuIndex);
-        float_textures.push(GpuFloatTexture::Constant { value });
+        let id = super::ir::FloatTextureId(float_textures.len() as Index);
+        float_textures.push(FloatTexture::Constant { value });
         float_ids[index] = Some(id);
     }
 
@@ -669,8 +666,8 @@ fn compile_textures(
         let source = texture_source_location(texture);
         if texture.base.name == "imagemap" {
             let info = compile_image_texture(builder, texture, images, texture_mappings)?;
-            let id = super::ir::SpectrumTextureId(spectrum_textures.len() as GpuIndex);
-            spectrum_textures.push(GpuSpectrumTexture::Image {
+            let id = super::ir::SpectrumTextureId(spectrum_textures.len() as Index);
+            spectrum_textures.push(SpectrumTexture::Image {
                 image: info.image,
                 mapping: info.mapping,
                 scale: info.scale,
@@ -678,7 +675,7 @@ fn compile_textures(
                 swrap: info.swrap,
                 twrap: info.twrap,
                 filter: info.filter,
-                spectrum_type: super::ir::GpuSpectrumType::Albedo,
+                spectrum_type: super::ir::SpectrumType::Albedo,
             });
             spectrum_ids[index] = Some(id);
             continue;
@@ -700,16 +697,16 @@ fn compile_textures(
                 ))
             }
         };
-        let spectrum = SpectrumId(spectra.len() as GpuIndex);
-        spectra.push(GpuSpectrumResource::RgbAlbedo {
+        let spectrum = SpectrumId(spectra.len() as Index);
+        spectra.push(SpectrumResource::RgbAlbedo {
             coefficients: [
                 to_gpu_float(coefficients[0], &source)?,
                 to_gpu_float(coefficients[1], &source)?,
                 to_gpu_float(coefficients[2], &source)?,
             ],
         });
-        let id = super::ir::SpectrumTextureId(spectrum_textures.len() as GpuIndex);
-        spectrum_textures.push(GpuSpectrumTexture::Constant { value: spectrum });
+        let id = super::ir::SpectrumTextureId(spectrum_textures.len() as Index);
+        spectrum_textures.push(SpectrumTexture::Constant { value: spectrum });
         spectrum_ids[index] = Some(id);
     }
     Ok((float_ids, spectrum_ids))
@@ -718,18 +715,18 @@ fn compile_textures(
 fn compile_shape(
     builder: &SceneBuilder,
     shape: &ShapeSceneEntity,
-    transforms: &mut Vec<GpuTransform>,
-    geometry: &mut Vec<GpuGeometry>,
-    spectra: &mut Vec<GpuSpectrumResource>,
-    spectrum_textures: &mut Vec<GpuSpectrumTexture>,
-    float_textures: &[GpuFloatTexture],
+    transforms: &mut Vec<Transform>,
+    geometry: &mut Vec<Geometry>,
+    spectra: &mut Vec<SpectrumResource>,
+    spectrum_textures: &mut Vec<SpectrumTexture>,
+    float_textures: &[FloatTexture],
     float_texture_ids: &[Option<super::ir::FloatTextureId>],
     spectrum_texture_ids: &[Option<super::ir::SpectrumTextureId>],
-    images: &mut Vec<GpuImageResource>,
-    texture_mappings: &mut Vec<GpuTextureMapping>,
-    materials: &mut Vec<GpuMaterial>,
-    primitives: &mut Vec<GpuPrimitive>,
-    lights: &mut Vec<GpuLight>,
+    images: &mut Vec<ImageResource>,
+    texture_mappings: &mut Vec<TextureMapping>,
+    materials: &mut Vec<Material>,
+    primitives: &mut Vec<Primitive>,
+    lights: &mut Vec<Light>,
 ) -> Result<super::ir::PrimitiveId, GpuCompileError> {
     let source = source_location(shape);
     if !matches!(
@@ -768,7 +765,7 @@ fn compile_shape(
             "shape displacement on non-PLY geometry",
         ));
     }
-    let transform_id = TransformId(transforms.len() as GpuIndex);
+    let transform_id = TransformId(transforms.len() as Index);
     transforms.push(compile_transform(&shape.render_from_object, &source)?);
     let material = compile_material(
         builder,
@@ -817,9 +814,9 @@ fn compile_shape(
     let geometry_id = if shape.base.name == "plymesh" {
         let base_mesh = ply_mesh(builder, &shape.base.params, &source)?;
         if shape.base.params.get_textures_ref("displacement").is_some() {
-            let base_id = GeometryId(geometry.len() as GpuIndex);
-            geometry.push(GpuGeometry::TriangleMesh(base_mesh.clone()));
-            let displaced_id = GeometryId(geometry.len() as GpuIndex);
+            let base_id = GeometryId(geometry.len() as Index);
+            geometry.push(Geometry::TriangleMesh(base_mesh.clone()));
+            let displaced_id = GeometryId(geometry.len() as Index);
             let displaced = displaced_ply_mesh(
                 builder,
                 &shape.base.params,
@@ -830,44 +827,42 @@ fn compile_shape(
                 images,
                 &source,
             )?;
-            geometry.push(GpuGeometry::DisplacedTriangleMesh(displaced));
+            geometry.push(Geometry::DisplacedTriangleMesh(displaced));
             displaced_id
         } else {
-            let id = GeometryId(geometry.len() as GpuIndex);
-            geometry.push(GpuGeometry::TriangleMesh(base_mesh));
+            let id = GeometryId(geometry.len() as Index);
+            geometry.push(Geometry::TriangleMesh(base_mesh));
             id
         }
     } else {
-        let id = GeometryId(geometry.len() as GpuIndex);
+        let id = GeometryId(geometry.len() as Index);
         let shape_geometry = match shape.base.name.as_str() {
-            "trianglemesh" => {
-                GpuGeometry::TriangleMesh(triangle_mesh(&shape.base.params, &source)?)
-            }
+            "trianglemesh" => Geometry::TriangleMesh(triangle_mesh(&shape.base.params, &source)?),
             "bilinearmesh" => {
-                GpuGeometry::BilinearPatchMesh(bilinear_mesh(&shape.base.params, &source)?)
+                Geometry::BilinearPatchMesh(bilinear_mesh(&shape.base.params, &source)?)
             }
-            "curve" | "curves" => GpuGeometry::CurveMesh(curve_mesh(
+            "curve" | "curves" => Geometry::CurveMesh(curve_mesh(
                 &shape.base.params,
                 &shape.child_params,
                 &source,
             )?),
-            "sphere" => GpuGeometry::Quadric(quadric(&shape.base.params, "sphere", &source)?),
-            "cylinder" => GpuGeometry::Quadric(quadric(&shape.base.params, "cylinder", &source)?),
-            "disk" => GpuGeometry::Quadric(quadric(&shape.base.params, "disk", &source)?),
+            "sphere" => Geometry::Quadric(quadric(&shape.base.params, "sphere", &source)?),
+            "cylinder" => Geometry::Quadric(quadric(&shape.base.params, "cylinder", &source)?),
+            "disk" => Geometry::Quadric(quadric(&shape.base.params, "disk", &source)?),
             _ => unreachable!("shape name was checked above"),
         };
         geometry.push(shape_geometry);
         id
     };
-    let primitive_id = super::ir::PrimitiveId(primitives.len() as GpuIndex);
-    primitives.push(GpuPrimitive {
+    let primitive_id = super::ir::PrimitiveId(primitives.len() as Index);
+    primitives.push(Primitive {
         geometry: geometry_id,
         transform: transform_id,
         material: Some(material),
         alpha,
         area_light: area_light.map_or(
-            super::ir::GpuAreaLightBinding::None,
-            super::ir::GpuAreaLightBinding::Uniform,
+            super::ir::AreaLightBinding::None,
+            super::ir::AreaLightBinding::Uniform,
         ),
         reverse_orientation: shape.reverse_orientation,
     });
@@ -878,7 +873,7 @@ fn ply_mesh(
     builder: &SceneBuilder,
     params: &ParameterDictionary,
     source: &GpuSourceLocation,
-) -> Result<GpuTriangleMesh, GpuCompileError> {
+) -> Result<TriangleMesh, GpuCompileError> {
     let params = make_absolute_path(params, &builder.seen_work_dirs);
     let filename = params.get_one_string("filename", "");
     if filename.is_empty() {
@@ -911,7 +906,7 @@ fn ply_mesh(
         .p
         .iter()
         .map(|point| {
-            Ok(GpuPoint3([
+            Ok(Point3([
                 to_gpu_float(point[0], source)?,
                 to_gpu_float(point[1], source)?,
                 to_gpu_float(point[2], source)?,
@@ -928,7 +923,7 @@ fn ply_mesh(
             mesh.n
                 .iter()
                 .map(|normal| {
-                    Ok(GpuNormal3([
+                    Ok(Normal3([
                         to_gpu_float(normal[0], source)?,
                         to_gpu_float(normal[1], source)?,
                         to_gpu_float(normal[2], source)?,
@@ -944,7 +939,7 @@ fn ply_mesh(
             mesh.uv
                 .iter()
                 .map(|uv| {
-                    Ok(GpuPoint2([
+                    Ok(Point2([
                         to_gpu_float(uv[0], source)?,
                         to_gpu_float(uv[1], source)?,
                     ]))
@@ -959,7 +954,7 @@ fn ply_mesh(
             mesh.face_indices
                 .iter()
                 .map(|index| {
-                    GpuIndex::try_from(*index)
+                    Index::try_from(*index)
                         .map_err(|_| invalid_parameter("face_indices", "negative index", source))
                 })
                 .collect::<Result<Vec<_>, GpuCompileError>>()?,
@@ -967,7 +962,7 @@ fn ply_mesh(
     } else {
         None
     };
-    Ok(GpuTriangleMesh {
+    Ok(TriangleMesh {
         positions,
         indices,
         normals,
@@ -981,12 +976,12 @@ fn displaced_ply_mesh(
     builder: &SceneBuilder,
     params: &ParameterDictionary,
     base_mesh_id: GeometryId,
-    base_mesh: &GpuTriangleMesh,
-    float_textures: &[GpuFloatTexture],
+    base_mesh: &TriangleMesh,
+    float_textures: &[FloatTexture],
     float_texture_ids: &[Option<super::ir::FloatTextureId>],
-    images: &[GpuImageResource],
+    images: &[ImageResource],
     source: &GpuSourceLocation,
-) -> Result<GpuDisplacedTriangleMesh, GpuCompileError> {
+) -> Result<DisplacedTriangleMesh, GpuCompileError> {
     let texture_name = params
         .get_textures_ref("displacement")
         .and_then(|names| names.first().cloned())
@@ -1016,12 +1011,12 @@ fn displaced_ply_mesh(
         let uv0 = uvs[triangle[0] as usize].0;
         let uv1 = uvs[triangle[1] as usize].0;
         let uv2 = uvs[triangle[2] as usize].0;
-        let parameter_bounds = GpuBounds2 {
-            min: GpuPoint2([
+        let parameter_bounds = Bounds2 {
+            min: Point2([
                 uv0[0].min(uv1[0]).min(uv2[0]),
                 uv0[1].min(uv1[1]).min(uv2[1]),
             ]),
-            max: GpuPoint2([
+            max: Point2([
                 uv0[0].max(uv1[0]).max(uv2[0]),
                 uv0[1].max(uv1[1]).max(uv2[1]),
             ]),
@@ -1039,8 +1034,8 @@ fn displaced_ply_mesh(
                 source,
             ));
         }
-        let root = MinMaxNodeId(min_max_nodes.len() as GpuIndex);
-        min_max_nodes.push(super::ir::GpuMinMaxNode {
+        let root = MinMaxNodeId(min_max_nodes.len() as Index);
+        min_max_nodes.push(super::ir::MinMaxNode {
             parameter_bounds,
             displacement_min,
             displacement_max,
@@ -1065,7 +1060,7 @@ fn displaced_ply_mesh(
             max[axis] = max[axis].max(point.0[axis] + extent);
         }
     }
-    Ok(GpuDisplacedTriangleMesh {
+    Ok(DisplacedTriangleMesh {
         base_mesh: base_mesh_id,
         displacement,
         displacement_scale: 1.0,
@@ -1074,9 +1069,9 @@ fn displaced_ply_mesh(
         min_max_nodes: min_max_nodes.into_boxed_slice(),
         triangle_roots: triangle_roots.into_boxed_slice(),
         displaced_bounds_object: vec![
-            GpuBounds3 {
-                min: GpuPoint3(min),
-                max: GpuPoint3(max),
+            Bounds3 {
+                min: Point3(min),
+                max: Point3(max),
             };
             base_mesh.indices.len()
         ]
@@ -1086,16 +1081,16 @@ fn displaced_ply_mesh(
 
 fn float_texture_bounds(
     texture_id: super::ir::FloatTextureId,
-    float_textures: &[GpuFloatTexture],
-    images: &[GpuImageResource],
+    float_textures: &[FloatTexture],
+    images: &[ImageResource],
     source: &GpuSourceLocation,
-) -> Result<(GpuFloat, GpuFloat), GpuCompileError> {
+) -> Result<(Float, Float), GpuCompileError> {
     let texture = float_textures
         .get(texture_id.0 as usize)
         .ok_or_else(|| invalid_parameter("displacement", "texture ID is invalid", source))?;
     let (mut min, mut max) = match texture {
-        GpuFloatTexture::Constant { value } => (*value, *value),
-        GpuFloatTexture::Image {
+        FloatTexture::Constant { value } => (*value, *value),
+        FloatTexture::Image {
             image,
             channel,
             scale,
@@ -1138,14 +1133,14 @@ fn float_texture_bounds(
 }
 
 fn image_float_channel_values(
-    image: &GpuImageResource,
-    channel: super::ir::GpuFloatImageChannel,
+    image: &ImageResource,
+    channel: super::ir::FloatImageChannel,
     source: &GpuSourceLocation,
 ) -> Result<Vec<Float>, GpuCompileError> {
     let channel_count = image.channels.count();
     let selected = match channel {
-        super::ir::GpuFloatImageChannel::Channel0 => 0,
-        super::ir::GpuFloatImageChannel::Alpha => {
+        super::ir::FloatImageChannel::Channel0 => 0,
+        super::ir::FloatImageChannel::Alpha => {
             if channel_count != 2 && channel_count != 4 {
                 return Err(invalid_parameter(
                     "displacement",
@@ -1155,7 +1150,7 @@ fn image_float_channel_values(
             }
             channel_count - 1
         }
-        super::ir::GpuFloatImageChannel::RgbAverage => {
+        super::ir::FloatImageChannel::RgbAverage => {
             if channel_count < 3 {
                 return Err(invalid_parameter(
                     "displacement",
@@ -1169,7 +1164,7 @@ fn image_float_channel_values(
     let mut values = Vec::new();
     let mut push_pixel = |pixel: &[Float]| {
         values.push(
-            if matches!(channel, super::ir::GpuFloatImageChannel::RgbAverage) {
+            if matches!(channel, super::ir::FloatImageChannel::RgbAverage) {
                 (pixel[0] + pixel[1] + pixel[2]) / 3.0
             } else {
                 pixel[selected]
@@ -1177,12 +1172,12 @@ fn image_float_channel_values(
         );
     };
     match &image.storage {
-        super::ir::GpuTexelStorage::F32(data) => {
+        super::ir::TexelStorage::F32(data) => {
             for pixel in data.chunks_exact(channel_count) {
                 push_pixel(pixel);
             }
         }
-        super::ir::GpuTexelStorage::F16(data) => {
+        super::ir::TexelStorage::F16(data) => {
             for pixel in data.chunks_exact(channel_count) {
                 let values_f32 = pixel
                     .iter()
@@ -1191,7 +1186,7 @@ fn image_float_channel_values(
                 push_pixel(&values_f32);
             }
         }
-        super::ir::GpuTexelStorage::U8(data) => {
+        super::ir::TexelStorage::U8(data) => {
             for pixel in data.chunks_exact(channel_count) {
                 let values_f32 = pixel
                     .iter()
@@ -1202,11 +1197,11 @@ fn image_float_channel_values(
                             normalized
                         } else {
                             match image.color_encoding {
-                                super::ir::GpuColorEncoding::Linear => normalized,
-                                super::ir::GpuColorEncoding::Srgb => {
+                                super::ir::ColorEncoding::Linear => normalized,
+                                super::ir::ColorEncoding::Srgb => {
                                     ColorEncoding::SRgb.to_linear(normalized)
                                 }
-                                super::ir::GpuColorEncoding::Gamma { exponent } => {
+                                super::ir::ColorEncoding::Gamma { exponent } => {
                                     normalized.powf(exponent)
                                 }
                             }
@@ -1231,7 +1226,7 @@ fn curve_mesh(
     params: &ParameterDictionary,
     child_params: &[ParameterDictionary],
     source: &GpuSourceLocation,
-) -> Result<GpuCurveMesh, GpuCompileError> {
+) -> Result<CurveMesh, GpuCompileError> {
     let grouped = params.get_points("P").is_empty();
     let first_params = if grouped {
         child_params
@@ -1241,9 +1236,9 @@ fn curve_mesh(
         params
     };
     let curve_type = match first_params.get_one_string("type", "flat").as_str() {
-        "flat" => GpuCurveType::Flat,
-        "cylinder" => GpuCurveType::Cylinder,
-        "ribbon" => GpuCurveType::Ribbon,
+        "flat" => CurveType::Flat,
+        "cylinder" => CurveType::Cylinder,
+        "ribbon" => CurveType::Ribbon,
         _ => return Err(invalid_parameter("type", "unknown curve type", source)),
     };
     let mut curves = Vec::with_capacity(child_params.len() + 1);
@@ -1257,14 +1252,14 @@ fn curve_mesh(
             curves.push(curve_segment(params, curve_type, source)?);
         }
     }
-    Ok(GpuCurveMesh { curve_type, curves })
+    Ok(CurveMesh { curve_type, curves })
 }
 
 fn curve_segment(
     params: &ParameterDictionary,
-    curve_type: GpuCurveType,
+    curve_type: CurveType,
     source: &GpuSourceLocation,
-) -> Result<GpuCurveSegment, GpuCompileError> {
+) -> Result<CurveSegment, GpuCompileError> {
     let points = params.get_points("P");
     if points.len() != 12 {
         return Err(invalid_parameter(
@@ -1273,9 +1268,9 @@ fn curve_segment(
             source,
         ));
     }
-    let mut control_points = [GpuPoint3([0.0; 3]); 4];
+    let mut control_points = [Point3([0.0; 3]); 4];
     for (point, values) in control_points.iter_mut().zip(points.chunks_exact(3)) {
-        *point = GpuPoint3([
+        *point = Point3([
             to_gpu_float(values[0], source)?,
             to_gpu_float(values[1], source)?,
             to_gpu_float(values[2], source)?,
@@ -1302,7 +1297,7 @@ fn curve_segment(
     }
     let raw_normals = params.get_points("N");
     let endpoint_normals = match curve_type {
-        GpuCurveType::Ribbon => {
+        CurveType::Ribbon => {
             if raw_normals.len() != 6 {
                 return Err(invalid_parameter(
                     "N",
@@ -1311,19 +1306,19 @@ fn curve_segment(
                 ));
             }
             Some([
-                GpuNormal3([
+                Normal3([
                     to_gpu_float(raw_normals[0], source)?,
                     to_gpu_float(raw_normals[1], source)?,
                     to_gpu_float(raw_normals[2], source)?,
                 ]),
-                GpuNormal3([
+                Normal3([
                     to_gpu_float(raw_normals[3], source)?,
                     to_gpu_float(raw_normals[4], source)?,
                     to_gpu_float(raw_normals[5], source)?,
                 ]),
             ])
         }
-        GpuCurveType::Flat | GpuCurveType::Cylinder => {
+        CurveType::Flat | CurveType::Cylinder => {
             if !raw_normals.is_empty() {
                 return Err(invalid_parameter(
                     "N",
@@ -1334,7 +1329,7 @@ fn curve_segment(
             None
         }
     };
-    Ok(GpuCurveSegment {
+    Ok(CurveSegment {
         control_points,
         widths,
         endpoint_normals,
@@ -1343,11 +1338,11 @@ fn curve_segment(
 
 fn compile_instance_transform(
     render_from_instance: &RenderFromObject,
-    transforms: &mut Vec<GpuTransform>,
+    transforms: &mut Vec<Transform>,
     source: &GpuSourceLocation,
 ) -> Result<TransformId, GpuCompileError> {
     let transform = compile_transform(render_from_instance, source)?;
-    let id = TransformId(transforms.len() as GpuIndex);
+    let id = TransformId(transforms.len() as Index);
     transforms.push(transform);
     Ok(id)
 }
@@ -1355,17 +1350,17 @@ fn compile_instance_transform(
 fn compile_transform(
     render_from_object: &RenderFromObject,
     source: &GpuSourceLocation,
-) -> Result<GpuTransform, GpuCompileError> {
+) -> Result<Transform, GpuCompileError> {
     Ok(match render_from_object {
         RenderFromObject::Static(transform) => {
-            GpuTransform::Static(static_transform(transform, source)?)
+            Transform::Static(static_transform(transform, source)?)
         }
         RenderFromObject::Animated {
             from,
             to,
             start_time,
             end_time,
-        } => GpuTransform::Animated(GpuAnimatedTransform {
+        } => Transform::Animated(AnimatedTransform {
             start: static_transform(from, source)?,
             end: static_transform(to, source)?,
             start_time: to_gpu_float(*start_time, source)?,
@@ -1376,9 +1371,9 @@ fn compile_transform(
 
 fn bounds_for_primitives(
     primitive_ids: &[super::ir::PrimitiveId],
-    primitives: &[GpuPrimitive],
-    geometry: &[GpuGeometry],
-) -> Result<GpuBounds3, GpuCompileError> {
+    primitives: &[Primitive],
+    geometry: &[Geometry],
+) -> Result<Bounds3, GpuCompileError> {
     let mut min = [f32::INFINITY; 3];
     let mut max = [f32::NEG_INFINITY; 3];
     for primitive_id in primitive_ids {
@@ -1397,17 +1392,17 @@ fn bounds_for_primitives(
             }
         })?;
         match shape_geometry {
-            GpuGeometry::TriangleMesh(mesh) => {
+            Geometry::TriangleMesh(mesh) => {
                 for point in &mesh.positions {
                     extend_bounds(&mut min, &mut max, point.0);
                 }
             }
-            GpuGeometry::BilinearPatchMesh(mesh) => {
+            Geometry::BilinearPatchMesh(mesh) => {
                 for point in &mesh.positions {
                     extend_bounds(&mut min, &mut max, point.0);
                 }
             }
-            GpuGeometry::CurveMesh(mesh) => {
+            Geometry::CurveMesh(mesh) => {
                 for curve in &mesh.curves {
                     let radius = curve.widths.iter().copied().fold(0.0, f32::max) * 0.5;
                     for point in curve.control_points {
@@ -1415,26 +1410,26 @@ fn bounds_for_primitives(
                     }
                 }
             }
-            GpuGeometry::Quadric(quadric) => {
+            Geometry::Quadric(quadric) => {
                 let (radius, z_min, z_max) = match quadric {
-                    GpuQuadric::Sphere {
+                    Quadric::Sphere {
                         radius,
                         z_min,
                         z_max,
                         ..
                     }
-                    | GpuQuadric::Cylinder {
+                    | Quadric::Cylinder {
                         radius,
                         z_min,
                         z_max,
                         ..
                     } => (*radius, *z_min, *z_max),
-                    GpuQuadric::Disk { radius, height, .. } => (*radius, *height, *height),
+                    Quadric::Disk { radius, height, .. } => (*radius, *height, *height),
                 };
                 extend_bounds(&mut min, &mut max, [-radius, -radius, z_min]);
                 extend_bounds(&mut min, &mut max, [radius, radius, z_max]);
             }
-            GpuGeometry::DisplacedTriangleMesh(mesh) => {
+            Geometry::DisplacedTriangleMesh(mesh) => {
                 for bound in &mesh.displaced_bounds_object {
                     extend_bounds(&mut min, &mut max, bound.min.0);
                     extend_bounds(&mut min, &mut max, bound.max.0);
@@ -1443,9 +1438,9 @@ fn bounds_for_primitives(
         }
     }
     if min.iter().zip(max.iter()).all(|(min, max)| min <= max) {
-        Ok(GpuBounds3 {
-            min: GpuPoint3(min),
-            max: GpuPoint3(max),
+        Ok(Bounds3 {
+            min: Point3(min),
+            max: Point3(max),
         })
     } else {
         Err(GpuCompileError::InvalidParameter {
@@ -1470,7 +1465,7 @@ fn extend_bounds_with_radius(min: &mut [f32; 3], max: &mut [f32; 3], point: [f32
 fn bilinear_mesh(
     params: &ParameterDictionary,
     source: &GpuSourceLocation,
-) -> Result<GpuBilinearPatchMesh, GpuCompileError> {
+) -> Result<BilinearPatchMesh, GpuCompileError> {
     let raw_positions = params.get_points("P");
     if raw_positions.is_empty() || raw_positions.len() % 3 != 0 {
         return Err(invalid_parameter(
@@ -1482,7 +1477,7 @@ fn bilinear_mesh(
     let positions = raw_positions
         .chunks_exact(3)
         .map(|point| {
-            Ok(GpuPoint3([
+            Ok(Point3([
                 to_gpu_float(point[0], source)?,
                 to_gpu_float(point[1], source)?,
                 to_gpu_float(point[2], source)?,
@@ -1502,13 +1497,13 @@ fn bilinear_mesh(
         .map(|patch| {
             let mut result = [0; 4];
             for (dst, index) in result.iter_mut().zip(patch) {
-                *dst = GpuIndex::try_from(*index)
+                *dst = Index::try_from(*index)
                     .map_err(|_| invalid_parameter("indices", "negative index", source))?;
             }
             Ok(result)
         })
-        .collect::<Result<Vec<[GpuIndex; 4]>, GpuCompileError>>()?;
-    Ok(GpuBilinearPatchMesh {
+        .collect::<Result<Vec<[Index; 4]>, GpuCompileError>>()?;
+    Ok(BilinearPatchMesh {
         positions,
         indices,
         normals: optional_vec3(params.get_points("N"), "N", source)?,
@@ -1521,26 +1516,26 @@ fn quadric(
     params: &ParameterDictionary,
     name: &'static str,
     source: &GpuSourceLocation,
-) -> Result<GpuQuadric, GpuCompileError> {
+) -> Result<Quadric, GpuCompileError> {
     let radius = finite_parameter(params, "radius", 1.0, source)?;
     let z_min = finite_parameter(params, "zmin", -1.0, source)?;
     let z_max = finite_parameter(params, "zmax", 1.0, source)?;
     let phi_max_radians =
         finite_parameter(params, "phimax", 360.0, source)? * std::f32::consts::PI / 180.0;
     match name {
-        "sphere" => Ok(GpuQuadric::Sphere {
+        "sphere" => Ok(Quadric::Sphere {
             radius,
             z_min,
             z_max,
             phi_max_radians,
         }),
-        "cylinder" => Ok(GpuQuadric::Cylinder {
+        "cylinder" => Ok(Quadric::Cylinder {
             radius,
             z_min,
             z_max,
             phi_max_radians,
         }),
-        "disk" => Ok(GpuQuadric::Disk {
+        "disk" => Ok(Quadric::Disk {
             height: finite_parameter(params, "height", 0.0, source)?,
             radius,
             inner_radius: finite_parameter(params, "innerradius", 0.0, source)?,
@@ -1555,7 +1550,7 @@ fn finite_parameter(
     name: &'static str,
     default: Float,
     source: &GpuSourceLocation,
-) -> Result<GpuFloat, GpuCompileError> {
+) -> Result<Float, GpuCompileError> {
     let value = params.get_one_float(name, default) as f32;
     value
         .is_finite()
@@ -1568,7 +1563,7 @@ fn vector3_parameter(
     name: &'static str,
     default: [Float; 3],
     source: &GpuSourceLocation,
-) -> Result<GpuVector3, GpuCompileError> {
+) -> Result<Vector3, GpuCompileError> {
     let values = params.get_points(name);
     let values = if values.is_empty() {
         default
@@ -1581,7 +1576,7 @@ fn vector3_parameter(
             source,
         ));
     };
-    Ok(GpuVector3([
+    Ok(Vector3([
         to_gpu_float(values[0], source)?,
         to_gpu_float(values[1], source)?,
         to_gpu_float(values[2], source)?,
@@ -1593,7 +1588,7 @@ fn compile_rgb_spectrum(
     name: &'static str,
     default: [Float; 3],
     source: &GpuSourceLocation,
-    spectra: &mut Vec<GpuSpectrumResource>,
+    spectra: &mut Vec<SpectrumResource>,
 ) -> Result<SpectrumId, GpuCompileError> {
     if params.get_textures_ref(name).is_some()
         || params.get_spectrums_ref(name).is_some()
@@ -1616,8 +1611,8 @@ fn compile_rgb_spectrum(
             ))
         }
     };
-    let id = SpectrumId(spectra.len() as GpuIndex);
-    spectra.push(GpuSpectrumResource::RgbUnbounded {
+    let id = SpectrumId(spectra.len() as Index);
+    spectra.push(SpectrumResource::RgbUnbounded {
         coefficients: [
             to_gpu_float(coefficients[0], source)?,
             to_gpu_float(coefficients[1], source)?,
@@ -1630,12 +1625,12 @@ fn compile_rgb_spectrum(
 fn compile_material(
     builder: &SceneBuilder,
     shape: &ShapeSceneEntity,
-    spectra: &mut Vec<GpuSpectrumResource>,
-    spectrum_textures: &mut Vec<GpuSpectrumTexture>,
+    spectra: &mut Vec<SpectrumResource>,
+    spectrum_textures: &mut Vec<SpectrumTexture>,
     float_texture_ids: &[Option<super::ir::FloatTextureId>],
     spectrum_texture_ids: &[Option<super::ir::SpectrumTextureId>],
-    images: &mut Vec<GpuImageResource>,
-    materials: &mut Vec<GpuMaterial>,
+    images: &mut Vec<ImageResource>,
+    materials: &mut Vec<Material>,
 ) -> Result<MaterialId, GpuCompileError> {
     if shape.material_is_default
         && shape.material_index == usize::MAX
@@ -1715,7 +1710,7 @@ fn compile_material(
                 )
             })?;
         let id = MaterialId(materials.len() as u32);
-        materials.push(GpuMaterial::Diffuse(GpuDiffuseMaterial {
+        materials.push(Material::Diffuse(DiffuseMaterial {
             reflectance: texture_id,
             displacement,
             normal_map,
@@ -1734,17 +1729,17 @@ fn compile_material(
         }
     };
     let spectrum = SpectrumId(spectra.len() as u32);
-    spectra.push(GpuSpectrumResource::RgbAlbedo {
+    spectra.push(SpectrumResource::RgbAlbedo {
         coefficients: [
             to_gpu_float(coefficients[0], &source_location(shape))?,
             to_gpu_float(coefficients[1], &source_location(shape))?,
             to_gpu_float(coefficients[2], &source_location(shape))?,
         ],
     });
-    let spectrum_texture = super::ir::SpectrumTextureId(spectrum_textures.len() as GpuIndex);
-    spectrum_textures.push(GpuSpectrumTexture::Constant { value: spectrum });
+    let spectrum_texture = super::ir::SpectrumTextureId(spectrum_textures.len() as Index);
+    spectrum_textures.push(SpectrumTexture::Constant { value: spectrum });
     let id = MaterialId(materials.len() as u32);
-    materials.push(GpuMaterial::Diffuse(GpuDiffuseMaterial {
+    materials.push(Material::Diffuse(DiffuseMaterial {
         reflectance: spectrum_texture,
         displacement,
         normal_map,
@@ -1778,7 +1773,7 @@ fn material_texture_id(
 fn compile_normal_map_image(
     builder: &SceneBuilder,
     material: &crate::parser::scene_builder::MaterialSceneEntity,
-    images: &mut Vec<GpuImageResource>,
+    images: &mut Vec<ImageResource>,
     source: &GpuSourceLocation,
 ) -> Result<Option<super::ir::ImageId>, GpuCompileError> {
     let params = make_absolute_path(&material.base.params, &builder.seen_work_dirs);
@@ -1806,14 +1801,14 @@ fn compile_normal_map_image(
         .map_err(|_| invalid_parameter("normalmap", "image width is too large", source))?;
     let height = u32::try_from(raw.resolution.y)
         .map_err(|_| invalid_parameter("normalmap", "image height is too large", source))?;
-    let image = super::ir::ImageId(images.len() as GpuIndex);
+    let image = super::ir::ImageId(images.len() as Index);
     let (mip_values, mip_levels) = build_mip_storage(&pixels, width, height, 3);
-    images.push(GpuImageResource {
+    images.push(ImageResource {
         resolution: [width, height],
-        channels: GpuImageChannels::Rgb,
+        channels: ImageChannels::Rgb,
         storage: encode_mip_storage(&mip_values, &raw.data, ColorEncoding::Linear, 3),
         mip_levels,
-        color_encoding: super::ir::GpuColorEncoding::Linear,
+        color_encoding: super::ir::ColorEncoding::Linear,
     });
     Ok(Some(image))
 }
@@ -1821,7 +1816,7 @@ fn compile_normal_map_image(
 fn triangle_mesh(
     params: &ParameterDictionary,
     source: &GpuSourceLocation,
-) -> Result<GpuTriangleMesh, GpuCompileError> {
+) -> Result<TriangleMesh, GpuCompileError> {
     let positions = params.get_points("P");
     if positions.is_empty() {
         return Err(GpuCompileError::MissingParameter {
@@ -1839,7 +1834,7 @@ fn triangle_mesh(
     let positions = positions
         .chunks_exact(3)
         .map(|p| {
-            Ok(GpuPoint3([
+            Ok(Point3([
                 to_gpu_float(p[0], source)?,
                 to_gpu_float(p[1], source)?,
                 to_gpu_float(p[2], source)?,
@@ -1865,21 +1860,17 @@ fn triangle_mesh(
     for triangle in raw_indices.chunks_exact(3) {
         let mut converted = [0; 3];
         for (dst, index) in converted.iter_mut().zip(triangle) {
-            *dst = GpuIndex::try_from(*index)
+            *dst = Index::try_from(*index)
                 .map_err(|_| invalid_parameter("indices", "negative index", source))?;
         }
         indices.push(converted);
     }
 
     let normals = optional_vec3(params.get_points("N"), "N", source)?;
-    let tangents = optional_vec3(params.get_points("S"), "S", source)?.map(|values| {
-        values
-            .into_iter()
-            .map(|normal| GpuVector3(normal.0))
-            .collect()
-    });
+    let tangents = optional_vec3(params.get_points("S"), "S", source)?
+        .map(|values| values.into_iter().map(|normal| Vector3(normal.0)).collect());
     let uvs = optional_vec2(params.get_points("uv"), "uv", source)?;
-    Ok(GpuTriangleMesh {
+    Ok(TriangleMesh {
         positions,
         indices,
         normals,
@@ -1893,7 +1884,7 @@ fn optional_vec2(
     values: Vec<Float>,
     parameter: &'static str,
     source: &GpuSourceLocation,
-) -> Result<Option<Vec<GpuPoint2>>, GpuCompileError> {
+) -> Result<Option<Vec<Point2>>, GpuCompileError> {
     if values.is_empty() {
         return Ok(None);
     }
@@ -1907,7 +1898,7 @@ fn optional_vec2(
     values
         .chunks_exact(2)
         .map(|value| {
-            Ok(GpuPoint2([
+            Ok(Point2([
                 to_gpu_float(value[0], source)?,
                 to_gpu_float(value[1], source)?,
             ]))
@@ -1920,7 +1911,7 @@ fn optional_vec3(
     values: Vec<Float>,
     parameter: &'static str,
     source: &GpuSourceLocation,
-) -> Result<Option<Vec<GpuNormal3>>, GpuCompileError> {
+) -> Result<Option<Vec<Normal3>>, GpuCompileError> {
     if values.is_empty() {
         return Ok(None);
     }
@@ -1934,7 +1925,7 @@ fn optional_vec3(
     values
         .chunks_exact(3)
         .map(|value| {
-            Ok(GpuNormal3([
+            Ok(Normal3([
                 to_gpu_float(value[0], source)?,
                 to_gpu_float(value[1], source)?,
                 to_gpu_float(value[2], source)?,
@@ -1945,30 +1936,30 @@ fn optional_vec3(
 }
 
 fn static_transform(
-    transform: &Transform,
+    transform: &CpuTransform,
     source: &GpuSourceLocation,
-) -> Result<GpuStaticTransform, GpuCompileError> {
-    Ok(GpuStaticTransform {
+) -> Result<StaticTransform, GpuCompileError> {
+    Ok(StaticTransform {
         render_from_object: matrix(transform.m, source)?,
         object_from_render: matrix(transform.minv, source)?,
         swaps_handedness: transform.swaps_handedness(),
     })
 }
 
-fn matrix(matrix: Matrix4x4, source: &GpuSourceLocation) -> Result<GpuMatrix4x4, GpuCompileError> {
+fn matrix(matrix: CpuMatrix4x4, source: &GpuSourceLocation) -> Result<Matrix4x4, GpuCompileError> {
     let mut result = [[0.0; 4]; 4];
     for (row, values) in result.iter_mut().enumerate() {
         for (column, value) in values.iter_mut().enumerate() {
             *value = to_gpu_float(matrix.m[row * 4 + column], source)?;
         }
     }
-    Ok(GpuMatrix4x4(result))
+    Ok(Matrix4x4(result))
 }
 
 fn render_config(
     builder: &SceneBuilder,
-    transforms: &mut Vec<GpuTransform>,
-) -> Result<GpuRenderConfig, GpuCompileError> {
+    transforms: &mut Vec<Transform>,
+) -> Result<RenderConfig, GpuCompileError> {
     let source = empty_source();
     if builder.camera_name != "perspective" {
         return Err(GpuCompileError::UnsupportedSceneFeature {
@@ -2063,7 +2054,7 @@ fn render_config(
             &empty_source(),
         ));
     }
-    let pixel_bounds = GpuBounds2i {
+    let pixel_bounds = Bounds2i {
         min: [
             u32::try_from(min[0]).map_err(|_| {
                 invalid_parameter(
@@ -2128,17 +2119,17 @@ fn render_config(
     if halffov > 0.0 {
         fov = 2.0 * halffov;
     }
-    let camera_to_screen = Transform::perspective(fov, 1e-2, 1000.0);
-    let screen_to_raster = Transform::scale(xresolution as Float, yresolution as Float, 1.0)
-        * Transform::scale(
+    let camera_to_screen = CpuTransform::perspective(fov, 1e-2, 1000.0);
+    let screen_to_raster = CpuTransform::scale(xresolution as Float, yresolution as Float, 1.0)
+        * CpuTransform::scale(
             1.0 / (screen[1] - screen[0]),
             1.0 / (screen[2] - screen[3]),
             1.0,
         )
-        * Transform::translate(-screen[0], -screen[3], 0.0);
+        * CpuTransform::translate(-screen[0], -screen[3], 0.0);
     let raster_to_camera = camera_to_screen.inverse() * screen_to_raster.inverse();
-    let camera_transform_id = TransformId(transforms.len() as GpuIndex);
-    transforms.push(GpuTransform::Static(static_transform(
+    let camera_transform_id = TransformId(transforms.len() as Index);
+    transforms.push(Transform::Static(static_transform(
         &builder.camera_to_world[0],
         &empty_source(),
     )?));
@@ -2191,8 +2182,8 @@ fn render_config(
             &empty_source(),
         ));
     }
-    Ok(GpuRenderConfig {
-        camera: GpuPerspectiveCamera {
+    Ok(RenderConfig {
+        camera: PerspectiveCamera {
             render_from_camera: camera_transform_id,
             camera_from_raster: matrix(raster_to_camera.m, &empty_source())?,
             lens_radius,
@@ -2200,15 +2191,15 @@ fn render_config(
             shutter_open,
             shutter_close,
         },
-        sampler: GpuIndependentSampler {
+        sampler: IndependentSampler {
             samples_per_pixel,
             seed: builder.sampler_params.get_one_int("seed", 0) as u64,
         },
-        film: GpuRgbFilm {
+        film: RgbFilm {
             full_resolution: [xresolution as u32, yresolution as u32],
             pixel_bounds,
             diagonal_mm,
-            output_rgb_from_xyz: GpuMatrix3x3([
+            output_rgb_from_xyz: Matrix3x3([
                 [3.240479, -1.537150, -0.498535],
                 [-0.969256, 1.875991, 0.041556],
                 [0.055648, -0.204043, 1.057311],
@@ -2216,10 +2207,10 @@ fn render_config(
             iso,
             max_component_value,
         },
-        filter: GpuBoxFilter {
-            radius: GpuVector2([xradius, yradius]),
+        filter: BoxFilter {
+            radius: Vector2([xradius, yradius]),
         },
-        integrator: GpuWavefrontVolPath {
+        integrator: WavefrontVolPath {
             max_depth: u32::try_from(max_depth).map_err(|_| {
                 invalid_parameter(
                     "maxdepth",
@@ -2229,7 +2220,7 @@ fn render_config(
             })?,
             regularize: builder.integrator_params.get_one_bool("regularize", false),
         },
-        light_sampler: GpuLightSampler::Uniform,
+        light_sampler: LightSampler::Uniform,
     })
 }
 
@@ -2252,7 +2243,7 @@ struct GpuSourceGroups {
     instances: Vec<SourceId>,
 }
 
-fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
+fn source_map(builder: &SceneBuilder, ir: &SceneIr) -> GpuSourceMap {
     let mut locations = Vec::new();
     let mut groups = GpuSourceGroups::default();
     for shape in &builder.shapes {
@@ -2312,7 +2303,7 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
         );
     }
     for material in &builder.materials {
-        groups.materials.push(SourceId(locations.len() as GpuIndex));
+        groups.materials.push(SourceId(locations.len() as Index));
         locations.push(GpuSourceLocation {
             filename: material.base.loc.filename.clone(),
             line: material.base.loc.line,
@@ -2334,7 +2325,7 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
         add_resource(
             &mut resources,
             GpuResourceKind::Primitive,
-            index as GpuIndex,
+            index as Index,
             source,
         );
         add_resource(
@@ -2343,7 +2334,7 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
             primitive.geometry.0,
             source,
         );
-        if let Some(super::ir::GpuGeometry::DisplacedTriangleMesh(mesh)) =
+        if let Some(super::ir::Geometry::DisplacedTriangleMesh(mesh)) =
             ir.view().geometry.get(primitive.geometry.0 as usize)
         {
             add_resource(
@@ -2366,7 +2357,7 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
                 material.0,
                 source,
             );
-            if let Some(super::ir::GpuMaterial::Diffuse(material)) =
+            if let Some(super::ir::Material::Diffuse(material)) =
                 ir.view().materials.get(material.0 as usize)
             {
                 add_spectrum_texture_resources(
@@ -2387,10 +2378,10 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
             add_float_texture_resources(&mut resources, ir.view(), texture, source);
         }
         match &primitive.area_light {
-            super::ir::GpuAreaLightBinding::None => {}
-            super::ir::GpuAreaLightBinding::Uniform(light) => {
+            super::ir::AreaLightBinding::None => {}
+            super::ir::AreaLightBinding::Uniform(light) => {
                 add_resource(&mut resources, GpuResourceKind::Light, light.0, source);
-                if let Some(super::ir::GpuLight::DiffuseArea(light)) =
+                if let Some(super::ir::Light::DiffuseArea(light)) =
                     ir.view().lights.get(light.0 as usize)
                 {
                     add_spectrum_texture_resources(
@@ -2401,7 +2392,7 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
                     );
                 }
             }
-            super::ir::GpuAreaLightBinding::PerElement(lights) => {
+            super::ir::AreaLightBinding::PerElement(lights) => {
                 for light in lights {
                     add_resource(&mut resources, GpuResourceKind::Light, light.0, source);
                 }
@@ -2415,10 +2406,10 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
         add_resource(
             &mut resources,
             GpuResourceKind::FloatTexture,
-            index as GpuIndex,
+            index as Index,
             source,
         );
-        if let super::ir::GpuFloatTexture::Image { image, mapping, .. } = texture {
+        if let super::ir::FloatTexture::Image { image, mapping, .. } = texture {
             add_resource(&mut resources, GpuResourceKind::Image, image.0, source);
             add_resource(
                 &mut resources,
@@ -2435,10 +2426,10 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
         add_resource(
             &mut resources,
             GpuResourceKind::SpectrumTexture,
-            index as GpuIndex,
+            index as Index,
             source,
         );
-        if let super::ir::GpuSpectrumTexture::Image { image, mapping, .. } = texture {
+        if let super::ir::SpectrumTexture::Image { image, mapping, .. } = texture {
             add_resource(&mut resources, GpuResourceKind::Image, image.0, source);
             add_resource(
                 &mut resources,
@@ -2453,10 +2444,10 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
             add_resource(
                 &mut resources,
                 GpuResourceKind::Light,
-                index as GpuIndex,
+                index as Index,
                 source,
             );
-            if let super::ir::GpuLight::Point(point) = light {
+            if let super::ir::Light::Point(point) = light {
                 add_resource(
                     &mut resources,
                     GpuResourceKind::Transform,
@@ -2470,7 +2461,7 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
         add_resource(
             &mut resources,
             GpuResourceKind::InstanceDefinition,
-            index as GpuIndex,
+            index as Index,
             source,
         );
     }
@@ -2481,7 +2472,7 @@ fn source_map(builder: &SceneBuilder, ir: &GpuSceneIr) -> GpuSourceMap {
         add_resource(
             &mut resources,
             GpuResourceKind::Instance,
-            index as GpuIndex,
+            index as Index,
             source,
         );
         add_resource(
@@ -2503,7 +2494,7 @@ fn add_source(
     group: &mut Vec<SourceId>,
     location: GpuSourceLocation,
 ) {
-    let id = SourceId(locations.len() as GpuIndex);
+    let id = SourceId(locations.len() as Index);
     locations.push(location);
     group.push(id);
 }
@@ -2511,7 +2502,7 @@ fn add_source(
 fn add_resource(
     resources: &mut Vec<GpuSourceEntry>,
     kind: GpuResourceKind,
-    index: GpuIndex,
+    index: Index,
     source: SourceId,
 ) {
     if resources
@@ -2529,12 +2520,12 @@ fn add_resource(
 
 fn add_float_texture_resources(
     resources: &mut Vec<GpuSourceEntry>,
-    view: super::ir::GpuSceneView<'_>,
+    view: super::ir::SceneView<'_>,
     texture: super::ir::FloatTextureId,
     source: SourceId,
 ) {
     add_resource(resources, GpuResourceKind::FloatTexture, texture.0, source);
-    if let Some(super::ir::GpuFloatTexture::Image { image, mapping, .. }) =
+    if let Some(super::ir::FloatTexture::Image { image, mapping, .. }) =
         view.float_textures.get(texture.0 as usize)
     {
         add_resource(resources, GpuResourceKind::Image, image.0, source);
@@ -2549,7 +2540,7 @@ fn add_float_texture_resources(
 
 fn add_spectrum_texture_resources(
     resources: &mut Vec<GpuSourceEntry>,
-    view: super::ir::GpuSceneView<'_>,
+    view: super::ir::SceneView<'_>,
     texture: super::ir::SpectrumTextureId,
     source: SourceId,
 ) {
@@ -2560,10 +2551,10 @@ fn add_spectrum_texture_resources(
         source,
     );
     match view.spectrum_textures.get(texture.0 as usize) {
-        Some(super::ir::GpuSpectrumTexture::Constant { value }) => {
+        Some(super::ir::SpectrumTexture::Constant { value }) => {
             add_resource(resources, GpuResourceKind::Spectrum, value.0, source);
         }
-        Some(super::ir::GpuSpectrumTexture::Image { image, mapping, .. }) => {
+        Some(super::ir::SpectrumTexture::Image { image, mapping, .. }) => {
             add_resource(resources, GpuResourceKind::Image, image.0, source);
             add_resource(
                 resources,
@@ -2577,8 +2568,8 @@ fn add_spectrum_texture_resources(
 }
 
 fn attach_requirement_sources(
-    requirements: &mut super::ir::GpuRequirements,
-    view: super::ir::GpuSceneView<'_>,
+    requirements: &mut super::ir::Requirements,
+    view: super::ir::SceneView<'_>,
     source_map: &GpuSourceMap,
 ) {
     for required in requirements.features.iter_mut() {
@@ -2596,126 +2587,126 @@ fn attach_requirement_sources(
 }
 
 fn requirement_resource_matches(
-    feature: GpuFeature,
+    feature: Feature,
     entry: &GpuSourceEntry,
-    view: super::ir::GpuSceneView<'_>,
+    view: super::ir::SceneView<'_>,
 ) -> bool {
     match feature {
-        GpuFeature::TriangleMesh => {
+        Feature::TriangleMesh => {
             entry.kind == GpuResourceKind::Geometry
                 && matches!(
                     view.geometry.get(entry.index as usize),
-                    Some(super::ir::GpuGeometry::TriangleMesh(_))
+                    Some(super::ir::Geometry::TriangleMesh(_))
                 )
         }
-        GpuFeature::BilinearPatch => {
+        Feature::BilinearPatch => {
             entry.kind == GpuResourceKind::Geometry
                 && matches!(
                     view.geometry.get(entry.index as usize),
-                    Some(super::ir::GpuGeometry::BilinearPatchMesh(_))
+                    Some(super::ir::Geometry::BilinearPatchMesh(_))
                 )
         }
-        GpuFeature::Curve => {
+        Feature::Curve => {
             entry.kind == GpuResourceKind::Geometry
                 && matches!(
                     view.geometry.get(entry.index as usize),
-                    Some(super::ir::GpuGeometry::CurveMesh(_))
+                    Some(super::ir::Geometry::CurveMesh(_))
                 )
         }
-        GpuFeature::Quadric => {
+        Feature::Quadric => {
             entry.kind == GpuResourceKind::Geometry
                 && matches!(
                     view.geometry.get(entry.index as usize),
-                    Some(super::ir::GpuGeometry::Quadric(_))
+                    Some(super::ir::Geometry::Quadric(_))
                 )
         }
-        GpuFeature::DisplacedTriangle => {
+        Feature::DisplacedTriangle => {
             entry.kind == GpuResourceKind::Geometry
                 && matches!(
                     view.geometry.get(entry.index as usize),
-                    Some(super::ir::GpuGeometry::DisplacedTriangleMesh(_))
+                    Some(super::ir::Geometry::DisplacedTriangleMesh(_))
                 )
         }
-        GpuFeature::FloatConstantTexture => {
+        Feature::FloatConstantTexture => {
             entry.kind == GpuResourceKind::FloatTexture
                 && matches!(
                     view.float_textures.get(entry.index as usize),
-                    Some(super::ir::GpuFloatTexture::Constant { .. })
+                    Some(super::ir::FloatTexture::Constant { .. })
                 )
         }
-        GpuFeature::FloatImageTexture => {
+        Feature::FloatImageTexture => {
             entry.kind == GpuResourceKind::FloatTexture
                 && matches!(
                     view.float_textures.get(entry.index as usize),
-                    Some(super::ir::GpuFloatTexture::Image { .. })
+                    Some(super::ir::FloatTexture::Image { .. })
                 )
         }
-        GpuFeature::SpectrumConstantTexture => {
+        Feature::SpectrumConstantTexture => {
             entry.kind == GpuResourceKind::SpectrumTexture
                 && matches!(
                     view.spectrum_textures.get(entry.index as usize),
-                    Some(super::ir::GpuSpectrumTexture::Constant { .. })
+                    Some(super::ir::SpectrumTexture::Constant { .. })
                 )
         }
-        GpuFeature::SpectrumImageTexture => {
+        Feature::SpectrumImageTexture => {
             entry.kind == GpuResourceKind::SpectrumTexture
                 && matches!(
                     view.spectrum_textures.get(entry.index as usize),
-                    Some(super::ir::GpuSpectrumTexture::Image { .. })
+                    Some(super::ir::SpectrumTexture::Image { .. })
                 )
         }
-        GpuFeature::DiffuseMaterial => {
+        Feature::DiffuseMaterial => {
             entry.kind == GpuResourceKind::Material
                 && matches!(
                     view.materials.get(entry.index as usize),
-                    Some(super::ir::GpuMaterial::Diffuse(_))
+                    Some(super::ir::Material::Diffuse(_))
                 )
         }
-        GpuFeature::PointLight => {
+        Feature::PointLight => {
             entry.kind == GpuResourceKind::Light
                 && matches!(
                     view.lights.get(entry.index as usize),
-                    Some(super::ir::GpuLight::Point(_))
+                    Some(super::ir::Light::Point(_))
                 )
         }
-        GpuFeature::DiffuseAreaLight => {
+        Feature::DiffuseAreaLight => {
             entry.kind == GpuResourceKind::Light
                 && matches!(
                     view.lights.get(entry.index as usize),
-                    Some(super::ir::GpuLight::DiffuseArea(_))
+                    Some(super::ir::Light::DiffuseArea(_))
                 )
         }
-        GpuFeature::UniformInfiniteLight => {
+        Feature::UniformInfiniteLight => {
             entry.kind == GpuResourceKind::Light
                 && matches!(
                     view.lights.get(entry.index as usize),
-                    Some(super::ir::GpuLight::UniformInfinite(_))
+                    Some(super::ir::Light::UniformInfinite(_))
                 )
         }
-        GpuFeature::StaticTransform => {
+        Feature::StaticTransform => {
             entry.kind == GpuResourceKind::Transform
                 && matches!(
                     view.transforms.get(entry.index as usize),
-                    Some(super::ir::GpuTransform::Static(_))
+                    Some(super::ir::Transform::Static(_))
                 )
         }
-        GpuFeature::AnimatedTransform => {
+        Feature::AnimatedTransform => {
             entry.kind == GpuResourceKind::Transform
                 && matches!(
                     view.transforms.get(entry.index as usize),
-                    Some(super::ir::GpuTransform::Animated(_))
+                    Some(super::ir::Transform::Animated(_))
                 )
         }
-        GpuFeature::PerspectiveCamera
-        | GpuFeature::IndependentSampler
-        | GpuFeature::RgbFilm
-        | GpuFeature::BoxFilter
-        | GpuFeature::WavefrontVolPath
-        | GpuFeature::UniformLightSampler => false,
+        Feature::PerspectiveCamera
+        | Feature::IndependentSampler
+        | Feature::RgbFilm
+        | Feature::BoxFilter
+        | Feature::WavefrontVolPath
+        | Feature::UniformLightSampler => false,
     }
 }
 
-fn to_gpu_float(value: Float, source: &GpuSourceLocation) -> Result<GpuFloat, GpuCompileError> {
+fn to_gpu_float(value: Float, source: &GpuSourceLocation) -> Result<Float, GpuCompileError> {
     let value = value as f32;
     value.is_finite().then_some(value).ok_or_else(|| {
         invalid_parameter(

--- a/src/gpu/compiler/source_map.rs
+++ b/src/gpu/compiler/source_map.rs
@@ -1,4 +1,4 @@
-use super::super::ir::{GpuIndex, SourceId};
+use super::super::ir::{Index, SourceId};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct GpuSourceMap {
@@ -25,6 +25,6 @@ pub enum GpuResourceKind {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GpuSourceEntry {
     pub kind: GpuResourceKind,
-    pub index: GpuIndex,
+    pub index: Index,
     pub source: SourceId,
 }

--- a/src/gpu/compiler/source_map.rs
+++ b/src/gpu/compiler/source_map.rs
@@ -1,13 +1,13 @@
 use super::super::ir::{Index, SourceId};
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct GpuSourceMap {
-    pub locations: Box<[super::GpuSourceLocation]>,
-    pub resources: Box<[GpuSourceEntry]>,
+pub struct SourceMap {
+    pub locations: Box<[super::SourceLocation]>,
+    pub resources: Box<[SourceEntry]>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub enum GpuResourceKind {
+pub enum ResourceKind {
     Transform,
     Spectrum,
     Image,
@@ -23,8 +23,8 @@ pub enum GpuResourceKind {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GpuSourceEntry {
-    pub kind: GpuResourceKind,
+pub struct SourceEntry {
+    pub kind: ResourceKind,
     pub index: Index,
     pub source: SourceId,
 }

--- a/src/gpu/ir/geometry.rs
+++ b/src/gpu/ir/geometry.rs
@@ -1,111 +1,111 @@
 use super::{
-    FloatTextureId, GeometryId, GpuBounds2, GpuBounds3, GpuFloat, GpuNormal3, GpuPoint2, GpuPoint3,
-    GpuVector3, LightId, MaterialId, MinMaxNodeId, TransformId,
+    Bounds2, Bounds3, Float, FloatTextureId, GeometryId, LightId, MaterialId, MinMaxNodeId,
+    Normal3, Point2, Point3, TransformId, Vector3,
 };
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuTriangleMesh {
-    pub positions: Vec<GpuPoint3>,
-    pub indices: Vec<[super::GpuIndex; 3]>,
-    pub normals: Option<Vec<GpuNormal3>>,
-    pub tangents: Option<Vec<GpuVector3>>,
-    pub uvs: Option<Vec<GpuPoint2>>,
-    pub face_indices: Option<Vec<super::GpuIndex>>,
+pub struct TriangleMesh {
+    pub positions: Vec<Point3>,
+    pub indices: Vec<[super::Index; 3]>,
+    pub normals: Option<Vec<Normal3>>,
+    pub tangents: Option<Vec<Vector3>>,
+    pub uvs: Option<Vec<Point2>>,
+    pub face_indices: Option<Vec<super::Index>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuBilinearPatchMesh {
-    pub positions: Vec<GpuPoint3>,
-    pub indices: Vec<[super::GpuIndex; 4]>,
-    pub normals: Option<Vec<GpuNormal3>>,
-    pub uvs: Option<Vec<GpuPoint2>>,
-    pub face_indices: Option<Vec<super::GpuIndex>>,
+pub struct BilinearPatchMesh {
+    pub positions: Vec<Point3>,
+    pub indices: Vec<[super::Index; 4]>,
+    pub normals: Option<Vec<Normal3>>,
+    pub uvs: Option<Vec<Point2>>,
+    pub face_indices: Option<Vec<super::Index>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GpuCurveType {
+pub enum CurveType {
     Flat,
     Cylinder,
     Ribbon,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuCurveSegment {
-    pub control_points: [GpuPoint3; 4],
-    pub widths: [GpuFloat; 2],
-    pub endpoint_normals: Option<[GpuNormal3; 2]>,
+pub struct CurveSegment {
+    pub control_points: [Point3; 4],
+    pub widths: [Float; 2],
+    pub endpoint_normals: Option<[Normal3; 2]>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuCurveMesh {
-    pub curve_type: GpuCurveType,
-    pub curves: Vec<GpuCurveSegment>,
+pub struct CurveMesh {
+    pub curve_type: CurveType,
+    pub curves: Vec<CurveSegment>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuQuadric {
+pub enum Quadric {
     Sphere {
-        radius: GpuFloat,
-        z_min: GpuFloat,
-        z_max: GpuFloat,
-        phi_max_radians: GpuFloat,
+        radius: Float,
+        z_min: Float,
+        z_max: Float,
+        phi_max_radians: Float,
     },
     Cylinder {
-        radius: GpuFloat,
-        z_min: GpuFloat,
-        z_max: GpuFloat,
-        phi_max_radians: GpuFloat,
+        radius: Float,
+        z_min: Float,
+        z_max: Float,
+        phi_max_radians: Float,
     },
     Disk {
-        height: GpuFloat,
-        radius: GpuFloat,
-        inner_radius: GpuFloat,
-        phi_max_radians: GpuFloat,
+        height: Float,
+        radius: Float,
+        inner_radius: Float,
+        phi_max_radians: Float,
     },
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuMinMaxNode {
-    pub parameter_bounds: GpuBounds2,
-    pub displacement_min: GpuFloat,
-    pub displacement_max: GpuFloat,
+pub struct MinMaxNode {
+    pub parameter_bounds: Bounds2,
+    pub displacement_min: Float,
+    pub displacement_max: Float,
     pub children: Option<[MinMaxNodeId; 4]>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuDisplacedTriangleMesh {
+pub struct DisplacedTriangleMesh {
     pub base_mesh: GeometryId,
     pub displacement: FloatTextureId,
-    pub displacement_scale: GpuFloat,
-    pub displacement_offset: GpuFloat,
-    pub edge_length: GpuFloat,
-    pub min_max_nodes: Box<[GpuMinMaxNode]>,
+    pub displacement_scale: Float,
+    pub displacement_offset: Float,
+    pub edge_length: Float,
+    pub min_max_nodes: Box<[MinMaxNode]>,
     pub triangle_roots: Box<[MinMaxNodeId]>,
-    pub displaced_bounds_object: Box<[GpuBounds3]>,
+    pub displaced_bounds_object: Box<[Bounds3]>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum GpuGeometry {
-    TriangleMesh(GpuTriangleMesh),
-    BilinearPatchMesh(GpuBilinearPatchMesh),
-    CurveMesh(GpuCurveMesh),
-    Quadric(GpuQuadric),
-    DisplacedTriangleMesh(GpuDisplacedTriangleMesh),
+pub enum Geometry {
+    TriangleMesh(TriangleMesh),
+    BilinearPatchMesh(BilinearPatchMesh),
+    CurveMesh(CurveMesh),
+    Quadric(Quadric),
+    DisplacedTriangleMesh(DisplacedTriangleMesh),
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum GpuAreaLightBinding {
+pub enum AreaLightBinding {
     None,
     Uniform(LightId),
     PerElement(Vec<LightId>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuPrimitive {
+pub struct Primitive {
     pub geometry: GeometryId,
     pub transform: TransformId,
     pub material: Option<MaterialId>,
     pub alpha: Option<FloatTextureId>,
-    pub area_light: GpuAreaLightBinding,
+    pub area_light: AreaLightBinding,
     pub reverse_orientation: bool,
 }

--- a/src/gpu/ir/math.rs
+++ b/src/gpu/ir/math.rs
@@ -1,10 +1,10 @@
-pub type GpuFloat = f32;
-pub type GpuIndex = u32;
+pub type Float = f32;
+pub type Index = u32;
 
 macro_rules! typed_id {
     ($name:ident) => {
         #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-        pub struct $name(pub GpuIndex);
+        pub struct $name(pub Index);
     };
 }
 
@@ -24,24 +24,24 @@ typed_id!(MinMaxNodeId);
 typed_id!(SourceId);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuPoint2(pub [GpuFloat; 2]);
+pub struct Point2(pub [Float; 2]);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuPoint3(pub [GpuFloat; 3]);
+pub struct Point3(pub [Float; 3]);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuVector2(pub [GpuFloat; 2]);
+pub struct Vector2(pub [Float; 2]);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuVector3(pub [GpuFloat; 3]);
+pub struct Vector3(pub [Float; 3]);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuNormal3(pub [GpuFloat; 3]);
+pub struct Normal3(pub [Float; 3]);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuMatrix4x4(pub [[GpuFloat; 4]; 4]);
+pub struct Matrix4x4(pub [[Float; 4]; 4]);
 
-impl GpuMatrix4x4 {
+impl Matrix4x4 {
     pub fn identity() -> Self {
         Self([
             [1.0, 0.0, 0.0, 0.0],
@@ -53,49 +53,49 @@ impl GpuMatrix4x4 {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuMatrix3x3(pub [[GpuFloat; 3]; 3]);
+pub struct Matrix3x3(pub [[Float; 3]; 3]);
 
-impl GpuMatrix3x3 {
+impl Matrix3x3 {
     pub fn identity() -> Self {
         Self([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuStaticTransform {
-    pub render_from_object: GpuMatrix4x4,
-    pub object_from_render: GpuMatrix4x4,
+pub struct StaticTransform {
+    pub render_from_object: Matrix4x4,
+    pub object_from_render: Matrix4x4,
     pub swaps_handedness: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuTransform {
-    Static(GpuStaticTransform),
-    Animated(GpuAnimatedTransform),
+pub enum Transform {
+    Static(StaticTransform),
+    Animated(AnimatedTransform),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuAnimatedTransform {
-    pub start: GpuStaticTransform,
-    pub end: GpuStaticTransform,
-    pub start_time: GpuFloat,
-    pub end_time: GpuFloat,
+pub struct AnimatedTransform {
+    pub start: StaticTransform,
+    pub end: StaticTransform,
+    pub start_time: Float,
+    pub end_time: Float,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuBounds3 {
-    pub min: GpuPoint3,
-    pub max: GpuPoint3,
+pub struct Bounds3 {
+    pub min: Point3,
+    pub max: Point3,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuBounds2 {
-    pub min: GpuPoint2,
-    pub max: GpuPoint2,
+pub struct Bounds2 {
+    pub min: Point2,
+    pub max: Point2,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GpuRange {
-    pub offset: GpuIndex,
-    pub count: GpuIndex,
+pub struct Range {
+    pub offset: Index,
+    pub count: Index,
 }

--- a/src/gpu/ir/mod.rs
+++ b/src/gpu/ir/mod.rs
@@ -15,15 +15,15 @@ pub use render::*;
 pub use texture::*;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GpuIrVersion {
+pub struct IrVersion {
     pub major: u16,
     pub minor: u16,
 }
 
-pub const CURRENT_IR_VERSION: GpuIrVersion = GpuIrVersion { major: 1, minor: 0 };
+pub const CURRENT_IR_VERSION: IrVersion = IrVersion { major: 1, minor: 0 };
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub enum GpuFeature {
+pub enum Feature {
     TriangleMesh,
     StaticTransform,
     AnimatedTransform,
@@ -48,13 +48,13 @@ pub enum GpuFeature {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GpuRequiredFeature {
-    pub feature: GpuFeature,
+pub struct RequiredFeature {
+    pub feature: Feature,
     pub sources: Box<[SourceId]>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct GpuResourceCounts {
+pub struct ResourceCounts {
     pub transforms: u64,
     pub spectra: u64,
     pub images: u64,
@@ -70,7 +70,7 @@ pub struct GpuResourceCounts {
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct GpuSemanticMaxima {
+pub struct SemanticMaxima {
     pub texture_graph_depth: u32,
     pub material_graph_depth: u32,
     pub instance_depth: u32,
@@ -80,19 +80,19 @@ pub struct GpuSemanticMaxima {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GpuRequirements {
-    pub features: Box<[GpuRequiredFeature]>,
-    pub resource_counts: GpuResourceCounts,
-    pub maxima: GpuSemanticMaxima,
+pub struct Requirements {
+    pub features: Box<[RequiredFeature]>,
+    pub resource_counts: ResourceCounts,
+    pub maxima: SemanticMaxima,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GpuBounds2i {
-    pub min: [GpuIndex; 2],
-    pub max: [GpuIndex; 2],
+pub struct Bounds2i {
+    pub min: [Index; 2],
+    pub max: [Index; 2],
 }
 
-impl GpuBounds2i {
+impl Bounds2i {
     pub fn pixel_count(self) -> Option<usize> {
         let width = self.max[0].checked_sub(self.min[0])?;
         let height = self.max[1].checked_sub(self.min[1])?;
@@ -103,150 +103,150 @@ impl GpuBounds2i {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuInstanceDefinition {
+pub struct InstanceDefinition {
     pub primitives: Vec<PrimitiveId>,
     pub instances: Vec<InstanceId>,
-    pub local_bounds: GpuBounds3,
+    pub local_bounds: Bounds3,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GpuInstance {
+pub struct Instance {
     pub definition: InstanceDefinitionId,
     pub transform: TransformId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuDiffuseMaterial {
+pub struct DiffuseMaterial {
     pub reflectance: SpectrumTextureId,
     pub displacement: Option<FloatTextureId>,
     pub normal_map: Option<ImageId>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuMaterial {
-    Diffuse(GpuDiffuseMaterial),
+pub enum Material {
+    Diffuse(DiffuseMaterial),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuPointLight {
+pub struct PointLight {
     pub render_from_light: TransformId,
     pub intensity: SpectrumId,
-    pub scale: GpuFloat,
+    pub scale: Float,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuDiffuseAreaLight {
+pub struct DiffuseAreaLight {
     pub emission: SpectrumTextureId,
-    pub scale: GpuFloat,
+    pub scale: Float,
     pub two_sided: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuUniformInfiniteLight {
+pub struct UniformInfiniteLight {
     pub radiance: SpectrumId,
-    pub scale: GpuFloat,
+    pub scale: Float,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuLight {
-    Point(GpuPointLight),
-    DiffuseArea(GpuDiffuseAreaLight),
-    UniformInfinite(GpuUniformInfiniteLight),
+pub enum Light {
+    Point(PointLight),
+    DiffuseArea(DiffuseAreaLight),
+    UniformInfinite(UniformInfiniteLight),
 }
 
-impl Default for GpuRenderConfig {
+impl Default for RenderConfig {
     fn default() -> Self {
         Self {
-            camera: GpuPerspectiveCamera {
+            camera: PerspectiveCamera {
                 render_from_camera: TransformId(0),
-                camera_from_raster: GpuMatrix4x4::identity(),
+                camera_from_raster: Matrix4x4::identity(),
                 lens_radius: 0.0,
                 focal_distance: 1.0,
                 shutter_open: 0.0,
                 shutter_close: 1.0,
             },
-            sampler: GpuIndependentSampler {
+            sampler: IndependentSampler {
                 samples_per_pixel: 1,
                 seed: 0,
             },
-            film: GpuRgbFilm {
+            film: RgbFilm {
                 full_resolution: [1, 1],
-                pixel_bounds: GpuBounds2i {
+                pixel_bounds: Bounds2i {
                     min: [0, 0],
                     max: [1, 1],
                 },
                 diagonal_mm: 35.0,
-                output_rgb_from_xyz: GpuMatrix3x3::identity(),
+                output_rgb_from_xyz: Matrix3x3::identity(),
                 iso: 100.0,
                 max_component_value: 1e6,
             },
-            filter: GpuBoxFilter {
-                radius: GpuVector2([0.5, 0.5]),
+            filter: BoxFilter {
+                radius: Vector2([0.5, 0.5]),
             },
-            integrator: GpuWavefrontVolPath {
+            integrator: WavefrontVolPath {
                 max_depth: 5,
                 regularize: false,
             },
-            light_sampler: GpuLightSampler::Uniform,
+            light_sampler: LightSampler::Uniform,
         }
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuSceneData {
-    pub transforms: Vec<GpuTransform>,
-    pub spectra: Vec<GpuSpectrumResource>,
-    pub float_textures: Vec<GpuFloatTexture>,
-    pub spectrum_textures: Vec<GpuSpectrumTexture>,
-    pub texture_mappings: Vec<GpuTextureMapping>,
-    pub images: Vec<GpuImageResource>,
-    pub geometry: Vec<GpuGeometry>,
-    pub materials: Vec<GpuMaterial>,
-    pub lights: Vec<GpuLight>,
-    pub primitives: Vec<GpuPrimitive>,
-    pub instance_definitions: Vec<GpuInstanceDefinition>,
-    pub instances: Vec<GpuInstance>,
+pub struct SceneData {
+    pub transforms: Vec<Transform>,
+    pub spectra: Vec<SpectrumResource>,
+    pub float_textures: Vec<FloatTexture>,
+    pub spectrum_textures: Vec<SpectrumTexture>,
+    pub texture_mappings: Vec<TextureMapping>,
+    pub images: Vec<ImageResource>,
+    pub geometry: Vec<Geometry>,
+    pub materials: Vec<Material>,
+    pub lights: Vec<Light>,
+    pub primitives: Vec<Primitive>,
+    pub instance_definitions: Vec<InstanceDefinition>,
+    pub instances: Vec<Instance>,
     pub world_primitives: Box<[PrimitiveId]>,
     pub world_instances: Box<[InstanceId]>,
-    pub render: GpuRenderConfig,
+    pub render: RenderConfig,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuSceneDraft {
-    pub version: GpuIrVersion,
-    pub data: GpuSceneData,
+pub struct SceneDraft {
+    pub version: IrVersion,
+    pub data: SceneData,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuSceneIr {
-    version: GpuIrVersion,
-    data: GpuSceneData,
+pub struct SceneIr {
+    version: IrVersion,
+    data: SceneData,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuSceneView<'a> {
-    pub version: &'a GpuIrVersion,
-    pub transforms: &'a [GpuTransform],
-    pub spectra: &'a [GpuSpectrumResource],
-    pub float_textures: &'a [GpuFloatTexture],
-    pub spectrum_textures: &'a [GpuSpectrumTexture],
-    pub texture_mappings: &'a [GpuTextureMapping],
-    pub images: &'a [GpuImageResource],
-    pub geometry: &'a [GpuGeometry],
-    pub materials: &'a [GpuMaterial],
-    pub lights: &'a [GpuLight],
-    pub primitives: &'a [GpuPrimitive],
-    pub instance_definitions: &'a [GpuInstanceDefinition],
-    pub instances: &'a [GpuInstance],
+pub struct SceneView<'a> {
+    pub version: &'a IrVersion,
+    pub transforms: &'a [Transform],
+    pub spectra: &'a [SpectrumResource],
+    pub float_textures: &'a [FloatTexture],
+    pub spectrum_textures: &'a [SpectrumTexture],
+    pub texture_mappings: &'a [TextureMapping],
+    pub images: &'a [ImageResource],
+    pub geometry: &'a [Geometry],
+    pub materials: &'a [Material],
+    pub lights: &'a [Light],
+    pub primitives: &'a [Primitive],
+    pub instance_definitions: &'a [InstanceDefinition],
+    pub instances: &'a [Instance],
     pub world_primitives: &'a [PrimitiveId],
     pub world_instances: &'a [InstanceId],
-    pub render: &'a GpuRenderConfig,
+    pub render: &'a RenderConfig,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum GpuIrValidationError {
+pub enum IrValidationError {
     UnsupportedMajorVersion {
-        found: GpuIrVersion,
+        found: IrVersion,
         expected_major: u16,
     },
     InvalidPixelBounds,
@@ -256,11 +256,11 @@ pub enum GpuIrValidationError {
     },
     TriangleIndexOutOfBounds {
         geometry: GeometryId,
-        index: GpuIndex,
+        index: Index,
     },
     DegenerateTriangle {
         geometry: GeometryId,
-        triangle: GpuIndex,
+        triangle: Index,
     },
     AttributeLengthMismatch {
         geometry: GeometryId,
@@ -323,7 +323,7 @@ pub enum GpuIrValidationError {
     },
     InvalidCurve {
         geometry: GeometryId,
-        curve: GpuIndex,
+        curve: Index,
     },
     InvalidInstanceDefinitionReference {
         instance: InstanceId,
@@ -363,57 +363,55 @@ pub enum GpuIrValidationError {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GpuIrValidationErrors {
-    issues: Box<[GpuIrValidationError]>,
+pub struct IrValidationErrors {
+    issues: Box<[IrValidationError]>,
 }
 
-impl GpuIrValidationErrors {
-    pub fn issues(&self) -> &[GpuIrValidationError] {
+impl IrValidationErrors {
+    pub fn issues(&self) -> &[IrValidationError] {
         &self.issues
     }
 }
 
-impl GpuSceneDraft {
-    pub fn finish(self) -> Result<GpuSceneIr, GpuIrValidationErrors> {
+impl SceneDraft {
+    pub fn finish(self) -> Result<SceneIr, IrValidationErrors> {
         let mut issues = Vec::new();
         if self.version.major != CURRENT_IR_VERSION.major {
-            issues.push(GpuIrValidationError::UnsupportedMajorVersion {
+            issues.push(IrValidationError::UnsupportedMajorVersion {
                 found: self.version,
                 expected_major: CURRENT_IR_VERSION.major,
             });
         }
         if self.data.render.film.pixel_bounds.area().is_none() {
-            issues.push(GpuIrValidationError::InvalidPixelBounds);
+            issues.push(IrValidationError::InvalidPixelBounds);
         }
         if self.data.render.sampler.samples_per_pixel == 0 {
-            issues.push(GpuIrValidationError::InvalidSampleCount);
+            issues.push(IrValidationError::InvalidSampleCount);
         }
         for (geometry_index, geometry) in self.data.geometry.iter().enumerate() {
-            let geometry_id = GeometryId(geometry_index as GpuIndex);
+            let geometry_id = GeometryId(geometry_index as Index);
             match geometry {
-                GpuGeometry::TriangleMesh(mesh) => {
+                Geometry::TriangleMesh(mesh) => {
                     validate_triangle_mesh(geometry_id, mesh, &mut issues)
                 }
-                GpuGeometry::BilinearPatchMesh(mesh) => {
+                Geometry::BilinearPatchMesh(mesh) => {
                     validate_bilinear_mesh(geometry_id, mesh, &mut issues)
                 }
-                GpuGeometry::CurveMesh(mesh) => validate_curve_mesh(geometry_id, mesh, &mut issues),
-                GpuGeometry::Quadric(quadric) => {
-                    validate_quadric(geometry_id, quadric, &mut issues)
-                }
-                GpuGeometry::DisplacedTriangleMesh(mesh) => {
+                Geometry::CurveMesh(mesh) => validate_curve_mesh(geometry_id, mesh, &mut issues),
+                Geometry::Quadric(quadric) => validate_quadric(geometry_id, quadric, &mut issues),
+                Geometry::DisplacedTriangleMesh(mesh) => {
                     validate_displaced_mesh(geometry_id, mesh, &self.data, &mut issues)
                 }
             }
         }
         for (primitive_index, primitive) in self.data.primitives.iter().enumerate() {
-            let primitive_id = PrimitiveId(primitive_index as GpuIndex);
+            let primitive_id = PrimitiveId(primitive_index as Index);
             if usize::try_from(primitive.geometry.0)
                 .ok()
                 .and_then(|index| self.data.geometry.get(index))
                 .is_none()
             {
-                issues.push(GpuIrValidationError::InvalidGeometryReference {
+                issues.push(IrValidationError::InvalidGeometryReference {
                     primitive: primitive_id,
                     geometry: primitive.geometry,
                 });
@@ -423,7 +421,7 @@ impl GpuSceneDraft {
                 .and_then(|index| self.data.transforms.get(index))
                 .is_none()
             {
-                issues.push(GpuIrValidationError::InvalidTransformReference {
+                issues.push(IrValidationError::InvalidTransformReference {
                     primitive: primitive_id,
                     transform: primitive.transform,
                 });
@@ -434,7 +432,7 @@ impl GpuSceneDraft {
                     .and_then(|index| self.data.materials.get(index))
                     .is_none()
                 {
-                    issues.push(GpuIrValidationError::InvalidMaterialReference {
+                    issues.push(IrValidationError::InvalidMaterialReference {
                         primitive: primitive_id,
                         material,
                     });
@@ -446,16 +444,16 @@ impl GpuSceneDraft {
                     .and_then(|index| self.data.float_textures.get(index))
                     .is_none()
                 {
-                    issues.push(GpuIrValidationError::InvalidFloatTextureReference {
+                    issues.push(IrValidationError::InvalidFloatTextureReference {
                         primitive: primitive_id,
                         texture,
                     });
                 }
             }
             let area_lights = match &primitive.area_light {
-                GpuAreaLightBinding::None => &[][..],
-                GpuAreaLightBinding::Uniform(light) => std::slice::from_ref(light),
-                GpuAreaLightBinding::PerElement(lights) => lights,
+                AreaLightBinding::None => &[][..],
+                AreaLightBinding::Uniform(light) => std::slice::from_ref(light),
+                AreaLightBinding::PerElement(lights) => lights,
             };
             for light in area_lights {
                 if usize::try_from(light.0)
@@ -463,7 +461,7 @@ impl GpuSceneDraft {
                     .and_then(|index| self.data.lights.get(index))
                     .is_none()
                 {
-                    issues.push(GpuIrValidationError::InvalidAreaLightReference {
+                    issues.push(IrValidationError::InvalidAreaLightReference {
                         primitive: primitive_id,
                         light: *light,
                     });
@@ -476,7 +474,7 @@ impl GpuSceneDraft {
                 .and_then(|index| self.data.primitives.get(index))
                 .is_none()
             {
-                issues.push(GpuIrValidationError::InvalidWorldPrimitiveReference {
+                issues.push(IrValidationError::InvalidWorldPrimitiveReference {
                     primitive: *primitive,
                 });
             }
@@ -487,13 +485,13 @@ impl GpuSceneDraft {
                 .and_then(|index| self.data.instances.get(index))
                 .is_none()
             {
-                issues.push(GpuIrValidationError::InvalidWorldInstanceReference {
+                issues.push(IrValidationError::InvalidWorldInstanceReference {
                     instance: *instance,
                 });
             }
         }
         for (definition_index, definition) in self.data.instance_definitions.iter().enumerate() {
-            let definition_id = InstanceDefinitionId(definition_index as GpuIndex);
+            let definition_id = InstanceDefinitionId(definition_index as Index);
             let valid_bounds = definition
                 .local_bounds
                 .min
@@ -502,7 +500,7 @@ impl GpuSceneDraft {
                 .zip(definition.local_bounds.max.0.iter())
                 .all(|(min, max)| min.is_finite() && max.is_finite() && min <= max);
             if !valid_bounds {
-                issues.push(GpuIrValidationError::InvalidInstanceBounds {
+                issues.push(IrValidationError::InvalidInstanceBounds {
                     definition: definition_id,
                 });
             }
@@ -512,7 +510,7 @@ impl GpuSceneDraft {
                     .and_then(|index| self.data.primitives.get(index))
                     .is_none()
                 {
-                    issues.push(GpuIrValidationError::InvalidInstancePrimitiveReference {
+                    issues.push(IrValidationError::InvalidInstancePrimitiveReference {
                         definition: definition_id,
                         primitive: *primitive,
                     });
@@ -524,7 +522,7 @@ impl GpuSceneDraft {
                     .and_then(|index| self.data.instances.get(index))
                     .is_none()
                 {
-                    issues.push(GpuIrValidationError::InvalidInstanceReference {
+                    issues.push(IrValidationError::InvalidInstanceReference {
                         definition: definition_id,
                         instance: *instance,
                     });
@@ -532,13 +530,13 @@ impl GpuSceneDraft {
             }
         }
         for (instance_index, instance) in self.data.instances.iter().enumerate() {
-            let instance_id = InstanceId(instance_index as GpuIndex);
+            let instance_id = InstanceId(instance_index as Index);
             if usize::try_from(instance.definition.0)
                 .ok()
                 .and_then(|index| self.data.instance_definitions.get(index))
                 .is_none()
             {
-                issues.push(GpuIrValidationError::InvalidInstanceDefinitionReference {
+                issues.push(IrValidationError::InvalidInstanceDefinitionReference {
                     instance: instance_id,
                     definition: instance.definition,
                 });
@@ -548,16 +546,16 @@ impl GpuSceneDraft {
                 .and_then(|index| self.data.transforms.get(index))
                 .is_none()
             {
-                issues.push(GpuIrValidationError::InvalidInstanceTransformReference {
+                issues.push(IrValidationError::InvalidInstanceTransformReference {
                     instance: instance_id,
                     transform: instance.transform,
                 });
             }
         }
         for (material_index, material) in self.data.materials.iter().enumerate() {
-            let material_id = MaterialId(material_index as GpuIndex);
+            let material_id = MaterialId(material_index as Index);
             let (texture, displacement, normal_map) = match material {
-                GpuMaterial::Diffuse(diffuse) => (
+                Material::Diffuse(diffuse) => (
                     diffuse.reflectance,
                     diffuse.displacement,
                     diffuse.normal_map,
@@ -568,7 +566,7 @@ impl GpuSceneDraft {
                 .and_then(|index| self.data.spectrum_textures.get(index))
                 .is_none()
             {
-                issues.push(GpuIrValidationError::InvalidSpectrumTextureReference {
+                issues.push(IrValidationError::InvalidSpectrumTextureReference {
                     material: material_id,
                     texture,
                 });
@@ -579,7 +577,7 @@ impl GpuSceneDraft {
                     .and_then(|index| self.data.float_textures.get(index))
                     .is_none()
                 {
-                    issues.push(GpuIrValidationError::InvalidMaterialFloatTextureReference {
+                    issues.push(IrValidationError::InvalidMaterialFloatTextureReference {
                         material: material_id,
                         texture: displacement,
                     });
@@ -591,43 +589,41 @@ impl GpuSceneDraft {
                     .and_then(|index| self.data.images.get(index))
                     .is_none()
                 {
-                    issues.push(GpuIrValidationError::InvalidImageReference { image: normal_map });
+                    issues.push(IrValidationError::InvalidImageReference { image: normal_map });
                 }
             }
         }
         for (texture_index, texture) in self.data.spectrum_textures.iter().enumerate() {
-            let texture_id = SpectrumTextureId(texture_index as GpuIndex);
+            let texture_id = SpectrumTextureId(texture_index as Index);
             match texture {
-                GpuSpectrumTexture::Constant { value } => {
+                SpectrumTexture::Constant { value } => {
                     if usize::try_from(value.0)
                         .ok()
                         .and_then(|index| self.data.spectra.get(index))
                         .is_none()
                     {
-                        issues.push(GpuIrValidationError::InvalidTextureSpectrumReference {
+                        issues.push(IrValidationError::InvalidTextureSpectrumReference {
                             texture: texture_id,
                             spectrum: *value,
                         });
                     }
                 }
-                GpuSpectrumTexture::Image { image, mapping, .. } => {
+                SpectrumTexture::Image { image, mapping, .. } => {
                     validate_image_texture_refs(*image, *mapping, &self.data, &mut issues)
                 }
             }
         }
         for texture in &self.data.float_textures {
-            if let GpuFloatTexture::Image { image, mapping, .. } = texture {
+            if let FloatTexture::Image { image, mapping, .. } = texture {
                 validate_image_texture_refs(*image, *mapping, &self.data, &mut issues);
             }
         }
         for (light_index, light) in self.data.lights.iter().enumerate() {
-            let light_id = LightId(light_index as GpuIndex);
+            let light_id = LightId(light_index as Index);
             let (transform, spectrum, texture) = match light {
-                GpuLight::Point(point) => {
-                    (Some(point.render_from_light), Some(point.intensity), None)
-                }
-                GpuLight::DiffuseArea(area) => (None, None, Some(area.emission)),
-                GpuLight::UniformInfinite(infinite) => (None, Some(infinite.radiance), None),
+                Light::Point(point) => (Some(point.render_from_light), Some(point.intensity), None),
+                Light::DiffuseArea(area) => (None, None, Some(area.emission)),
+                Light::UniformInfinite(infinite) => (None, Some(infinite.radiance), None),
             };
             if let Some(transform) = transform {
                 if usize::try_from(transform.0)
@@ -635,7 +631,7 @@ impl GpuSceneDraft {
                     .and_then(|index| self.data.transforms.get(index))
                     .is_none()
                 {
-                    issues.push(GpuIrValidationError::InvalidLightTransformReference {
+                    issues.push(IrValidationError::InvalidLightTransformReference {
                         light: light_id,
                         transform,
                     });
@@ -647,7 +643,7 @@ impl GpuSceneDraft {
                     .and_then(|index| self.data.spectra.get(index))
                     .is_none()
                 {
-                    issues.push(GpuIrValidationError::InvalidLightSpectrumReference {
+                    issues.push(IrValidationError::InvalidLightSpectrumReference {
                         light: light_id,
                         spectrum,
                     });
@@ -659,7 +655,7 @@ impl GpuSceneDraft {
                     .and_then(|index| self.data.spectrum_textures.get(index))
                     .is_none()
                 {
-                    issues.push(GpuIrValidationError::InvalidLightTextureReference {
+                    issues.push(IrValidationError::InvalidLightTextureReference {
                         light: light_id,
                         texture,
                     });
@@ -667,12 +663,12 @@ impl GpuSceneDraft {
             }
         }
         if issues.is_empty() {
-            Ok(GpuSceneIr {
+            Ok(SceneIr {
                 version: self.version,
                 data: self.data,
             })
         } else {
-            Err(GpuIrValidationErrors {
+            Err(IrValidationErrors {
                 issues: issues.into_boxed_slice(),
             })
         }
@@ -681,11 +677,11 @@ impl GpuSceneDraft {
 
 fn validate_triangle_mesh(
     geometry: GeometryId,
-    mesh: &GpuTriangleMesh,
-    issues: &mut Vec<GpuIrValidationError>,
+    mesh: &TriangleMesh,
+    issues: &mut Vec<IrValidationError>,
 ) {
     if mesh.positions.is_empty() || mesh.indices.is_empty() {
-        issues.push(GpuIrValidationError::EmptyTriangleMesh { geometry });
+        issues.push(IrValidationError::EmptyTriangleMesh { geometry });
         return;
     }
     let position_count = mesh.positions.len();
@@ -699,12 +695,12 @@ fn validate_triangle_mesh(
                 .copied()
                 .find(|index| usize::try_from(*index).map_or(true, |index| index >= position_count))
                 .unwrap_or_default();
-            issues.push(GpuIrValidationError::TriangleIndexOutOfBounds { geometry, index });
+            issues.push(IrValidationError::TriangleIndexOutOfBounds { geometry, index });
         }
         if triangle[0] == triangle[1] || triangle[1] == triangle[2] || triangle[2] == triangle[0] {
-            issues.push(GpuIrValidationError::DegenerateTriangle {
+            issues.push(IrValidationError::DegenerateTriangle {
                 geometry,
-                triangle: triangle_index as GpuIndex,
+                triangle: triangle_index as Index,
             });
         }
     }
@@ -717,17 +713,17 @@ fn validate_triangle_mesh(
             .as_ref()
             .is_some_and(|v| v.len() != mesh.indices.len())
     {
-        issues.push(GpuIrValidationError::AttributeLengthMismatch { geometry });
+        issues.push(IrValidationError::AttributeLengthMismatch { geometry });
     }
 }
 
 fn validate_bilinear_mesh(
     geometry: GeometryId,
-    mesh: &GpuBilinearPatchMesh,
-    issues: &mut Vec<GpuIrValidationError>,
+    mesh: &BilinearPatchMesh,
+    issues: &mut Vec<IrValidationError>,
 ) {
     if mesh.positions.is_empty() || mesh.indices.is_empty() {
-        issues.push(GpuIrValidationError::EmptyTriangleMesh { geometry });
+        issues.push(IrValidationError::EmptyTriangleMesh { geometry });
         return;
     }
     let position_count = mesh.positions.len();
@@ -741,7 +737,7 @@ fn validate_bilinear_mesh(
                 .copied()
                 .find(|index| usize::try_from(*index).map_or(true, |index| index >= position_count))
                 .unwrap_or_default();
-            issues.push(GpuIrValidationError::TriangleIndexOutOfBounds { geometry, index });
+            issues.push(IrValidationError::TriangleIndexOutOfBounds { geometry, index });
         }
     }
     if mesh
@@ -754,17 +750,17 @@ fn validate_bilinear_mesh(
             .as_ref()
             .is_some_and(|v| v.len() != mesh.indices.len())
     {
-        issues.push(GpuIrValidationError::AttributeLengthMismatch { geometry });
+        issues.push(IrValidationError::AttributeLengthMismatch { geometry });
     }
 }
 
 fn validate_curve_mesh(
     geometry: GeometryId,
-    mesh: &GpuCurveMesh,
-    issues: &mut Vec<GpuIrValidationError>,
+    mesh: &CurveMesh,
+    issues: &mut Vec<IrValidationError>,
 ) {
     if mesh.curves.is_empty() {
-        issues.push(GpuIrValidationError::InvalidCurve { geometry, curve: 0 });
+        issues.push(IrValidationError::InvalidCurve { geometry, curve: 0 });
     }
     for (curve_index, curve) in mesh.curves.iter().enumerate() {
         let valid_points = curve
@@ -781,31 +777,27 @@ fn validate_curve_mesh(
                 .all(|normal| normal.0.iter().all(|value| value.is_finite()))
         });
         let type_valid = match mesh.curve_type {
-            GpuCurveType::Ribbon => curve.endpoint_normals.is_some(),
-            GpuCurveType::Flat | GpuCurveType::Cylinder => curve.endpoint_normals.is_none(),
+            CurveType::Ribbon => curve.endpoint_normals.is_some(),
+            CurveType::Flat | CurveType::Cylinder => curve.endpoint_normals.is_none(),
         };
         if !valid_points || !valid_widths || !valid_normals || !type_valid {
-            issues.push(GpuIrValidationError::InvalidCurve {
+            issues.push(IrValidationError::InvalidCurve {
                 geometry,
-                curve: curve_index as GpuIndex,
+                curve: curve_index as Index,
             });
         }
     }
 }
 
-fn validate_quadric(
-    geometry: GeometryId,
-    quadric: &GpuQuadric,
-    issues: &mut Vec<GpuIrValidationError>,
-) {
+fn validate_quadric(geometry: GeometryId, quadric: &Quadric, issues: &mut Vec<IrValidationError>) {
     let valid = match quadric {
-        GpuQuadric::Sphere {
+        Quadric::Sphere {
             radius,
             z_min,
             z_max,
             phi_max_radians,
         }
-        | GpuQuadric::Cylinder {
+        | Quadric::Cylinder {
             radius,
             z_min,
             z_max,
@@ -820,7 +812,7 @@ fn validate_quadric(
                 && *phi_max_radians > 0.0
                 && *phi_max_radians <= 2.0 * std::f32::consts::PI
         }
-        GpuQuadric::Disk {
+        Quadric::Disk {
             height,
             radius,
             inner_radius,
@@ -838,30 +830,30 @@ fn validate_quadric(
         }
     };
     if !valid {
-        issues.push(GpuIrValidationError::InvalidQuadric { geometry });
+        issues.push(IrValidationError::InvalidQuadric { geometry });
     }
 }
 
 fn validate_displaced_mesh(
     geometry: GeometryId,
-    mesh: &GpuDisplacedTriangleMesh,
-    data: &GpuSceneData,
-    issues: &mut Vec<GpuIrValidationError>,
+    mesh: &DisplacedTriangleMesh,
+    data: &SceneData,
+    issues: &mut Vec<IrValidationError>,
 ) {
     if !matches!(
         usize::try_from(mesh.base_mesh.0)
             .ok()
             .and_then(|index| data.geometry.get(index)),
-        Some(GpuGeometry::TriangleMesh(_))
+        Some(Geometry::TriangleMesh(_))
     ) {
-        issues.push(GpuIrValidationError::InvalidDisplacementBase { geometry });
+        issues.push(IrValidationError::InvalidDisplacementBase { geometry });
     }
     if usize::try_from(mesh.displacement.0)
         .ok()
         .and_then(|index| data.float_textures.get(index))
         .is_none()
     {
-        issues.push(GpuIrValidationError::InvalidDisplacementTexture {
+        issues.push(IrValidationError::InvalidDisplacementTexture {
             geometry,
             texture: mesh.displacement,
         });
@@ -906,11 +898,11 @@ fn validate_displaced_mesh(
     });
     let graph_valid = validate_minmax_graph(&mesh.min_max_nodes);
     if !finite || !bounds_match || !roots_valid || !nodes_valid || !bounds_valid || !graph_valid {
-        issues.push(GpuIrValidationError::InvalidDisplacementData { geometry });
+        issues.push(IrValidationError::InvalidDisplacementData { geometry });
     }
 }
 
-fn validate_minmax_graph(nodes: &[GpuMinMaxNode]) -> bool {
+fn validate_minmax_graph(nodes: &[MinMaxNode]) -> bool {
     for parent in nodes {
         let Some(children) = parent.children else {
             continue;
@@ -956,7 +948,7 @@ fn validate_minmax_graph(nodes: &[GpuMinMaxNode]) -> bool {
     true
 }
 
-fn visit_minmax_node(index: usize, nodes: &[GpuMinMaxNode], marks: &mut [u8]) -> bool {
+fn visit_minmax_node(index: usize, nodes: &[MinMaxNode], marks: &mut [u8]) -> bool {
     if marks[index] == 1 {
         return false;
     }
@@ -978,61 +970,61 @@ fn visit_minmax_node(index: usize, nodes: &[GpuMinMaxNode], marks: &mut [u8]) ->
     true
 }
 
-impl GpuSceneIr {
-    pub fn requirements(&self) -> GpuRequirements {
+impl SceneIr {
+    pub fn requirements(&self) -> Requirements {
         use std::collections::BTreeSet;
 
         let data = &self.data;
         let mut features = BTreeSet::new();
         for transform in &data.transforms {
             features.insert(match transform {
-                GpuTransform::Static(_) => GpuFeature::StaticTransform,
-                GpuTransform::Animated(_) => GpuFeature::AnimatedTransform,
+                Transform::Static(_) => Feature::StaticTransform,
+                Transform::Animated(_) => Feature::AnimatedTransform,
             });
         }
         for geometry in &data.geometry {
             features.insert(match geometry {
-                GpuGeometry::TriangleMesh(_) => GpuFeature::TriangleMesh,
-                GpuGeometry::BilinearPatchMesh(_) => GpuFeature::BilinearPatch,
-                GpuGeometry::CurveMesh(_) => GpuFeature::Curve,
-                GpuGeometry::Quadric(_) => GpuFeature::Quadric,
-                GpuGeometry::DisplacedTriangleMesh(_) => GpuFeature::DisplacedTriangle,
+                Geometry::TriangleMesh(_) => Feature::TriangleMesh,
+                Geometry::BilinearPatchMesh(_) => Feature::BilinearPatch,
+                Geometry::CurveMesh(_) => Feature::Curve,
+                Geometry::Quadric(_) => Feature::Quadric,
+                Geometry::DisplacedTriangleMesh(_) => Feature::DisplacedTriangle,
             });
         }
         for texture in &data.float_textures {
             features.insert(match texture {
-                GpuFloatTexture::Constant { .. } => GpuFeature::FloatConstantTexture,
-                GpuFloatTexture::Image { .. } => GpuFeature::FloatImageTexture,
+                FloatTexture::Constant { .. } => Feature::FloatConstantTexture,
+                FloatTexture::Image { .. } => Feature::FloatImageTexture,
             });
         }
         for texture in &data.spectrum_textures {
             features.insert(match texture {
-                GpuSpectrumTexture::Constant { .. } => GpuFeature::SpectrumConstantTexture,
-                GpuSpectrumTexture::Image { .. } => GpuFeature::SpectrumImageTexture,
+                SpectrumTexture::Constant { .. } => Feature::SpectrumConstantTexture,
+                SpectrumTexture::Image { .. } => Feature::SpectrumImageTexture,
             });
         }
         for material in &data.materials {
-            if matches!(material, GpuMaterial::Diffuse(_)) {
-                features.insert(GpuFeature::DiffuseMaterial);
+            if matches!(material, Material::Diffuse(_)) {
+                features.insert(Feature::DiffuseMaterial);
             }
         }
         for light in &data.lights {
             features.insert(match light {
-                GpuLight::Point(_) => GpuFeature::PointLight,
-                GpuLight::DiffuseArea(_) => GpuFeature::DiffuseAreaLight,
-                GpuLight::UniformInfinite(_) => GpuFeature::UniformInfiniteLight,
+                Light::Point(_) => Feature::PointLight,
+                Light::DiffuseArea(_) => Feature::DiffuseAreaLight,
+                Light::UniformInfinite(_) => Feature::UniformInfiniteLight,
             });
         }
         features.extend([
-            GpuFeature::PerspectiveCamera,
-            GpuFeature::IndependentSampler,
-            GpuFeature::RgbFilm,
-            GpuFeature::BoxFilter,
-            GpuFeature::WavefrontVolPath,
-            GpuFeature::UniformLightSampler,
+            Feature::PerspectiveCamera,
+            Feature::IndependentSampler,
+            Feature::RgbFilm,
+            Feature::BoxFilter,
+            Feature::WavefrontVolPath,
+            Feature::UniformLightSampler,
         ]);
 
-        let resource_counts = GpuResourceCounts {
+        let resource_counts = ResourceCounts {
             transforms: data.transforms.len() as u64,
             spectra: data.spectra.len() as u64,
             images: data.images.len() as u64,
@@ -1046,7 +1038,7 @@ impl GpuSceneIr {
             instance_definitions: data.instance_definitions.len() as u64,
             instances: data.instances.len() as u64,
         };
-        let maxima = GpuSemanticMaxima {
+        let maxima = SemanticMaxima {
             texture_graph_depth: u32::from(
                 !data.float_textures.is_empty() || !data.spectrum_textures.is_empty(),
             ),
@@ -1062,11 +1054,11 @@ impl GpuSceneIr {
                 .geometry
                 .iter()
                 .map(|geometry| match geometry {
-                    GpuGeometry::TriangleMesh(mesh) => mesh.positions.len() as u64,
-                    GpuGeometry::BilinearPatchMesh(mesh) => mesh.positions.len() as u64,
-                    GpuGeometry::CurveMesh(mesh) => (mesh.curves.len() * 4) as u64,
-                    GpuGeometry::Quadric(_) => 0,
-                    GpuGeometry::DisplacedTriangleMesh(mesh) => {
+                    Geometry::TriangleMesh(mesh) => mesh.positions.len() as u64,
+                    Geometry::BilinearPatchMesh(mesh) => mesh.positions.len() as u64,
+                    Geometry::CurveMesh(mesh) => (mesh.curves.len() * 4) as u64,
+                    Geometry::Quadric(_) => 0,
+                    Geometry::DisplacedTriangleMesh(mesh) => {
                         mesh.displaced_bounds_object.len() as u64
                     }
                 })
@@ -1076,19 +1068,19 @@ impl GpuSceneIr {
                 .geometry
                 .iter()
                 .map(|geometry| match geometry {
-                    GpuGeometry::TriangleMesh(mesh) => mesh.indices.len() as u64,
-                    GpuGeometry::BilinearPatchMesh(mesh) => mesh.indices.len() as u64,
-                    GpuGeometry::CurveMesh(mesh) => mesh.curves.len() as u64,
-                    GpuGeometry::Quadric(_) => 1,
-                    GpuGeometry::DisplacedTriangleMesh(mesh) => mesh.triangle_roots.len() as u64,
+                    Geometry::TriangleMesh(mesh) => mesh.indices.len() as u64,
+                    Geometry::BilinearPatchMesh(mesh) => mesh.indices.len() as u64,
+                    Geometry::CurveMesh(mesh) => mesh.curves.len() as u64,
+                    Geometry::Quadric(_) => 1,
+                    Geometry::DisplacedTriangleMesh(mesh) => mesh.triangle_roots.len() as u64,
                 })
                 .max()
                 .unwrap_or(0),
         };
-        GpuRequirements {
+        Requirements {
             features: features
                 .into_iter()
-                .map(|feature| GpuRequiredFeature {
+                .map(|feature| RequiredFeature {
                     feature,
                     sources: Box::new([]),
                 })
@@ -1099,8 +1091,8 @@ impl GpuSceneIr {
         }
     }
 
-    pub fn view(&self) -> GpuSceneView<'_> {
-        GpuSceneView {
+    pub fn view(&self) -> SceneView<'_> {
+        SceneView {
             version: &self.version,
             transforms: &self.data.transforms,
             spectra: &self.data.spectra,
@@ -1124,14 +1116,14 @@ impl GpuSceneIr {
 fn validate_image_texture_refs(
     image: ImageId,
     mapping: TextureMappingId,
-    data: &GpuSceneData,
-    issues: &mut Vec<GpuIrValidationError>,
+    data: &SceneData,
+    issues: &mut Vec<IrValidationError>,
 ) {
     let Some(image_resource) = usize::try_from(image.0)
         .ok()
         .and_then(|index| data.images.get(index))
     else {
-        issues.push(GpuIrValidationError::InvalidImageReference { image });
+        issues.push(IrValidationError::InvalidImageReference { image });
         return;
     };
     if usize::try_from(mapping.0)
@@ -1139,19 +1131,17 @@ fn validate_image_texture_refs(
         .and_then(|index| data.texture_mappings.get(index))
         .is_none()
     {
-        issues.push(GpuIrValidationError::InvalidTextureMappingReference { mapping });
+        issues.push(IrValidationError::InvalidTextureMappingReference { mapping });
     }
     let (storage_len, storage_finite) = match &image_resource.storage {
-        GpuTexelStorage::U8(values) => (values.len(), true),
-        GpuTexelStorage::F16(values) => (
+        TexelStorage::U8(values) => (values.len(), true),
+        TexelStorage::F16(values) => (
             values.len(),
             values
                 .iter()
                 .all(|value| half::f16::from_bits(*value).to_f32().is_finite()),
         ),
-        GpuTexelStorage::F32(values) => {
-            (values.len(), values.iter().all(|value| value.is_finite()))
-        }
+        TexelStorage::F32(values) => (values.len(), values.iter().all(|value| value.is_finite())),
     };
     let channels = image_resource.channels.count();
     let base_components = usize::try_from(image_resource.resolution[0])
@@ -1198,8 +1188,8 @@ fn validate_image_texture_refs(
             .windows(2)
             .all(|levels| levels[0].texel_offset + levels[0].texel_count <= levels[1].texel_offset);
     let encoding_valid = match image_resource.color_encoding {
-        GpuColorEncoding::Linear | GpuColorEncoding::Srgb => true,
-        GpuColorEncoding::Gamma { exponent } => exponent.is_finite() && exponent > 0.0,
+        ColorEncoding::Linear | ColorEncoding::Srgb => true,
+        ColorEncoding::Gamma { exponent } => exponent.is_finite() && exponent > 0.0,
     };
     if base_components
         != image_resource
@@ -1211,6 +1201,6 @@ fn validate_image_texture_refs(
         || image_resource.resolution.contains(&0)
         || !storage_finite
     {
-        issues.push(GpuIrValidationError::InvalidImageData { image });
+        issues.push(IrValidationError::InvalidImageData { image });
     }
 }

--- a/src/gpu/ir/render.rs
+++ b/src/gpu/ir/render.rs
@@ -1,8 +1,8 @@
-use super::{GpuBounds2i, GpuFloat, GpuIndex, GpuMatrix3x3, GpuMatrix4x4, GpuVector2, TransformId};
+use super::{Bounds2i, Float, Index, Matrix3x3, Matrix4x4, TransformId, Vector2};
 use crate::base::film::Film;
 use crate::util::spectrum::{Spectrum, SpectrumType};
 
-impl GpuBounds2i {
+impl Bounds2i {
     pub fn area(self) -> Option<u64> {
         let width = u64::from(self.max[0]).checked_sub(u64::from(self.min[0]))?;
         let height = u64::from(self.max[1]).checked_sub(u64::from(self.min[1]))?;
@@ -11,32 +11,32 @@ impl GpuBounds2i {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GpuRenderRequestError {
+pub enum RenderRequestError {
     ZeroSampleCount,
     SampleRangeOverflow,
     SampleRangeExceedsSamplesPerPixel,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GpuRenderRequest {
+pub struct RenderRequest {
     pub sample_start: u64,
     pub sample_count: u32,
 }
 
-impl GpuRenderRequest {
+impl RenderRequest {
     pub fn new(
-        render: &GpuRenderConfig,
+        render: &RenderConfig,
         sample_start: u64,
         sample_count: u32,
-    ) -> Result<Self, GpuRenderRequestError> {
+    ) -> Result<Self, RenderRequestError> {
         if sample_count == 0 {
-            return Err(GpuRenderRequestError::ZeroSampleCount);
+            return Err(RenderRequestError::ZeroSampleCount);
         }
         let sample_end = sample_start
             .checked_add(u64::from(sample_count))
-            .ok_or(GpuRenderRequestError::SampleRangeOverflow)?;
+            .ok_or(RenderRequestError::SampleRangeOverflow)?;
         if sample_end > u64::from(render.sampler.samples_per_pixel) {
-            return Err(GpuRenderRequestError::SampleRangeExceedsSamplesPerPixel);
+            return Err(RenderRequestError::SampleRangeExceedsSamplesPerPixel);
         }
         Ok(Self {
             sample_start,
@@ -46,31 +46,31 @@ impl GpuRenderRequest {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuRenderOutput {
-    pub pixel_bounds: GpuBounds2i,
+pub struct RenderOutput {
+    pub pixel_bounds: Bounds2i,
     pub rgb: Box<[[f32; 3]]>,
     pub sample_start: u64,
     pub sample_count: u32,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GpuRenderOutputError {
+pub enum RenderOutputError {
     InvalidPixelBounds,
     PixelCountMismatch { expected: usize, actual: usize },
 }
 
-impl GpuRenderOutput {
+impl RenderOutput {
     pub fn new(
-        pixel_bounds: GpuBounds2i,
+        pixel_bounds: Bounds2i,
         rgb: Box<[[f32; 3]]>,
-        request: GpuRenderRequest,
-    ) -> Result<Self, GpuRenderOutputError> {
+        request: RenderRequest,
+    ) -> Result<Self, RenderOutputError> {
         let expected = pixel_bounds
             .pixel_count()
             .filter(|count| *count > 0)
-            .ok_or(GpuRenderOutputError::InvalidPixelBounds)?;
+            .ok_or(RenderOutputError::InvalidPixelBounds)?;
         if rgb.len() != expected {
-            return Err(GpuRenderOutputError::PixelCountMismatch {
+            return Err(RenderOutputError::PixelCountMismatch {
                 expected,
                 actual: rgb.len(),
             });
@@ -97,53 +97,53 @@ impl GpuRenderOutput {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuPerspectiveCamera {
+pub struct PerspectiveCamera {
     pub render_from_camera: TransformId,
-    pub camera_from_raster: GpuMatrix4x4,
-    pub lens_radius: GpuFloat,
-    pub focal_distance: GpuFloat,
-    pub shutter_open: GpuFloat,
-    pub shutter_close: GpuFloat,
+    pub camera_from_raster: Matrix4x4,
+    pub lens_radius: Float,
+    pub focal_distance: Float,
+    pub shutter_open: Float,
+    pub shutter_close: Float,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuIndependentSampler {
+pub struct IndependentSampler {
     pub samples_per_pixel: u32,
     pub seed: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuRgbFilm {
-    pub full_resolution: [GpuIndex; 2],
-    pub pixel_bounds: GpuBounds2i,
-    pub diagonal_mm: GpuFloat,
-    pub output_rgb_from_xyz: GpuMatrix3x3,
-    pub iso: GpuFloat,
-    pub max_component_value: GpuFloat,
+pub struct RgbFilm {
+    pub full_resolution: [Index; 2],
+    pub pixel_bounds: Bounds2i,
+    pub diagonal_mm: Float,
+    pub output_rgb_from_xyz: Matrix3x3,
+    pub iso: Float,
+    pub max_component_value: Float,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuBoxFilter {
-    pub radius: GpuVector2,
+pub struct BoxFilter {
+    pub radius: Vector2,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuWavefrontVolPath {
+pub struct WavefrontVolPath {
     pub max_depth: u32,
     pub regularize: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuLightSampler {
+pub enum LightSampler {
     Uniform,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GpuRenderConfig {
-    pub camera: GpuPerspectiveCamera,
-    pub sampler: GpuIndependentSampler,
-    pub film: GpuRgbFilm,
-    pub filter: GpuBoxFilter,
-    pub integrator: GpuWavefrontVolPath,
-    pub light_sampler: GpuLightSampler,
+pub struct RenderConfig {
+    pub camera: PerspectiveCamera,
+    pub sampler: IndependentSampler,
+    pub film: RgbFilm,
+    pub filter: BoxFilter,
+    pub integrator: WavefrontVolPath,
+    pub light_sampler: LightSampler,
 }

--- a/src/gpu/ir/texture.rs
+++ b/src/gpu/ir/texture.rs
@@ -1,39 +1,39 @@
-use super::{GpuFloat, GpuIndex, GpuMatrix4x4, GpuVector3, ImageId, SpectrumId};
+use super::{Float, ImageId, Index, Matrix4x4, SpectrumId, Vector3};
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum GpuSpectrumResource {
+pub enum SpectrumResource {
     Constant {
-        value: GpuFloat,
+        value: Float,
     },
     PiecewiseLinear {
-        wavelengths_nm: Box<[GpuFloat]>,
-        values: Box<[GpuFloat]>,
+        wavelengths_nm: Box<[Float]>,
+        values: Box<[Float]>,
     },
     RgbAlbedo {
-        coefficients: [GpuFloat; 3],
+        coefficients: [Float; 3],
     },
     RgbUnbounded {
-        coefficients: [GpuFloat; 3],
+        coefficients: [Float; 3],
     },
     RgbIlluminant {
-        coefficients: [GpuFloat; 3],
+        coefficients: [Float; 3],
         illuminant: SpectrumId,
     },
     Blackbody {
-        temperature_kelvin: GpuFloat,
-        scale: GpuFloat,
+        temperature_kelvin: Float,
+        scale: Float,
     },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GpuImageChannels {
+pub enum ImageChannels {
     R,
     Rg,
     Rgb,
     Rgba,
 }
 
-impl GpuImageChannels {
+impl ImageChannels {
     pub fn count(self) -> usize {
         match self {
             Self::R => 1,
@@ -45,37 +45,37 @@ impl GpuImageChannels {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum GpuTexelStorage {
+pub enum TexelStorage {
     U8(Box<[u8]>),
     F16(Box<[u16]>),
-    F32(Box<[GpuFloat]>),
+    F32(Box<[Float]>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuColorEncoding {
+pub enum ColorEncoding {
     Linear,
     Srgb,
-    Gamma { exponent: GpuFloat },
+    Gamma { exponent: Float },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GpuMipLevel {
-    pub resolution: [GpuIndex; 2],
+pub struct MipLevel {
+    pub resolution: [Index; 2],
     pub texel_offset: u64,
     pub texel_count: u64,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GpuImageResource {
-    pub resolution: [GpuIndex; 2],
-    pub channels: GpuImageChannels,
-    pub storage: GpuTexelStorage,
-    pub mip_levels: Box<[GpuMipLevel]>,
-    pub color_encoding: GpuColorEncoding,
+pub struct ImageResource {
+    pub resolution: [Index; 2],
+    pub channels: ImageChannels,
+    pub storage: TexelStorage,
+    pub mip_levels: Box<[MipLevel]>,
+    pub color_encoding: ColorEncoding,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuImageWrapMode {
+pub enum ImageWrapMode {
     Black,
     Clamp,
     Repeat,
@@ -83,82 +83,82 @@ pub enum GpuImageWrapMode {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuImageFilter {
+pub enum ImageFilter {
     Point,
     Bilinear,
     Trilinear,
-    Ewa { max_anisotropy: GpuFloat },
+    Ewa { max_anisotropy: Float },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuTextureMapping {
+pub enum TextureMapping {
     Uv {
-        su: GpuFloat,
-        sv: GpuFloat,
-        du: GpuFloat,
-        dv: GpuFloat,
+        su: Float,
+        sv: Float,
+        du: Float,
+        dv: Float,
     },
     Spherical {
-        texture_from_render: GpuMatrix4x4,
+        texture_from_render: Matrix4x4,
     },
     Cylindrical {
-        texture_from_render: GpuMatrix4x4,
+        texture_from_render: Matrix4x4,
     },
     Planar {
-        texture_from_render: GpuMatrix4x4,
-        vs: GpuVector3,
-        vt: GpuVector3,
-        ds: GpuFloat,
-        dt: GpuFloat,
+        texture_from_render: Matrix4x4,
+        vs: Vector3,
+        vt: Vector3,
+        ds: Float,
+        dt: Float,
     },
     Transform3D {
-        texture_from_render: GpuMatrix4x4,
+        texture_from_render: Matrix4x4,
     },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuFloatTexture {
+pub enum FloatTexture {
     Constant {
-        value: GpuFloat,
+        value: Float,
     },
     Image {
         image: ImageId,
         mapping: super::TextureMappingId,
-        scale: GpuFloat,
+        scale: Float,
         invert: bool,
-        swrap: GpuImageWrapMode,
-        twrap: GpuImageWrapMode,
-        filter: GpuImageFilter,
-        channel: GpuFloatImageChannel,
+        swrap: ImageWrapMode,
+        twrap: ImageWrapMode,
+        filter: ImageFilter,
+        channel: FloatImageChannel,
     },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GpuFloatImageChannel {
+pub enum FloatImageChannel {
     Channel0,
     Alpha,
     RgbAverage,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GpuSpectrumTexture {
+pub enum SpectrumTexture {
     Constant {
         value: SpectrumId,
     },
     Image {
         image: ImageId,
         mapping: super::TextureMappingId,
-        scale: GpuFloat,
+        scale: Float,
         invert: bool,
-        swrap: GpuImageWrapMode,
-        twrap: GpuImageWrapMode,
-        filter: GpuImageFilter,
-        spectrum_type: GpuSpectrumType,
+        swrap: ImageWrapMode,
+        twrap: ImageWrapMode,
+        filter: ImageFilter,
+        spectrum_type: SpectrumType,
     },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GpuSpectrumType {
+pub enum SpectrumType {
     Albedo,
     Unbounded,
     Illuminant,

--- a/src/gpu/webgpu/error.rs
+++ b/src/gpu/webgpu/error.rs
@@ -8,7 +8,7 @@ pub enum BackendError {
     DeviceRequest(String),
     MissingRayQueryFeature,
     Plan(PlanError),
-    InvalidRenderRequest(super::super::ir::GpuRenderRequestError),
+    InvalidRenderRequest(super::super::ir::RenderRequestError),
     UnsupportedRenderRequest { reason: &'static str },
     Readback(String),
     UnsupportedAccelerationMode(AccelerationMode),

--- a/src/gpu/webgpu/geometry.rs
+++ b/src/gpu/webgpu/geometry.rs
@@ -1,8 +1,8 @@
 use super::super::ir::{
-    GeometryId, GpuAreaLightBinding, GpuColorEncoding, GpuFloatImageChannel, GpuFloatTexture,
-    GpuGeometry, GpuImageChannels, GpuImageFilter, GpuImageResource, GpuImageWrapMode, GpuLight,
-    GpuMaterial, GpuSceneView, GpuSpectrumResource, GpuSpectrumTexture, GpuSpectrumType,
-    GpuTexelStorage, GpuTextureMapping, GpuTransform, InstanceId, LightId, PrimitiveId,
+    AreaLightBinding, ColorEncoding, FloatImageChannel, FloatTexture, Geometry, GeometryId,
+    ImageChannels, ImageFilter, ImageResource, ImageWrapMode, InstanceId, Light, LightId, Material,
+    PrimitiveId, SceneView, SpectrumResource, SpectrumTexture, SpectrumType, TexelStorage,
+    TextureMapping, Transform,
 };
 use super::device::DeviceContext;
 use super::error::{BackendError, PlanError};
@@ -52,7 +52,7 @@ pub struct ImageMipPlan {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ImagePlan {
     pub resolution: [u32; 2],
-    pub channels: GpuImageChannels,
+    pub channels: ImageChannels,
     pub mip_levels: Vec<ImageMipPlan>,
     pub texels: Vec<f32>,
 }
@@ -60,13 +60,13 @@ pub struct ImagePlan {
 #[derive(Clone, Debug, PartialEq)]
 pub struct SpectrumTexturePlan {
     pub image: u32,
-    pub mapping: GpuTextureMapping,
+    pub mapping: TextureMapping,
     pub scale: f32,
     pub invert: bool,
-    pub swrap: GpuImageWrapMode,
-    pub twrap: GpuImageWrapMode,
-    pub filter: GpuImageFilter,
-    pub spectrum_type: GpuSpectrumType,
+    pub swrap: ImageWrapMode,
+    pub twrap: ImageWrapMode,
+    pub filter: ImageFilter,
+    pub spectrum_type: SpectrumType,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -74,13 +74,13 @@ pub enum FloatTexturePlan {
     Constant(f32),
     Image {
         image: u32,
-        mapping: GpuTextureMapping,
+        mapping: TextureMapping,
         scale: f32,
         invert: bool,
-        swrap: GpuImageWrapMode,
-        twrap: GpuImageWrapMode,
-        filter: GpuImageFilter,
-        channel: GpuFloatImageChannel,
+        swrap: ImageWrapMode,
+        twrap: ImageWrapMode,
+        filter: ImageFilter,
+        channel: FloatImageChannel,
     },
 }
 
@@ -174,7 +174,7 @@ pub struct ScenePlan {
 }
 
 fn primitive_transform(
-    scene: GpuSceneView<'_>,
+    scene: SceneView<'_>,
     primitive_id: PrimitiveId,
 ) -> Result<[[f32; 4]; 4], BackendError> {
     let primitive = scene
@@ -193,15 +193,15 @@ fn primitive_transform(
                 index: primitive.transform.0,
             }))?;
     match transform {
-        GpuTransform::Static(transform) => Ok(transform.render_from_object.0),
-        GpuTransform::Animated(_) => Err(BackendError::Plan(PlanError::UnsupportedTransform {
+        Transform::Static(transform) => Ok(transform.render_from_object.0),
+        Transform::Animated(_) => Err(BackendError::Plan(PlanError::UnsupportedTransform {
             transform: primitive.transform,
         })),
     }
 }
 
 fn collect_instance_primitives(
-    scene: GpuSceneView<'_>,
+    scene: SceneView<'_>,
     instance_id: InstanceId,
     parent: [[f32; 4]; 4],
     output: &mut Vec<(PrimitiveId, [[f32; 4]; 4])>,
@@ -234,7 +234,7 @@ fn collect_instance_primitives(
                 resource: "instance transform",
                 index: instance.transform.0,
             }))?;
-    let GpuTransform::Static(instance_transform) = instance_transform else {
+    let Transform::Static(instance_transform) = instance_transform else {
         return Err(BackendError::Plan(PlanError::UnsupportedTransform {
             transform: instance.transform,
         }));
@@ -322,7 +322,7 @@ impl ScenePlan {
         Ok(())
     }
 
-    pub fn from_scene(scene: GpuSceneView<'_>) -> Result<Self, BackendError> {
+    pub fn from_scene(scene: SceneView<'_>) -> Result<Self, BackendError> {
         let mut world_entries = Vec::new();
         for primitive_id in scene.world_primitives {
             world_entries.push((*primitive_id, primitive_transform(scene, *primitive_id)?));
@@ -392,7 +392,7 @@ impl ScenePlan {
                         index: primitive.geometry.0,
                     }))?;
             let triangle_mesh = match geometry {
-                GpuGeometry::TriangleMesh(mesh) => mesh,
+                Geometry::TriangleMesh(mesh) => mesh,
                 _ => {
                     return Err(BackendError::Plan(PlanError::UnsupportedGeometry {
                         geometry: primitive.geometry,
@@ -502,8 +502,8 @@ impl ScenePlan {
             Self::validate_custom_data(custom_data).map_err(BackendError::Plan)?;
             let triangle_count = blases[blas].index_count / 3;
             match &primitive.area_light {
-                GpuAreaLightBinding::None => {}
-                GpuAreaLightBinding::Uniform(light) => {
+                AreaLightBinding::None => {}
+                AreaLightBinding::Uniform(light) => {
                     validate_area_light(scene, *light, primitive_id.0)?;
                     area_light_occurrences.extend((0..triangle_count).map(|triangle| {
                         AreaLightOccurrence {
@@ -514,7 +514,7 @@ impl ScenePlan {
                         }
                     }));
                 }
-                GpuAreaLightBinding::PerElement(lights) => {
+                AreaLightBinding::PerElement(lights) => {
                     if lights.len() != triangle_count as usize {
                         return Err(BackendError::Plan(PlanError::InvalidAreaLightBinding {
                             primitive: primitive_id.0,
@@ -585,7 +585,7 @@ fn validate_initial_light_scope(lights: &[LightPlan]) -> Result<(), BackendError
 }
 
 fn lower_material(
-    scene: GpuSceneView<'_>,
+    scene: SceneView<'_>,
     material_id: Option<super::super::ir::MaterialId>,
     primitive: PrimitiveId,
     images: &mut Vec<ImagePlan>,
@@ -602,7 +602,7 @@ fn lower_material(
             resource: "material",
             index: material_id.0,
         }))?;
-    let GpuMaterial::Diffuse(diffuse) = material;
+    let Material::Diffuse(diffuse) = material;
     let displacement = diffuse
         .displacement
         .map(|texture| {
@@ -627,12 +627,12 @@ fn lower_material(
             index: diffuse.reflectance.0,
         }))?;
     let reflectance = match texture {
-        GpuSpectrumTexture::Constant { value } => {
+        SpectrumTexture::Constant { value } => {
             MaterialReflectancePlan::Constant(match spectrum_rgb(scene, *value, primitive.0)? {
                 [red, green, blue] => [red, green, blue, 1.0],
             })
         }
-        GpuSpectrumTexture::Image {
+        SpectrumTexture::Image {
             image,
             mapping,
             scale,
@@ -676,7 +676,7 @@ fn lower_material(
 }
 
 fn lower_normal_map_image(
-    scene: GpuSceneView<'_>,
+    scene: SceneView<'_>,
     image: super::super::ir::ImageId,
     images: &mut Vec<ImagePlan>,
     image_to_plan: &mut [Option<u32>],
@@ -691,7 +691,7 @@ fn lower_normal_map_image(
         }))?;
     if !matches!(
         image_resource.channels,
-        GpuImageChannels::Rgb | GpuImageChannels::Rgba
+        ImageChannels::Rgb | ImageChannels::Rgba
     ) {
         return Err(BackendError::Plan(PlanError::UnsupportedTexture {
             texture: primitive.0,
@@ -710,15 +710,15 @@ fn lower_normal_map_image(
 
 #[allow(clippy::too_many_arguments)]
 fn lower_spectrum_texture(
-    scene: GpuSceneView<'_>,
+    scene: SceneView<'_>,
     image: super::super::ir::ImageId,
     mapping: super::super::ir::TextureMappingId,
     scale: f32,
     invert: bool,
-    swrap: GpuImageWrapMode,
-    twrap: GpuImageWrapMode,
-    filter: GpuImageFilter,
-    spectrum_type: GpuSpectrumType,
+    swrap: ImageWrapMode,
+    twrap: ImageWrapMode,
+    filter: ImageFilter,
+    spectrum_type: SpectrumType,
     images: &mut Vec<ImagePlan>,
     spectrum_textures: &mut Vec<SpectrumTexturePlan>,
     image_to_plan: &mut [Option<u32>],
@@ -738,7 +738,7 @@ fn lower_spectrum_texture(
             resource: "texture mapping",
             index: mapping.0,
         }))?;
-    if !matches!(mapping, GpuTextureMapping::Uv { .. })
+    if !matches!(mapping, TextureMapping::Uv { .. })
         || !supported_filter(filter)
         || !supported_wrap(swrap)
         || !supported_wrap(twrap)
@@ -786,32 +786,32 @@ fn lower_spectrum_texture(
     Ok(texture_index)
 }
 
-fn supported_wrap(wrap: GpuImageWrapMode) -> bool {
+fn supported_wrap(wrap: ImageWrapMode) -> bool {
     matches!(
         wrap,
-        GpuImageWrapMode::Black | GpuImageWrapMode::Clamp | GpuImageWrapMode::Repeat
+        ImageWrapMode::Black | ImageWrapMode::Clamp | ImageWrapMode::Repeat
     )
 }
 
-fn supported_filter(filter: GpuImageFilter) -> bool {
+fn supported_filter(filter: ImageFilter) -> bool {
     matches!(
         filter,
-        GpuImageFilter::Point
-            | GpuImageFilter::Bilinear
-            | GpuImageFilter::Trilinear
-            | GpuImageFilter::Ewa { .. }
+        ImageFilter::Point
+            | ImageFilter::Bilinear
+            | ImageFilter::Trilinear
+            | ImageFilter::Ewa { .. }
     )
 }
 
 fn lower_float_texture(
-    scene: GpuSceneView<'_>,
-    texture: GpuFloatTexture,
+    scene: SceneView<'_>,
+    texture: FloatTexture,
     images: &mut Vec<ImagePlan>,
     image_to_plan: &mut [Option<u32>],
 ) -> Result<FloatTexturePlan, BackendError> {
     match texture {
-        GpuFloatTexture::Constant { value } => Ok(FloatTexturePlan::Constant(value)),
-        GpuFloatTexture::Image {
+        FloatTexture::Constant { value } => Ok(FloatTexturePlan::Constant(value)),
+        FloatTexture::Image {
             image,
             mapping,
             scale,
@@ -836,7 +836,7 @@ fn lower_float_texture(
                     resource: "image",
                     index: image.0,
                 }))?;
-            if !matches!(mapping, GpuTextureMapping::Uv { .. })
+            if !matches!(mapping, TextureMapping::Uv { .. })
                 || !supported_filter(filter)
                 || !supported_wrap(swrap)
                 || !supported_wrap(twrap)
@@ -845,10 +845,10 @@ fn lower_float_texture(
                     texture: image.0,
                 }));
             }
-            if matches!(channel, GpuFloatImageChannel::Alpha)
+            if matches!(channel, FloatImageChannel::Alpha)
                 && !matches!(
                     image_resource.channels,
-                    GpuImageChannels::Rg | GpuImageChannels::Rgba
+                    ImageChannels::Rg | ImageChannels::Rgba
                 )
             {
                 return Err(BackendError::Plan(PlanError::UnsupportedTexture {
@@ -880,7 +880,7 @@ fn lower_float_texture(
     }
 }
 
-fn lower_image(image: &GpuImageResource) -> Result<ImagePlan, BackendError> {
+fn lower_image(image: &ImageResource) -> Result<ImagePlan, BackendError> {
     let channel_count = image.channels.count();
     let texels = image_scalar_values(image, channel_count)?;
     let mip_levels = image
@@ -934,17 +934,17 @@ fn lower_image(image: &GpuImageResource) -> Result<ImagePlan, BackendError> {
 }
 
 fn image_scalar_values(
-    image: &GpuImageResource,
+    image: &ImageResource,
     channel_count: usize,
 ) -> Result<Vec<f32>, BackendError> {
     let mut values = Vec::new();
     match &image.storage {
-        GpuTexelStorage::F32(data) => values.extend(data.iter().copied()),
-        GpuTexelStorage::F16(data) => values.extend(
+        TexelStorage::F32(data) => values.extend(data.iter().copied()),
+        TexelStorage::F16(data) => values.extend(
             data.iter()
                 .map(|value| half::f16::from_bits(*value).to_f32()),
         ),
-        GpuTexelStorage::U8(data) => {
+        TexelStorage::U8(data) => {
             values.extend(data.iter().enumerate().map(|(index, value)| {
                 let normalized = f32::from(*value) / 255.0;
                 let channel = index % channel_count;
@@ -952,11 +952,11 @@ fn image_scalar_values(
                     normalized
                 } else {
                     match image.color_encoding {
-                        GpuColorEncoding::Linear => normalized,
-                        GpuColorEncoding::Srgb => {
+                        ColorEncoding::Linear => normalized,
+                        ColorEncoding::Srgb => {
                             crate::util::imageio::ColorEncoding::SRgb.to_linear(normalized)
                         }
-                        GpuColorEncoding::Gamma { exponent } => normalized.powf(exponent),
+                        ColorEncoding::Gamma { exponent } => normalized.powf(exponent),
                     }
                 }
             }));
@@ -972,7 +972,7 @@ fn image_scalar_values(
 }
 
 fn spectrum_rgb(
-    scene: GpuSceneView<'_>,
+    scene: SceneView<'_>,
     spectrum_id: super::super::ir::SpectrumId,
     resource_id: u32,
 ) -> Result<[f32; 3], BackendError> {
@@ -983,9 +983,9 @@ fn spectrum_rgb(
             resource: "spectrum",
             index: spectrum_id.0,
         }))? {
-        GpuSpectrumResource::Constant { value } => Ok([*value, *value, *value]),
-        GpuSpectrumResource::RgbAlbedo { coefficients }
-        | GpuSpectrumResource::RgbUnbounded { coefficients } => {
+        SpectrumResource::Constant { value } => Ok([*value, *value, *value]),
+        SpectrumResource::RgbAlbedo { coefficients }
+        | SpectrumResource::RgbUnbounded { coefficients } => {
             Ok([coefficients[0], coefficients[1], coefficients[2]])
         }
         _ => {
@@ -997,20 +997,20 @@ fn spectrum_rgb(
 }
 
 fn validate_area_light(
-    scene: GpuSceneView<'_>,
+    scene: SceneView<'_>,
     light: LightId,
     primitive: u32,
 ) -> Result<(), BackendError> {
     match scene.lights.get(light.0 as usize) {
-        Some(GpuLight::DiffuseArea(_)) => Ok(()),
+        Some(Light::DiffuseArea(_)) => Ok(()),
         _ => Err(BackendError::Plan(PlanError::UnsupportedAreaLight {
             primitive,
         })),
     }
 }
 
-fn area_emission_rgb(scene: GpuSceneView<'_>, light_id: LightId) -> Result<[f32; 3], BackendError> {
-    let Some(GpuLight::DiffuseArea(area)) = scene.lights.get(light_id.0 as usize) else {
+fn area_emission_rgb(scene: SceneView<'_>, light_id: LightId) -> Result<[f32; 3], BackendError> {
+    let Some(Light::DiffuseArea(area)) = scene.lights.get(light_id.0 as usize) else {
         return Err(BackendError::Plan(PlanError::UnsupportedLight {
             light: light_id.0,
         }));
@@ -1022,7 +1022,7 @@ fn area_emission_rgb(scene: GpuSceneView<'_>, light_id: LightId) -> Result<[f32;
             resource: "area light emission texture",
             index: area.emission.0,
         }))?;
-    let GpuSpectrumTexture::Constant { value } = texture else {
+    let SpectrumTexture::Constant { value } = texture else {
         return Err(BackendError::Plan(PlanError::UnsupportedLight {
             light: light_id.0,
         }));
@@ -1031,14 +1031,14 @@ fn area_emission_rgb(scene: GpuSceneView<'_>, light_id: LightId) -> Result<[f32;
 }
 
 fn lower_lights(
-    scene: GpuSceneView<'_>,
+    scene: SceneView<'_>,
     area_light_occurrences: &[AreaLightOccurrence],
 ) -> Result<Vec<LightPlan>, BackendError> {
     let mut lights = Vec::with_capacity(scene.lights.len().max(1));
     let mut area_sources = Vec::new();
     for (index, light) in scene.lights.iter().enumerate() {
         match light {
-            GpuLight::Point(point) => {
+            Light::Point(point) => {
                 let transform = scene
                     .transforms
                     .get(point.render_from_light.0 as usize)
@@ -1046,7 +1046,7 @@ fn lower_lights(
                         resource: "light transform",
                         index: point.render_from_light.0,
                     }))?;
-                let GpuTransform::Static(transform) = transform else {
+                let Transform::Static(transform) = transform else {
                     return Err(BackendError::Plan(PlanError::UnsupportedTransform {
                         transform: point.render_from_light,
                     }));
@@ -1068,7 +1068,7 @@ fn lower_lights(
                     flags: 0,
                 });
             }
-            GpuLight::UniformInfinite(infinite) => {
+            Light::UniformInfinite(infinite) => {
                 let rgb = spectrum_rgb(scene, infinite.radiance, index as u32)?;
                 lights.push(LightPlan {
                     position: [0.0; 4],
@@ -1084,7 +1084,7 @@ fn lower_lights(
                     flags: 0,
                 });
             }
-            GpuLight::DiffuseArea(area) => {
+            Light::DiffuseArea(area) => {
                 let light_id = LightId(index as u32);
                 let rgb = area_emission_rgb(scene, light_id)?;
                 let source_index = checked_len(lights.len(), "light source table")?;
@@ -1349,54 +1349,54 @@ pub fn texture_bytes(plan: &ScenePlan) -> Vec<u8> {
     words.into_iter().flat_map(u32::to_le_bytes).collect()
 }
 
-fn uv_mapping_words(mapping: GpuTextureMapping) -> [u32; 4] {
+fn uv_mapping_words(mapping: TextureMapping) -> [u32; 4] {
     match mapping {
-        GpuTextureMapping::Uv { su, sv, du, dv } => {
+        TextureMapping::Uv { su, sv, du, dv } => {
             [su.to_bits(), sv.to_bits(), du.to_bits(), dv.to_bits()]
         }
         _ => [1.0f32.to_bits(), 1.0f32.to_bits(), 0, 0],
     }
 }
 
-fn float_channel_bits(channel: GpuFloatImageChannel) -> u32 {
+fn float_channel_bits(channel: FloatImageChannel) -> u32 {
     match channel {
-        GpuFloatImageChannel::Channel0 => 0,
-        GpuFloatImageChannel::Alpha => 1,
-        GpuFloatImageChannel::RgbAverage => 2,
+        FloatImageChannel::Channel0 => 0,
+        FloatImageChannel::Alpha => 1,
+        FloatImageChannel::RgbAverage => 2,
     }
 }
 
-fn filter_bits(filter: GpuImageFilter) -> u32 {
+fn filter_bits(filter: ImageFilter) -> u32 {
     match filter {
-        GpuImageFilter::Point => 0,
-        GpuImageFilter::Bilinear => 1,
-        GpuImageFilter::Trilinear => 2,
-        GpuImageFilter::Ewa { .. } => 3,
+        ImageFilter::Point => 0,
+        ImageFilter::Bilinear => 1,
+        ImageFilter::Trilinear => 2,
+        ImageFilter::Ewa { .. } => 3,
     }
 }
 
-fn max_anisotropy_bits(filter: GpuImageFilter) -> u32 {
+fn max_anisotropy_bits(filter: ImageFilter) -> u32 {
     match filter {
-        GpuImageFilter::Ewa { max_anisotropy } => max_anisotropy.to_bits(),
+        ImageFilter::Ewa { max_anisotropy } => max_anisotropy.to_bits(),
         _ => 0,
     }
 }
 
-fn wrap_bits(wrap: GpuImageWrapMode, shift: u32) -> u32 {
+fn wrap_bits(wrap: ImageWrapMode, shift: u32) -> u32 {
     let value = match wrap {
-        GpuImageWrapMode::Black => 0,
-        GpuImageWrapMode::Clamp => 1,
-        GpuImageWrapMode::Repeat => 2,
-        GpuImageWrapMode::OctahedralSphere => 3,
+        ImageWrapMode::Black => 0,
+        ImageWrapMode::Clamp => 1,
+        ImageWrapMode::Repeat => 2,
+        ImageWrapMode::OctahedralSphere => 3,
     };
     value << shift
 }
 
-fn spectrum_bits(spectrum: GpuSpectrumType) -> u32 {
+fn spectrum_bits(spectrum: SpectrumType) -> u32 {
     match spectrum {
-        GpuSpectrumType::Albedo => 0,
-        GpuSpectrumType::Unbounded => 1,
-        GpuSpectrumType::Illuminant => 2,
+        SpectrumType::Albedo => 0,
+        SpectrumType::Unbounded => 1,
+        SpectrumType::Illuminant => 2,
     }
 }
 

--- a/src/gpu/webgpu/renderer/mod.rs
+++ b/src/gpu/webgpu/renderer/mod.rs
@@ -1,5 +1,5 @@
 use super::super::compiler::GpuCompiledScene;
-use super::super::ir::{GpuMatrix4x4, GpuRenderOutput, GpuRenderRequest, GpuSceneView};
+use super::super::ir::{Matrix4x4, RenderOutput, RenderRequest, SceneView};
 use super::device::{AccelerationMode, DeviceContext, PrepareOptions};
 use super::error::BackendError;
 use super::geometry::{HardwareAcceleration, ScenePlan};
@@ -21,7 +21,7 @@ pub struct ExecutableScene {
 }
 
 impl ExecutableScene {
-    pub fn scene(&self) -> GpuSceneView<'_> {
+    pub fn scene(&self) -> SceneView<'_> {
         self.scene.view()
     }
 }
@@ -81,10 +81,10 @@ impl Renderer {
     pub fn render(
         &mut self,
         scene: &ExecutableScene,
-        request: &GpuRenderRequest,
-    ) -> Result<GpuRenderOutput, BackendError> {
+        request: &RenderRequest,
+    ) -> Result<RenderOutput, BackendError> {
         let scene_view = scene.scene();
-        let request = GpuRenderRequest::new(
+        let request = RenderRequest::new(
             scene_view.render,
             request.sample_start,
             request.sample_count,
@@ -115,7 +115,7 @@ impl Renderer {
     pub fn render_to_film(
         &mut self,
         scene: &ExecutableScene,
-        request: &GpuRenderRequest,
+        request: &RenderRequest,
         film: &mut Film,
     ) -> Result<(), BackendError> {
         let output = self.render(scene, request)?;
@@ -260,8 +260,8 @@ fn common_bind_group_entries() -> Vec<wgpu::BindGroupLayoutEntry> {
 }
 
 fn camera_uniform_bytes(
-    scene: GpuSceneView<'_>,
-    request: GpuRenderRequest,
+    scene: SceneView<'_>,
+    request: RenderRequest,
     bvh_primitive_offset: u32,
     bvh_node_offset: u32,
 ) -> Vec<u8> {
@@ -269,8 +269,8 @@ fn camera_uniform_bytes(
         .transforms
         .get(scene.render.camera.render_from_camera.0 as usize)
     {
-        Some(super::super::ir::GpuTransform::Static(transform)) => transform.render_from_object,
-        _ => GpuMatrix4x4::identity(),
+        Some(super::super::ir::Transform::Static(transform)) => transform.render_from_object,
+        _ => Matrix4x4::identity(),
     };
     let pixel_bounds = scene.render.film.pixel_bounds;
     let width = (pixel_bounds.max[0] - pixel_bounds.min[0]) as f32;

--- a/src/gpu/webgpu/renderer/mod.rs
+++ b/src/gpu/webgpu/renderer/mod.rs
@@ -1,4 +1,4 @@
-use super::super::compiler::GpuCompiledScene;
+use super::super::compiler::CompiledScene;
 use super::super::ir::{Matrix4x4, RenderOutput, RenderRequest, SceneView};
 use super::device::{AccelerationMode, DeviceContext, PrepareOptions};
 use super::error::BackendError;
@@ -16,7 +16,7 @@ enum SceneResources {
 }
 
 pub struct ExecutableScene {
-    scene: GpuCompiledScene,
+    scene: CompiledScene,
     resources: SceneResources,
 }
 
@@ -62,7 +62,7 @@ impl Renderer {
         })
     }
 
-    pub fn prepare(&mut self, scene: &GpuCompiledScene) -> Result<ExecutableScene, BackendError> {
+    pub fn prepare(&mut self, scene: &CompiledScene) -> Result<ExecutableScene, BackendError> {
         let plan = ScenePlan::from_scene(scene.view())?;
         let resources = match self.device_context.acceleration_mode {
             AccelerationMode::HardwareRayQuery => {

--- a/src/gpu/webgpu/renderer/resources.rs
+++ b/src/gpu/webgpu/renderer/resources.rs
@@ -1,11 +1,11 @@
-use super::super::super::ir::{GpuBounds2i, GpuSceneView};
+use super::super::super::ir::{Bounds2i, SceneView};
 use super::super::arena::ArenaLayout;
 use super::super::error::BackendError;
 use super::{Pipeline, SceneResources};
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 
 pub struct RenderDimensions {
-    pub pixel_bounds: GpuBounds2i,
+    pub pixel_bounds: Bounds2i,
     pub pixel_count: usize,
     pub output_size: wgpu::BufferAddress,
     pub output_buffer_size: wgpu::BufferAddress,
@@ -15,7 +15,7 @@ pub struct RenderDimensions {
 }
 
 impl RenderDimensions {
-    pub fn from_scene(scene: GpuSceneView<'_>) -> Result<Self, BackendError> {
+    pub fn from_scene(scene: SceneView<'_>) -> Result<Self, BackendError> {
         let pixel_bounds = scene.render.film.pixel_bounds;
         let width = pixel_bounds.max[0]
             .checked_sub(pixel_bounds.min[0])
@@ -93,8 +93,8 @@ impl RenderBuffers {
 
 pub fn create_uniform_buffer(
     device: &wgpu::Device,
-    scene: GpuSceneView<'_>,
-    request: super::super::super::ir::GpuRenderRequest,
+    scene: SceneView<'_>,
+    request: super::super::super::ir::RenderRequest,
     bvh_primitive_offset: u32,
     bvh_node_offset: u32,
 ) -> wgpu::Buffer {

--- a/src/gpu/webgpu/renderer/wavefront/mod.rs
+++ b/src/gpu/webgpu/renderer/wavefront/mod.rs
@@ -1,4 +1,4 @@
-use super::super::super::ir::{GpuRenderOutput, GpuRenderRequest};
+use super::super::super::ir::{RenderOutput, RenderRequest};
 use super::super::error::BackendError;
 use super::super::shader::ShaderStageId;
 use super::resources::{RenderBuffers, RenderDimensions};
@@ -6,11 +6,11 @@ use super::Renderer;
 
 pub fn render(
     renderer: &Renderer,
-    request: GpuRenderRequest,
+    request: RenderRequest,
     dimensions: &RenderDimensions,
     buffers: &RenderBuffers,
     bind_group: &wgpu::BindGroup,
-) -> Result<GpuRenderOutput, BackendError> {
+) -> Result<RenderOutput, BackendError> {
     let sample_end = request
         .sample_start
         .checked_add(u64::from(request.sample_count))
@@ -113,7 +113,7 @@ pub fn render(
         .into_iter()
         .map(|pixel| pixel.map(|component| component * inverse_sample_count))
         .collect();
-    GpuRenderOutput::new(dimensions.pixel_bounds, rgb.into_boxed_slice(), request)
+    RenderOutput::new(dimensions.pixel_bounds, rgb.into_boxed_slice(), request)
         .map_err(|error| BackendError::Readback(format!("invalid wavefront output: {error:?}")))
 }
 

--- a/tests/gpu_scene_compiler.rs
+++ b/tests/gpu_scene_compiler.rs
@@ -1,6 +1,6 @@
 #![cfg(any(feature = "cuda", feature = "webgpu"))]
 
-use pbrt_r4::gpu::compiler::{GpuResourceKind, GpuSourceEntry};
+use pbrt_r4::gpu::compiler::{ResourceKind, SourceEntry};
 use pbrt_r4::gpu::ir::{Geometry, ImageFilter, Material, SpectrumResource};
 use pbrt_r4::parser::{parse_string, SceneBuilder};
 
@@ -33,13 +33,13 @@ fn scene_builder_compiles_a_default_trianglemesh() {
     assert!(matches!(view.geometry[0], Geometry::TriangleMesh(_)));
     let requirements = compiled.requirements();
     assert_eq!(compiled.source_map().locations.len(), 1);
-    assert!(compiled.source_map().resources.contains(&GpuSourceEntry {
-        kind: GpuResourceKind::Geometry,
+    assert!(compiled.source_map().resources.contains(&SourceEntry {
+        kind: ResourceKind::Geometry,
         index: 0,
         source: pbrt_r4::gpu::ir::SourceId(0),
     }));
-    assert!(compiled.source_map().resources.contains(&GpuSourceEntry {
-        kind: GpuResourceKind::Primitive,
+    assert!(compiled.source_map().resources.contains(&SourceEntry {
+        kind: ResourceKind::Primitive,
         index: 0,
         source: pbrt_r4::gpu::ir::SourceId(0),
     }));
@@ -84,8 +84,8 @@ fn scene_builder_rejects_path_integrator_without_volpath_fallback() {
     let error = builder.build_gpu_ir().unwrap_err();
     assert!(matches!(
         error,
-        pbrt_r4::gpu::compiler::GpuSceneBuildError::Compile(
-            pbrt_r4::gpu::compiler::GpuCompileError::UnsupportedSceneFeature {
+        pbrt_r4::gpu::compiler::SceneBuildError::Compile(
+            pbrt_r4::gpu::compiler::CompileError::UnsupportedSceneFeature {
                 feature: "non-volpath integrator",
                 ..
             }
@@ -187,13 +187,13 @@ fn scene_builder_compiles_instances_without_flattening() {
     assert_eq!(view.world_primitives.len(), 0);
     assert_eq!(view.world_instances.len(), 1);
     assert_eq!(view.instance_definitions[0].primitives.len(), 1);
-    assert!(compiled.source_map().resources.contains(&GpuSourceEntry {
-        kind: GpuResourceKind::InstanceDefinition,
+    assert!(compiled.source_map().resources.contains(&SourceEntry {
+        kind: ResourceKind::InstanceDefinition,
         index: 0,
         source: pbrt_r4::gpu::ir::SourceId(1),
     }));
-    assert!(compiled.source_map().resources.contains(&GpuSourceEntry {
-        kind: GpuResourceKind::Instance,
+    assert!(compiled.source_map().resources.contains(&SourceEntry {
+        kind: ResourceKind::Instance,
         index: 0,
         source: pbrt_r4::gpu::ir::SourceId(2),
     }));
@@ -312,8 +312,8 @@ fn scene_builder_rejects_unsupported_area_light_inputs() {
     let error = builder.build_gpu_ir().unwrap_err();
     assert!(matches!(
         error,
-        pbrt_r4::gpu::compiler::GpuSceneBuildError::Compile(
-            pbrt_r4::gpu::compiler::GpuCompileError::UnsupportedSceneFeature {
+        pbrt_r4::gpu::compiler::SceneBuildError::Compile(
+            pbrt_r4::gpu::compiler::CompileError::UnsupportedSceneFeature {
                 feature: "area light image emission",
                 ..
             },

--- a/tests/gpu_scene_compiler.rs
+++ b/tests/gpu_scene_compiler.rs
@@ -1,7 +1,7 @@
 #![cfg(any(feature = "cuda", feature = "webgpu"))]
 
 use pbrt_r4::gpu::compiler::{GpuResourceKind, GpuSourceEntry};
-use pbrt_r4::gpu::ir::{GpuGeometry, GpuImageFilter, GpuMaterial, GpuSpectrumResource};
+use pbrt_r4::gpu::ir::{Geometry, ImageFilter, Material, SpectrumResource};
 use pbrt_r4::parser::{parse_string, SceneBuilder};
 
 #[test]
@@ -30,7 +30,7 @@ fn scene_builder_compiles_a_default_trianglemesh() {
     assert_eq!(view.render.film.pixel_bounds.max, [1280, 720]);
     assert_eq!(view.render.sampler.samples_per_pixel, 4);
     assert!(!view.primitives[0].reverse_orientation);
-    assert!(matches!(view.geometry[0], GpuGeometry::TriangleMesh(_)));
+    assert!(matches!(view.geometry[0], Geometry::TriangleMesh(_)));
     let requirements = compiled.requirements();
     assert_eq!(compiled.source_map().locations.len(), 1);
     assert!(compiled.source_map().resources.contains(&GpuSourceEntry {
@@ -53,7 +53,7 @@ fn scene_builder_compiles_a_default_trianglemesh() {
     assert_eq!(requirements.resource_counts.primitives, 1);
     assert_eq!(requirements.maxima.vertices_per_geometry, 3);
     assert!(requirements.features.iter().any(|required| {
-        required.feature == pbrt_r4::gpu::ir::GpuFeature::TriangleMesh
+        required.feature == pbrt_r4::gpu::ir::Feature::TriangleMesh
             && required.sources.as_ref() == [pbrt_r4::gpu::ir::SourceId(0)]
     }));
     assert!(requirements
@@ -149,11 +149,11 @@ fn scene_builder_compiles_constant_diffuse_material() {
     assert_eq!(view.primitives[0].material.map(|id| id.0), Some(1));
     assert!(matches!(
         view.materials[1],
-        GpuMaterial::Diffuse(material) if material.reflectance.0 == 1
+        Material::Diffuse(material) if material.reflectance.0 == 1
     ));
     assert!(matches!(
         view.spectra[1],
-        GpuSpectrumResource::RgbAlbedo { coefficients }
+        SpectrumResource::RgbAlbedo { coefficients }
             if coefficients == [0.2, 0.4, 0.6]
     ));
 }
@@ -226,10 +226,10 @@ fn scene_builder_compiles_animated_shape_transforms() {
     let compiled = builder.build_gpu_ir().unwrap();
     assert!(matches!(
         compiled.view().transforms[0],
-        pbrt_r4::gpu::ir::GpuTransform::Animated(_)
+        pbrt_r4::gpu::ir::Transform::Animated(_)
     ));
     assert!(compiled.requirements().features.iter().any(|required| {
-        required.feature == pbrt_r4::gpu::ir::GpuFeature::AnimatedTransform
+        required.feature == pbrt_r4::gpu::ir::Feature::AnimatedTransform
             && required.sources.as_ref() == [pbrt_r4::gpu::ir::SourceId(0)]
     }));
 }
@@ -280,12 +280,12 @@ fn scene_builder_binds_diffuse_area_light_to_primitive() {
     assert_eq!(view.lights.len(), 1);
     assert!(matches!(
         view.lights[0],
-        pbrt_r4::gpu::ir::GpuLight::DiffuseArea(light)
+        pbrt_r4::gpu::ir::Light::DiffuseArea(light)
             if light.scale == 3.0 && light.two_sided == false
     ));
     assert!(matches!(
         view.primitives[0].area_light,
-        pbrt_r4::gpu::ir::GpuAreaLightBinding::Uniform(light) if light.0 == 0
+        pbrt_r4::gpu::ir::AreaLightBinding::Uniform(light) if light.0 == 0
     ));
 }
 
@@ -330,12 +330,12 @@ fn scene_builder_preserves_imagemap_filter_selection() {
         .unwrap();
 
     for (filter, expected) in [
-        ("point", GpuImageFilter::Point),
-        ("bilinear", GpuImageFilter::Bilinear),
-        ("trilinear", GpuImageFilter::Trilinear),
+        ("point", ImageFilter::Point),
+        ("bilinear", ImageFilter::Bilinear),
+        ("trilinear", ImageFilter::Trilinear),
         (
             "ewa",
-            GpuImageFilter::Ewa {
+            ImageFilter::Ewa {
                 max_anisotropy: 4.0,
             },
         ),
@@ -367,15 +367,15 @@ fn scene_builder_preserves_imagemap_filter_selection() {
         let texture = compiled.view().spectrum_textures[1];
         assert!(matches!(
             texture,
-            pbrt_r4::gpu::ir::GpuSpectrumTexture::Image { filter, .. } if filter == expected
+            pbrt_r4::gpu::ir::SpectrumTexture::Image { filter, .. } if filter == expected
         ));
         assert!(matches!(
             &compiled.view().images[0].storage,
-            pbrt_r4::gpu::ir::GpuTexelStorage::U8(_)
+            pbrt_r4::gpu::ir::TexelStorage::U8(_)
         ));
         assert_eq!(
             compiled.view().images[0].color_encoding,
-            pbrt_r4::gpu::ir::GpuColorEncoding::Srgb
+            pbrt_r4::gpu::ir::ColorEncoding::Srgb
         );
     }
 }
@@ -411,16 +411,13 @@ fn scene_builder_uses_luma_channel_for_two_channel_float_imagemap() {
     let view = compiled.view();
     assert!(matches!(
         view.float_textures[0],
-        pbrt_r4::gpu::ir::GpuFloatTexture::Image {
-            channel: pbrt_r4::gpu::ir::GpuFloatImageChannel::Channel0,
+        pbrt_r4::gpu::ir::FloatTexture::Image {
+            channel: pbrt_r4::gpu::ir::FloatImageChannel::Channel0,
             ..
         }
     ));
     assert_eq!(view.primitives[0].alpha.map(|id| id.0), Some(0));
-    assert_eq!(
-        view.images[0].channels,
-        pbrt_r4::gpu::ir::GpuImageChannels::Rg
-    );
+    assert_eq!(view.images[0].channels, pbrt_r4::gpu::ir::ImageChannels::Rg);
 }
 
 #[test]
@@ -444,7 +441,7 @@ fn scene_builder_compiles_uniform_infinite_light() {
     assert_eq!(compiled.view().lights.len(), 1);
     assert!(matches!(
         compiled.view().lights[0],
-        pbrt_r4::gpu::ir::GpuLight::UniformInfinite(light)
+        pbrt_r4::gpu::ir::Light::UniformInfinite(light)
             if light.radiance.0 == 1 && light.scale == 2.0
     ));
 }
@@ -497,7 +494,7 @@ fn scene_builder_preserves_material_displacement_reference() {
     let compiled = builder.build_gpu_ir().unwrap();
     assert!(matches!(
         compiled.view().materials[1],
-        GpuMaterial::Diffuse(material) if material.displacement.is_some()
+        Material::Diffuse(material) if material.displacement.is_some()
     ));
 }
 
@@ -519,10 +516,7 @@ fn scene_builder_compiles_quadric_shapes_without_fallback() {
     .unwrap();
 
     let compiled = builder.build_gpu_ir().unwrap();
-    assert!(matches!(
-        compiled.view().geometry[0],
-        GpuGeometry::Quadric(_)
-    ));
+    assert!(matches!(compiled.view().geometry[0], Geometry::Quadric(_)));
 }
 
 #[test]
@@ -547,7 +541,7 @@ fn scene_builder_compiles_bilinear_mesh() {
     let compiled = builder.build_gpu_ir().unwrap();
     assert!(matches!(
         compiled.view().geometry[0],
-        GpuGeometry::BilinearPatchMesh(_)
+        Geometry::BilinearPatchMesh(_)
     ));
 }
 
@@ -573,7 +567,7 @@ fn scene_builder_compiles_curve_mesh() {
     let compiled = builder.build_gpu_ir().unwrap();
     assert!(matches!(
         &compiled.view().geometry[0],
-        GpuGeometry::CurveMesh(mesh) if mesh.curves.len() == 1
+        Geometry::CurveMesh(mesh) if mesh.curves.len() == 1
     ));
 }
 
@@ -604,7 +598,7 @@ fn scene_builder_compiles_triangle_plymesh() {
     let compiled = builder.build_gpu_ir().unwrap();
     assert!(matches!(
         &compiled.view().geometry[0],
-        GpuGeometry::TriangleMesh(mesh)
+        Geometry::TriangleMesh(mesh)
             if mesh.positions.len() == 3 && mesh.indices == vec![[0, 1, 2]]
     ));
 }
@@ -640,7 +634,7 @@ fn scene_builder_compiles_ply_shape_displacement_into_minmax_ir() {
     assert_eq!(view.primitives[0].geometry.0, 1);
     assert!(matches!(
         &view.geometry[1],
-        GpuGeometry::DisplacedTriangleMesh(mesh)
+        Geometry::DisplacedTriangleMesh(mesh)
             if mesh.base_mesh.0 == 0
                 && mesh.triangle_roots.len() == 1
                 && mesh.min_max_nodes[0].displacement_min == 0.25

--- a/tests/gpu_wavefront_camera.rs
+++ b/tests/gpu_wavefront_camera.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "webgpu")]
 
-use pbrt_r4::gpu::ir::{GpuRenderConfig, GpuRenderRequest};
+use pbrt_r4::gpu::ir::{RenderConfig, RenderRequest};
 use pbrt_r4::gpu::webgpu::{PrepareOptions, Renderer};
 use pbrt_r4::parser::{parse_string, SceneBuilder};
 
@@ -35,7 +35,7 @@ fn wavefront_renders_direct_diffuse_lighting_with_hit_and_miss_pixels() {
         panic!("Hardware Ray Query is required for this WebGPU test: {error}")
     });
     let executable = renderer.prepare(&compiled).unwrap();
-    let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
+    let request = RenderRequest::new(&RenderConfig::default(), 0, 1).unwrap();
     let output = renderer.render(&executable, &request).unwrap();
 
     assert_eq!(output.rgb.len(), 8);
@@ -123,7 +123,7 @@ fn wavefront_adds_uniform_infinite_radiance_for_miss_rays() {
         panic!("Hardware Ray Query is required for this WebGPU test: {error}")
     });
     let executable = renderer.prepare(&compiled).unwrap();
-    let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
+    let request = RenderRequest::new(&RenderConfig::default(), 0, 1).unwrap();
     let output = renderer.render(&executable, &request).unwrap();
     assert!(output.rgb[0].iter().all(|component| *component > 0.0));
 }
@@ -161,7 +161,7 @@ fn wavefront_samples_a_diffuse_area_light() {
         panic!("Hardware Ray Query is required for this WebGPU test: {error}")
     });
     let executable = renderer.prepare(&compiled).unwrap();
-    let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
+    let request = RenderRequest::new(&RenderConfig::default(), 0, 1).unwrap();
     let output = renderer.render(&executable, &request).unwrap();
     assert!(output.rgb[0].iter().all(|component| component.is_finite()));
     assert!(
@@ -200,7 +200,7 @@ fn wavefront_adds_emissive_area_surface_when_hit() {
         panic!("Hardware Ray Query is required for this WebGPU test: {error}")
     });
     let executable = renderer.prepare(&compiled).unwrap();
-    let request = GpuRenderRequest::new(&GpuRenderConfig::default(), 0, 1).unwrap();
+    let request = RenderRequest::new(&RenderConfig::default(), 0, 1).unwrap();
     let output = renderer.render(&executable, &request).unwrap();
 
     assert!(output.rgb[0].iter().all(|component| component.is_finite()));
@@ -244,8 +244,8 @@ fn render_center_pixel_with_sample_count(
         panic!("Hardware Ray Query is required for this WebGPU test: {error}")
     });
     let executable = renderer.prepare(&compiled).unwrap();
-    let mut render_config = GpuRenderConfig::default();
+    let mut render_config = RenderConfig::default();
     render_config.sampler.samples_per_pixel = sample_count;
-    let request = GpuRenderRequest::new(&render_config, 0, sample_count).unwrap();
+    let request = RenderRequest::new(&render_config, 0, sample_count).unwrap();
     renderer.render(&executable, &request).unwrap().rgb[0]
 }


### PR DESCRIPTION
## Summary
- remove the redundant `Gpu` prefix from types defined under `gpu::ir`
- keep compiler-specific types such as `GpuCompiledScene` unchanged
- update WebGPU, compiler, and test references

## Validation
- `cargo fmt --all`
- `cargo check --features webgpu`
- `git diff --check`