### PR TITLE
Fix PiecewiseConstant1D PDF normalization and invert for custom domains

### DIFF
--- a/src/util/sampling/piecewise_constant_2d.rs
+++ b/src/util/sampling/piecewise_constant_2d.rs
@@ -77,7 +77,10 @@ impl PiecewiseConstant1D {
             self.func.len() - 1,
         );
         if self.integral > 0.0 {
-            self.func[i] / self.integral / (self.domain.1 - self.domain.0)
+            // `integral` already includes the width of the domain, so this
+            // ratio is a density with respect to x. Dividing by the domain
+            // width again would make the PDF integrate to 1 / (b - a).
+            self.func[i] / self.integral
         } else {
             0.0
         }
@@ -93,12 +96,8 @@ impl PiecewiseConstant1D {
             0,
             self.func.len() - 1,
         );
-        let c0 = self.cdf[i];
-        let c1 = self.cdf[i + 1];
-        if c1 <= c0 {
-            return None;
-        }
-        Some((i as Float + (u - c0) / (c1 - c0)) / self.func.len() as Float)
+        let du = u * self.func.len() as Float - i as Float;
+        Some(lerp(du, self.cdf[i], self.cdf[i + 1]))
     }
 }
 

--- a/tests/piecewise_constant_2d.rs
+++ b/tests/piecewise_constant_2d.rs
@@ -26,3 +26,19 @@ fn domain_width_contributes_to_integral() {
     let distribution = PiecewiseConstant1D::new(&[2.0, 2.0], -2.0, 4.0);
     assert!((distribution.integral() - 12.0).abs() < 1e-6);
 }
+
+#[test]
+fn one_dimensional_pdf_is_normalized_on_non_unit_domain() {
+    let distribution = PiecewiseConstant1D::new(&[1.0, 1.0], -2.0, 4.0);
+    assert!((distribution.pdf(0.0) - 1.0 / 6.0).abs() < 1e-6);
+}
+
+#[test]
+fn one_dimensional_sample_invert_round_trips() {
+    let distribution = PiecewiseConstant1D::new(&[1.0, 3.0], -2.0, 4.0);
+    for sample in [0.0, 0.125, 0.25, 0.5, 0.875, 1.0] {
+        let (value, _, _) = distribution.sample(sample);
+        let inverse = distribution.invert(value).unwrap();
+        assert!((inverse - sample.min(1.0 - 1e-7)).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
### Motivation
- Piecewise-constant sampling on non-unit domains produced incorrect PDF values because the domain width was double-counted when normalizing, causing PDFs to not integrate to 1 over the domain.
- The `invert()` implementation mixed spatial coordinates and CDF values when computing the inverse, preventing `sample()`/`invert()` from round-tripping correctly.

### Description
- Correct `PiecewiseConstant1D::pdf()` in `src/util/sampling/piecewise_constant_2d.rs` to return `self.func[i] / self.integral` when `integral > 0.0`, avoiding an extra division by the domain width.
- Replace the broken inverse logic in `PiecewiseConstant1D::invert()` with interpolation of the CDF within the selected bin using `lerp(du, self.cdf[i], self.cdf[i + 1])` so inversion maps spatial samples back to the correct CDF values.
- Add regression tests in `tests/piecewise_constant_2d.rs` that verify PDF normalization on non-unit domains and that `sample()`/`invert()` round-trip across a set of example inputs.

### Testing
- Ran `cargo test --test piecewise_constant_2d` and observed all tests in that test binary passed (5 passed, 0 failed).
- Ran `cargo fmt --check` to ensure formatting compliance and it succeeded.
- New tests were added to `tests/piecewise_constant_2d.rs` covering PDF normalization and sample/invert round-trips and they pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f2f60cd408326bc6a6eb5afe65d8c)