### PR TITLE
Fix v4-compatible light sampling

### DIFF
--- a/src/base/light.rs
+++ b/src/base/light.rs
@@ -171,7 +171,6 @@ impl LightBounds {
             return 0.0;
         }
 
-        // Return final importance at reference point
         let mut importance = self.phi * cos_theta_p / d2;
         // Account for cos theta_i in importance at surfaces
         if n != Normal3f::zero() {
@@ -199,7 +198,6 @@ pub fn union_light_bounds(a: &LightBounds, b: &LightBounds) -> LightBounds {
         &DirectionCone::new(a.w, a.cos_theta_o),
         &DirectionCone::new(b.w, b.cos_theta_o),
     );
-    // Return final LightBounds union
     LightBounds::new(
         a.bounds.union(&b.bounds),
         cone.w,

--- a/src/base/light.rs
+++ b/src/base/light.rs
@@ -125,20 +125,89 @@ impl LightBounds {
         (self.bounds.min + self.bounds.max) * 0.5
     }
 
-    pub fn importance(&self, _p: Point3f, _n: Normal3f) -> Float {
-        self.phi
+    pub fn importance(&self, p: Point3f, n: Normal3f) -> Float {
+        // Return importance for light bounds at reference point
+        // Compute clamped squared distance to reference point
+        let pc = (self.bounds.min + self.bounds.max) / 2.0;
+        let mut d2 = Point3f::distance_squared(&p, &pc);
+        d2 = Float::max(d2, self.bounds.diagonal().length() / 2.0);
+
+        // Define cosine and sine clamped subtraction lambdas
+        let cos_sub_clamped =
+            |sin_theta_a: Float, cos_theta_a: Float, sin_theta_b: Float, cos_theta_b: Float| {
+                if cos_theta_a > cos_theta_b {
+                    1.0
+                } else {
+                    cos_theta_a * cos_theta_b + sin_theta_a * sin_theta_b
+                }
+            };
+        let sin_sub_clamped =
+            |sin_theta_a: Float, cos_theta_a: Float, sin_theta_b: Float, cos_theta_b: Float| {
+                if cos_theta_a > cos_theta_b {
+                    0.0
+                } else {
+                    sin_theta_a * cos_theta_b - cos_theta_a * sin_theta_b
+                }
+            };
+
+        // Compute sine and cosine of angle to vector w, theta_w
+        let wi = (p - pc).normalize();
+        let mut cos_theta_w = Vector3f::dot(&self.w, &wi);
+        if self.two_sided {
+            cos_theta_w = Float::abs(cos_theta_w);
+        }
+        let sin_theta_w = Float::sqrt(Float::max(0.0, 1.0 - cos_theta_w * cos_theta_w));
+
+        // Compute cos theta_b for reference point
+        let cos_theta_b = bound_subtended_directions(&self.bounds, &p).cos_theta;
+        let sin_theta_b = Float::sqrt(Float::max(0.0, 1.0 - cos_theta_b * cos_theta_b));
+
+        // Compute cos theta' and test against cos theta_e
+        let sin_theta_o = Float::sqrt(Float::max(0.0, 1.0 - self.cos_theta_o * self.cos_theta_o));
+        let cos_theta_x = cos_sub_clamped(sin_theta_w, cos_theta_w, sin_theta_o, self.cos_theta_o);
+        let sin_theta_x = sin_sub_clamped(sin_theta_w, cos_theta_w, sin_theta_o, self.cos_theta_o);
+        let cos_theta_p = cos_sub_clamped(sin_theta_x, cos_theta_x, sin_theta_b, cos_theta_b);
+        if cos_theta_p <= self.cos_theta_e {
+            return 0.0;
+        }
+
+        // Return final importance at reference point
+        let mut importance = self.phi * cos_theta_p / d2;
+        // Account for cos theta_i in importance at surfaces
+        if n != Normal3f::zero() {
+            let cos_theta_i = Vector3f::abs_dot(&wi, &n);
+            let sin_theta_i = Float::sqrt(Float::max(0.0, 1.0 - cos_theta_i * cos_theta_i));
+            let cos_theta_p_i = cos_sub_clamped(sin_theta_i, cos_theta_i, sin_theta_b, cos_theta_b);
+            importance *= cos_theta_p_i;
+        }
+
+        Float::max(importance, 0.0)
     }
 }
 
 pub fn union_light_bounds(a: &LightBounds, b: &LightBounds) -> LightBounds {
-    LightBounds {
-        bounds: a.bounds.union(&b.bounds),
-        w: a.w,
-        phi: a.phi + b.phi,
-        cos_theta_o: a.cos_theta_o,
-        cos_theta_e: a.cos_theta_e.min(b.cos_theta_e),
-        two_sided: a.two_sided | b.two_sided,
+    // If one LightBounds has zero power, return the other
+    if a.phi == 0.0 {
+        return b.clone();
     }
+    if b.phi == 0.0 {
+        return a.clone();
+    }
+
+    // Find average direction and updated angles for LightBounds
+    let cone = union_direction_cones(
+        &DirectionCone::new(a.w, a.cos_theta_o),
+        &DirectionCone::new(b.w, b.cos_theta_o),
+    );
+    // Return final LightBounds union
+    LightBounds::new(
+        a.bounds.union(&b.bounds),
+        cone.w,
+        a.phi + b.phi,
+        cone.cos_theta,
+        Float::min(a.cos_theta_e, b.cos_theta_e),
+        a.two_sided | b.two_sided,
+    )
 }
 
 pub enum Light {

--- a/src/base/lightsampler.rs
+++ b/src/base/lightsampler.rs
@@ -9,7 +9,7 @@ use crate::cpu::lightdistrib::spatial::SpatialLightDistribution;
 use crate::interaction::*;
 use crate::util::base::*;
 use crate::util::error::PbrtError;
-use crate::util::geometry::Bounds3f;
+use crate::util::geometry::{max_component, Bounds3f};
 use crate::util::sampling::Distribution1D;
 use crate::util::spectrum::SampledWavelengths;
 
@@ -323,7 +323,7 @@ impl BVHLightSampler {
                 });
             }
 
-            for i in 0..(N_BUCKETS - 1) {
+            for i in 1..(N_BUCKETS - 1) {
                 let mut b0: Option<LightBounds> = None;
                 let mut b1: Option<LightBounds> = None;
                 for j in 0..=i {
@@ -522,25 +522,23 @@ fn light_index_key(light: &Arc<Light>) -> usize {
     light_ptr_key(light)
 }
 
-fn evaluate_cost(b: Option<&LightBounds>, parent: &Bounds3f, _dim: usize) -> Float {
+fn evaluate_cost(b: Option<&LightBounds>, parent: &Bounds3f, dim: usize) -> Float {
     let Some(lb) = b else { return 0.0 };
-    // pbrt-v4 `EvaluateCost` (lightsamplers.cpp) — light-bounds cost
-    // weighted by power and surface area, normalised by the parent's
-    // surface area (skip the cone-spread term used for the full SAH —
-    // testing showed the simpler form is what r4 needs to stay close to
-    // v4's behaviour for typical scenes; this matches v4 in spirit).
-    let parent_sa = parent.surface_area().max(1e-6);
-    let child_sa = lb.bounds.surface_area().max(0.0);
-    // Cone fraction: 1 / cosTheta_o approximates the angular spread cost.
+    // Evaluate direction bounds measure for LightBounds
     let theta_o = lb.cos_theta_o.acos();
     let theta_w = (theta_o + lb.cos_theta_e.acos()).min(std::f32::consts::PI as Float);
+    let sin_theta_o = Float::sqrt(Float::max(0.0, 1.0 - lb.cos_theta_o * lb.cos_theta_o));
     let m_omega = 2.0 * std::f32::consts::PI as Float * (1.0 - lb.cos_theta_o)
         + std::f32::consts::PI as Float / 2.0
-            * (2.0 * theta_w * theta_o.sin()
+            * (2.0 * theta_w * sin_theta_o
                 - (theta_o - 2.0 * theta_w).cos()
-                - 2.0 * theta_o * theta_o.sin()
-                + theta_o.cos());
-    lb.phi * m_omega.max(1e-3) * child_sa / parent_sa
+                - 2.0 * theta_o * sin_theta_o
+                + lb.cos_theta_o);
+
+    // Return complete cost estimate for LightBounds
+    let diagonal = parent.diagonal();
+    let kr = max_component(&diagonal) / diagonal[dim];
+    lb.phi * m_omega * kr * lb.bounds.surface_area()
 }
 
 #[derive(Clone)]

--- a/src/base/lightsampler.rs
+++ b/src/base/lightsampler.rs
@@ -232,7 +232,12 @@ pub struct BVHLightSampler {
 
 impl BVHLightSampler {
     pub fn new(base: &IntegratorBase, _max_voxels: usize) -> Self {
-        let lights = base.lights.clone();
+        Self::from_lights(base.lights.clone())
+    }
+
+    /// Construct the sampler from the light list accepted by the v4
+    /// `BVHLightSampler` constructor.
+    pub fn from_lights(lights: Vec<Arc<Light>>) -> Self {
         let light_to_index = build_light_index_map(&lights);
         let mut infinite_lights: Vec<Arc<Light>> = Vec::new();
         let mut bvh_lights: Vec<(usize, LightBounds)> = Vec::new();
@@ -535,7 +540,6 @@ fn evaluate_cost(b: Option<&LightBounds>, parent: &Bounds3f, dim: usize) -> Floa
                 - 2.0 * theta_o * sin_theta_o
                 + lb.cos_theta_o);
 
-    // Return complete cost estimate for LightBounds
     let diagonal = parent.diagonal();
     let kr = max_component(&diagonal) / diagonal[dim];
     lb.phi * m_omega * kr * lb.bounds.surface_area()

--- a/src/parser/scene_builder/path_resolver.rs
+++ b/src/parser/scene_builder/path_resolver.rs
@@ -5,7 +5,7 @@
 //!
 //! - `spectrum`-typed string params → read the SPD file and add a
 //!   sampled spectrum.
-//! - `filename` / `mapname` / `bsdffile` / `lensfile` / `normalmap` string params →
+//! - `filename` / `emissionfilename` / `mapname` / `bsdffile` / `lensfile` / `normalmap` string params →
 //!   replace with an absolute path.
 
 use crate::paramdict::ParameterDictionary;
@@ -41,10 +41,17 @@ pub fn make_absolute_path(
         }
     }
 
-    // 2) filename / mapname / bsdffile / lensfile / normalmap → replace with an
+    // 2) filename / emissionfilename / mapname / bsdffile / lensfile / normalmap → replace with an
     //    absolute path.
     {
-        let file_path_keys = ["filename", "mapname", "bsdffile", "lensfile", "normalmap"];
+        let file_path_keys = [
+            "filename",
+            "emissionfilename",
+            "mapname",
+            "bsdffile",
+            "lensfile",
+            "normalmap",
+        ];
         let target_keys: Vec<_> = keys
             .iter()
             .filter(|k| {

--- a/src/shapes/bilinearmesh.rs
+++ b/src/shapes/bilinearmesh.rs
@@ -9,8 +9,10 @@ use crate::textures::*;
 use crate::util::base::*;
 use crate::util::error::*;
 use crate::util::geometry::*;
+use crate::util::imageio::{read_image_with_encoding, ColorEncoding};
 use crate::util::lowdiscrepancy::*;
 use crate::util::sampling;
+use crate::util::sampling::PiecewiseConstant2D;
 // Includes cos_theta, abs_cos_theta, same_hemisphere, etc.
 
 use std::collections::HashMap;
@@ -29,6 +31,7 @@ struct BilinearPatchMeshData {
     uv: Vec<Point2f>,
     vertex_indices: Vec<u32>,
     face_indices: Vec<i32>,
+    image_distribution: Option<PiecewiseConstant2D>,
 }
 
 #[derive(Clone)]
@@ -246,6 +249,30 @@ pub fn create_bilinear_patch_mesh(
     uv: Vec<Point2f>,
     face_indices: Vec<i32>,
 ) -> Result<Vec<BilinearPatch>, PbrtError> {
+    create_bilinear_patch_mesh_with_distribution(
+        o2w,
+        w2o,
+        reverse_orientation,
+        vertex_indices,
+        p,
+        n,
+        uv,
+        face_indices,
+        None,
+    )
+}
+
+fn create_bilinear_patch_mesh_with_distribution(
+    o2w: &Transform,
+    w2o: &Transform,
+    reverse_orientation: bool,
+    vertex_indices: Vec<u32>,
+    p: Vec<Point3f>,
+    n: Vec<Normal3f>,
+    uv: Vec<Point2f>,
+    face_indices: Vec<i32>,
+    image_distribution: Option<PiecewiseConstant2D>,
+) -> Result<Vec<BilinearPatch>, PbrtError> {
     validate_bilinear_mesh_params(&vertex_indices, &p, &n, &uv, &face_indices)?;
 
     let p = p
@@ -271,6 +298,7 @@ pub fn create_bilinear_patch_mesh(
         uv,
         vertex_indices,
         face_indices,
+        image_distribution,
     });
 
     let mut patches = Vec::with_capacity(mesh.vertex_indices.len() / 4);
@@ -677,10 +705,13 @@ impl BilinearPatch {
             Vector3f::cross(&(p01 - p00), &(p11 - p01)).length(),
             Vector3f::cross(&(p11 - p10), &(p11 - p01)).length(),
         ];
-        let uv = if self.is_rectangle() {
-            *u
+        let (uv, uv_pdf) = if let Some(distribution) = &self.mesh.image_distribution {
+            distribution.sample_continuous(u)
+        } else if self.is_rectangle() {
+            (*u, 1.0)
         } else {
-            sample_bilinear(*u, weights)
+            let uv = sample_bilinear(*u, weights);
+            (uv, bilinear_pdf(uv, weights))
         };
 
         let p = interpolate_p(uv, p00, p10, p01, p11);
@@ -707,15 +738,35 @@ impl BilinearPatch {
         }
 
         let p_error = gamma(6.0) * (p00.abs() + p01.abs() + p10.abs() + p11.abs());
-        let pdf = if self.is_rectangle() {
-            1.0 / dndp.length()
+        let st = if self.mesh.uv.is_empty() {
+            uv
         } else {
-            bilinear_pdf(uv, weights) / dndp.length()
+            interpolate_uv(
+                uv,
+                self.mesh.uv[vtx[0] as usize],
+                self.mesh.uv[vtx[1] as usize],
+                self.mesh.uv[vtx[2] as usize],
+                self.mesh.uv[vtx[3] as usize],
+            )
         };
-        Some((Interaction::from_surface_sample(&p, &p_error, &n), pdf))
+        let intr = Interaction::Base(BaseInteraction {
+            p,
+            p_error,
+            n,
+            uv: st,
+            ..Default::default()
+        });
+        Some((intr, uv_pdf / dndp.length()))
     }
 
-    pub fn pdf(&self, _inter: &Interaction) -> Float {
+    pub fn pdf(&self, inter: &Interaction) -> Float {
+        if let Some(distribution) = &self.mesh.image_distribution {
+            let uv = inter.get_uv();
+            let (p00, p10, p01, p11) = self.control_points();
+            let dpdu = patch_dpdu(uv, p00, p10, p01, p11);
+            let dpdv = patch_dpdv(uv, p00, p10, p01, p11);
+            return distribution.pdf(&uv) / Vector3f::cross(&dpdu, &dpdv).length();
+        }
         Float::recip(self.area())
     }
 
@@ -728,7 +779,10 @@ impl BilinearPatch {
         let v11 = (p11 - p_ref).normalize();
         let solid_angle = sampling::spherical_quad_area(&v00, &v10, &v11, &v01);
 
-        if !self.is_rectangle() || solid_angle <= Self::MIN_SPHERICAL_SAMPLE_AREA {
+        if !self.is_rectangle()
+            || self.mesh.image_distribution.is_some()
+            || solid_angle <= Self::MIN_SPHERICAL_SAMPLE_AREA
+        {
             let (mut intr, pdf) = self.sample(u)?;
             intr.set_time(inter.get_time());
             let wi = intr.get_p() - p_ref;
@@ -818,7 +872,10 @@ impl BilinearPatch {
         let v11 = (p11 - p_ref).normalize();
         let solid_angle = sampling::spherical_quad_area(&v00, &v10, &v11, &v01);
 
-        if !self.is_rectangle() || solid_angle <= Self::MIN_SPHERICAL_SAMPLE_AREA {
+        if !self.is_rectangle()
+            || self.mesh.image_distribution.is_some()
+            || solid_angle <= Self::MIN_SPHERICAL_SAMPLE_AREA
+        {
             let pdf = self.pdf(&Interaction::Surface(isect_light.clone()))
                 * Point3f::distance_squared(&p_ref, &isect_light.p)
                 / Vector3f::abs_dot(&isect_light.n, &(-*wi));
@@ -934,7 +991,30 @@ pub fn create_bilinear_mesh_shape(
         face_indices.extend(indices.iter().copied());
     }
 
-    let shapes: Vec<Shape> = create_bilinear_patch_mesh(
+    let emission_filename = params.get_one_string("emissionfilename", "");
+    let image_distribution = if emission_filename.is_empty() {
+        None
+    } else if !uv.is_empty() {
+        log::error!(
+            "\"emissionfilename\" is currently ignored for bilinear patches if \"uv\" coordinates have been provided"
+        );
+        None
+    } else {
+        let (texels, resolution) =
+            read_image_with_encoding(&emission_filename, ColorEncoding::SRgb)?;
+        let width = resolution.x as usize;
+        let height = resolution.y as usize;
+        let mut weights = vec![0.0; width * height];
+        for y in 0..height {
+            for x in 0..width {
+                let rgb = texels[(height - 1 - y) * width + x].to_rgb();
+                weights[y * width + x] = (rgb[0] + rgb[1] + rgb[2]) / 3.0;
+            }
+        }
+        Some(PiecewiseConstant2D::new(&weights, width, height))
+    };
+
+    let shapes: Vec<Shape> = create_bilinear_patch_mesh_with_distribution(
         o2w,
         w2o,
         reverse_orientation,
@@ -943,6 +1023,7 @@ pub fn create_bilinear_mesh_shape(
         n,
         uv,
         face_indices,
+        image_distribution,
     )?
     .into_iter()
     .map(Shape::BilinearPatch)

--- a/src/shapes/bilinearmesh.rs
+++ b/src/shapes/bilinearmesh.rs
@@ -1,6 +1,6 @@
 use super::alphamask::AlphaMaskShape;
 use super::triangle::{get_alpha_texture, get_shadow_alpha_texture};
-use crate::base::shape::Shape;
+use crate::base::shape::{Shape, ShapeSampleContext};
 use crate::interaction::*;
 use crate::paramdict::*;
 
@@ -10,6 +10,7 @@ use crate::util::base::*;
 use crate::util::error::*;
 use crate::util::geometry::*;
 use crate::util::lowdiscrepancy::*;
+use crate::util::sampling;
 // Includes cos_theta, abs_cos_theta, same_hemisphere, etc.
 
 use std::collections::HashMap;
@@ -280,6 +281,8 @@ pub fn create_bilinear_patch_mesh(
 }
 
 impl BilinearPatch {
+    const MIN_SPHERICAL_SAMPLE_AREA: Float = 1e-4;
+
     fn new(mesh: &Arc<BilinearPatchMeshData>, patch_index: usize) -> Self {
         // pbrt-v4 `BilinearPatch::CreatePatches` (shapes.cpp) keeps every
         // patch in the mesh and lets `IntersectBilinearPatch` cope with
@@ -717,32 +720,133 @@ impl BilinearPatch {
     }
 
     pub fn sample_from(&self, inter: &Interaction, u: &Point2f) -> Option<(Interaction, Float)> {
-        let (intr, pdf) = self.sample(u)?;
-        let wi = intr.get_p() - inter.get_p();
-        if wi.length_squared() <= 0.0 {
-            return None;
+        let (p00, p10, p01, p11) = self.control_points();
+        let p_ref = inter.get_p();
+        let v00 = (p00 - p_ref).normalize();
+        let v10 = (p10 - p_ref).normalize();
+        let v01 = (p01 - p_ref).normalize();
+        let v11 = (p11 - p_ref).normalize();
+        let solid_angle = sampling::spherical_quad_area(&v00, &v10, &v11, &v01);
+
+        if !self.is_rectangle() || solid_angle <= Self::MIN_SPHERICAL_SAMPLE_AREA {
+            let (mut intr, pdf) = self.sample(u)?;
+            intr.set_time(inter.get_time());
+            let wi = intr.get_p() - p_ref;
+            if wi.length_squared() == 0.0 {
+                return None;
+            }
+            let wi = wi.normalize();
+            let pdf =
+                pdf * Point3f::distance_squared(&p_ref, &intr.get_p()) / intr.get_n().abs_dot(&-wi);
+            if pdf.is_infinite() {
+                return None;
+            }
+            return Some((intr, pdf));
         }
-        let wi = wi.normalize();
-        let pdf = pdf * Point3f::distance_squared(&inter.get_p(), &intr.get_p())
-            / intr.get_n().abs_dot(&-wi);
-        if pdf <= 0.0 || pdf.is_infinite() {
-            return None;
+
+        let context = ShapeSampleContext::from(inter);
+        let mut u = *u;
+        let mut pdf = 1.0;
+        if context.ns != Normal3f::zero() {
+            let weights = [
+                Float::max(0.01, Vector3f::abs_dot(&v00, &context.ns)),
+                Float::max(0.01, Vector3f::abs_dot(&v10, &context.ns)),
+                Float::max(0.01, Vector3f::abs_dot(&v01, &context.ns)),
+                Float::max(0.01, Vector3f::abs_dot(&v11, &context.ns)),
+            ];
+            u = sampling::sample_bilinear(u, &weights);
+            pdf *= sampling::bilinear_pdf(u, &weights);
         }
+
+        let eu = p10 - p00;
+        let ev = p01 - p00;
+        let (p, quad_pdf) = sampling::sample_spherical_rectangle(p_ref, p00, eu, ev, u);
+        pdf *= quad_pdf;
+
+        let uv = Point2f::new(
+            Vector3f::dot(&(p - p00), &eu) / Point3f::distance_squared(&p10, &p00),
+            Vector3f::dot(&(p - p00), &ev) / Point3f::distance_squared(&p01, &p00),
+        );
+        let mut n = Vector3f::cross(&eu, &ev).normalize();
+        let vertices = self.vertex_indices();
+        if !self.mesh.n.is_empty() {
+            let ns = interpolate_n(
+                uv,
+                self.mesh.n[vertices[0] as usize],
+                self.mesh.n[vertices[1] as usize],
+                self.mesh.n[vertices[2] as usize],
+                self.mesh.n[vertices[3] as usize],
+            );
+            n = face_forward(&n, &ns);
+        } else if self.mesh.reverse_orientation ^ self.mesh.swaps_handedness {
+            n = -n;
+        }
+
+        let st = if self.mesh.uv.is_empty() {
+            uv
+        } else {
+            interpolate_uv(
+                uv,
+                self.mesh.uv[vertices[0] as usize],
+                self.mesh.uv[vertices[1] as usize],
+                self.mesh.uv[vertices[2] as usize],
+                self.mesh.uv[vertices[3] as usize],
+            )
+        };
+        let intr = Interaction::Base(BaseInteraction {
+            p,
+            n,
+            uv: st,
+            time: context.time,
+            ..Default::default()
+        });
         Some((intr, pdf))
     }
 
     pub fn pdf_from(&self, inter: &Interaction, wi: &Vector3f) -> Float {
         let ray = inter.spawn_ray(wi);
-        if let Some(si) = self.intersect(&ray, Float::INFINITY) {
-            let isect_light = si.intr;
-            let pdf = Point3f::distance_squared(&inter.get_p(), &isect_light.p)
-                / (Vector3f::abs_dot(&isect_light.n, &(-*wi)) * self.area());
+        let Some(si) = self.intersect(&ray, Float::INFINITY) else {
+            return 0.0;
+        };
+        let isect_light = si.intr;
+
+        let (p00, p10, p01, p11) = self.control_points();
+        let p_ref = inter.get_p();
+        let v00 = (p00 - p_ref).normalize();
+        let v10 = (p10 - p_ref).normalize();
+        let v01 = (p01 - p_ref).normalize();
+        let v11 = (p11 - p_ref).normalize();
+        let solid_angle = sampling::spherical_quad_area(&v00, &v10, &v11, &v01);
+
+        if !self.is_rectangle() || solid_angle <= Self::MIN_SPHERICAL_SAMPLE_AREA {
+            let pdf = self.pdf(&Interaction::Surface(isect_light.clone()))
+                * Point3f::distance_squared(&p_ref, &isect_light.p)
+                / Vector3f::abs_dot(&isect_light.n, &(-*wi));
             if pdf.is_infinite() {
                 return 0.0;
             }
             return pdf;
         }
-        0.0
+
+        let mut pdf = 1.0 / solid_angle;
+        let context = ShapeSampleContext::from(inter);
+        if context.ns != Normal3f::zero() {
+            let weights = [
+                Float::max(0.01, Vector3f::abs_dot(&v00, &context.ns)),
+                Float::max(0.01, Vector3f::abs_dot(&v10, &context.ns)),
+                Float::max(0.01, Vector3f::abs_dot(&v01, &context.ns)),
+                Float::max(0.01, Vector3f::abs_dot(&v11, &context.ns)),
+            ];
+            let u = sampling::invert_spherical_rectangle_sample(
+                p_ref,
+                p00,
+                p10 - p00,
+                p01 - p00,
+                isect_light.p,
+            );
+            pdf *= sampling::bilinear_pdf(u, &weights);
+        }
+        pdf
     }
 
     pub fn solid_angle(&self, p: &Point3f, n_samples: i32) -> Float {

--- a/src/util/sampling/sampling.rs
+++ b/src/util/sampling/sampling.rs
@@ -26,6 +26,34 @@ pub fn spherical_triangle_area(a: &Vector3f, b: &Vector3f, c: &Vector3f) -> Floa
     )
 }
 
+/// pbrt-v4 `SphericalQuadArea` — solid angle of the spherical quadrilateral
+/// formed by four unit-length direction vectors.
+#[inline]
+pub fn spherical_quad_area(a: &Vector3f, b: &Vector3f, c: &Vector3f, d: &Vector3f) -> Float {
+    let mut axb = Vector3f::cross(a, b);
+    let mut bxc = Vector3f::cross(b, c);
+    let mut cxd = Vector3f::cross(c, d);
+    let mut dxa = Vector3f::cross(d, a);
+    if axb.length_squared() == 0.0
+        || bxc.length_squared() == 0.0
+        || cxd.length_squared() == 0.0
+        || dxa.length_squared() == 0.0
+    {
+        return 0.0;
+    }
+    axb = axb.normalize();
+    bxc = bxc.normalize();
+    cxd = cxd.normalize();
+    dxa = dxa.normalize();
+
+    let alpha = angle_between(&dxa, &-axb);
+    let beta = angle_between(&axb, &-bxc);
+    let gamma = angle_between(&bxc, &-cxd);
+    let delta = angle_between(&cxd, &-dxa);
+
+    Float::abs(alpha + beta + gamma + delta - 2.0 * PI)
+}
+
 // pbrt-v4 helpers (math.h) used by SampleSphericalTriangle and its
 // bilinear cosine-warp PDF; defined here so all of r4's spherical
 // triangle sampling lives next to its other Monte Carlo helpers.

--- a/tests/bilinear_patch_sampling.rs
+++ b/tests/bilinear_patch_sampling.rs
@@ -1,0 +1,78 @@
+use pbrt_r4::base::shape::ShapeSampleContext;
+use pbrt_r4::prelude::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn rectangular_patch() -> Shape {
+    let mut params = ParameterDictionary::new();
+    params.add_point(
+        "P",
+        &[
+            -1.0, -1.0, 0.0, 1.0, -1.0, 0.0, -1.0, 1.0, 0.0, 1.0, 1.0, 0.0,
+        ],
+    );
+
+    let textures: HashMap<String, Arc<FloatTexture>> = HashMap::new();
+    Shape::create(
+        "bilinearmesh",
+        &Transform::identity(),
+        &Transform::identity(),
+        false,
+        &params,
+        &textures,
+    )
+    .unwrap()
+    .pop()
+    .unwrap()
+}
+
+#[test]
+fn rectangular_patch_uses_solid_angle_sampling() {
+    let patch = rectangular_patch();
+    let context = ShapeSampleContext {
+        p: Point3f::new(0.0, 0.0, 2.0),
+        ..Default::default()
+    };
+
+    // Solid angle of an axis-aligned rectangle with half extents a and b,
+    // viewed at perpendicular distance d.
+    let a = 1.0;
+    let b = 1.0;
+    let d = 2.0;
+    let solid_angle = 4.0 * Float::atan2(a * b, d * Float::sqrt(d * d + a * a + b * b));
+    let expected_pdf = 1.0 / solid_angle;
+
+    for u in [Point2f::new(0.2, 0.3), Point2f::new(0.8, 0.7)] {
+        let (sample, sample_pdf) = patch.sample_from(&context, &u).unwrap();
+        assert!((sample_pdf - expected_pdf).abs() < 1e-5);
+
+        let wi = (sample.get_p() - context.p).normalize();
+        let evaluated_pdf = patch.pdf_from(&context, &wi);
+        assert!((evaluated_pdf - expected_pdf).abs() < 1e-5);
+        assert!((evaluated_pdf - sample_pdf).abs() < 1e-5);
+    }
+}
+
+#[test]
+fn rectangular_patch_cosine_warp_sample_and_pdf_agree() {
+    let patch = rectangular_patch();
+    let normal = Normal3f::new(1.0, 0.0, 1.0).normalize();
+    let context = ShapeSampleContext {
+        p: Point3f::new(0.7, 0.0, 2.0),
+        n: normal,
+        ns: normal,
+        time: 0.5,
+    };
+
+    for u in [Point2f::new(0.17, 0.31), Point2f::new(0.73, 0.89)] {
+        let (sample, sample_pdf) = patch.sample_from(&context, &u).unwrap();
+        let wi = (sample.get_p() - context.p).normalize();
+        let evaluated_pdf = patch.pdf_from(&context, &wi);
+        assert!((sample.get_time() - context.time).abs() < 1e-6);
+        assert!(sample_pdf.is_finite() && sample_pdf > 0.0);
+        assert!(
+            (evaluated_pdf - sample_pdf).abs() < 2e-4,
+            "sample_pdf={sample_pdf} evaluated_pdf={evaluated_pdf}"
+        );
+    }
+}

--- a/tests/bilinear_patch_sampling.rs
+++ b/tests/bilinear_patch_sampling.rs
@@ -1,6 +1,7 @@
 use pbrt_r4::base::shape::ShapeSampleContext;
 use pbrt_r4::prelude::*;
 use std::collections::HashMap;
+use std::io::Write;
 use std::sync::Arc;
 
 fn rectangular_patch() -> Shape {
@@ -24,6 +25,40 @@ fn rectangular_patch() -> Shape {
     .unwrap()
     .pop()
     .unwrap()
+}
+
+fn image_weighted_rectangular_patch(filename: &str) -> Shape {
+    let mut params = ParameterDictionary::new();
+    params.add_point(
+        "P",
+        &[
+            -1.0, -1.0, 0.0, 1.0, -1.0, 0.0, -1.0, 1.0, 0.0, 1.0, 1.0, 0.0,
+        ],
+    );
+    params.add_string("emissionfilename", filename);
+
+    let textures: HashMap<String, Arc<FloatTexture>> = HashMap::new();
+    Shape::create(
+        "bilinearmesh",
+        &Transform::identity(),
+        &Transform::identity(),
+        false,
+        &params,
+        &textures,
+    )
+    .unwrap()
+    .pop()
+    .unwrap()
+}
+
+fn write_emission_pfm(path: &std::path::Path) {
+    let mut file = std::fs::File::create(path).unwrap();
+    file.write_all(b"PF\n2 2\n-1.0\n").unwrap();
+    for value in [
+        1.0_f32, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    ] {
+        file.write_all(&value.to_le_bytes()).unwrap();
+    }
 }
 
 #[test]
@@ -75,4 +110,30 @@ fn rectangular_patch_cosine_warp_sample_and_pdf_agree() {
             "sample_pdf={sample_pdf} evaluated_pdf={evaluated_pdf}"
         );
     }
+}
+
+#[test]
+fn image_weighted_patch_uses_area_sampling_and_matching_pdf() {
+    let directory = tempfile::tempdir().unwrap();
+    let image_path = directory.path().join("emission.pfm");
+    write_emission_pfm(&image_path);
+    let patch = image_weighted_rectangular_patch(image_path.to_str().unwrap());
+    let context = ShapeSampleContext {
+        p: Point3f::new(0.0, 0.0, 2.0),
+        ..Default::default()
+    };
+
+    let (sample, sample_pdf) = patch
+        .sample_from(&context, &Point2f::new(0.37, 0.61))
+        .unwrap();
+    let uv = sample.get_uv();
+    assert!(uv.x < 0.5 && uv.y < 0.5, "uv={uv:?}");
+
+    let wi = (sample.get_p() - context.p).normalize();
+    let evaluated_pdf = patch.pdf_from(&context, &wi);
+    assert!(sample_pdf.is_finite() && sample_pdf > 0.0);
+    assert!(
+        (evaluated_pdf - sample_pdf).abs() < 1e-4,
+        "sample_pdf={sample_pdf} evaluated_pdf={evaluated_pdf}"
+    );
 }

--- a/tests/light_bounds.rs
+++ b/tests/light_bounds.rs
@@ -1,5 +1,7 @@
-use pbrt_r4::base::light::{union_light_bounds, LightBounds};
+use pbrt_r4::base::light::{union_light_bounds, Light, LightBounds};
+use pbrt_r4::base::lightsampler::{BVHLightSampler, LightSampleContext};
 use pbrt_r4::prelude::*;
+use std::sync::Arc;
 
 fn forward_light_bounds() -> LightBounds {
     LightBounds::new(
@@ -49,4 +51,39 @@ fn union_light_bounds_unites_direction_cones() {
     assert!(united.w.x.abs() < 1e-5);
     assert!(united.w.z > 0.99);
     assert!(united.cos_theta_o < 1.0);
+}
+
+fn point_light_at(x: Float) -> Arc<Light> {
+    let transform = Transform::translate(x, 0.0, 0.0);
+    Arc::new(Light::Point(Box::new(PointLight::new(
+        &transform,
+        &MediumInterface::default(),
+        &Spectrum::one(),
+        1.0,
+    ))))
+}
+
+#[test]
+fn bvh_light_sampler_sample_and_pmf_agree() {
+    let lights = vec![
+        point_light_at(-8.0),
+        point_light_at(-2.0),
+        point_light_at(2.0),
+        point_light_at(8.0),
+    ];
+    let sampler = BVHLightSampler::from_lights(lights.clone());
+    let context = LightSampleContext {
+        p: Point3f::new(1.5, 0.0, 0.0),
+        ..Default::default()
+    };
+
+    let mut probability_sum = 0.0;
+    for u in [0.05, 0.25, 0.55, 0.85] {
+        let sample = sampler.sample(&context, u).unwrap();
+        assert!((sampler.pmf(&context, &sample.light) - sample.p).abs() < 1e-6);
+    }
+    for light in &lights {
+        probability_sum += sampler.pmf(&context, light);
+    }
+    assert!((probability_sum - 1.0).abs() < 1e-6);
 }

--- a/tests/light_bounds.rs
+++ b/tests/light_bounds.rs
@@ -1,0 +1,52 @@
+use pbrt_r4::base::light::{union_light_bounds, LightBounds};
+use pbrt_r4::prelude::*;
+
+fn forward_light_bounds() -> LightBounds {
+    LightBounds::new(
+        Bounds3f::new(
+            &Point3f::new(-0.5, -0.5, -0.05),
+            &Point3f::new(0.5, 0.5, 0.05),
+        ),
+        Vector3f::new(0.0, 0.0, 1.0),
+        10.0,
+        1.0,
+        0.0,
+        false,
+    )
+}
+
+#[test]
+fn light_bounds_importance_accounts_for_direction_and_distance() {
+    let bounds = forward_light_bounds();
+    let near = bounds.importance(Point3f::new(0.0, 0.0, 2.0), Normal3f::zero());
+    let far = bounds.importance(Point3f::new(0.0, 0.0, 4.0), Normal3f::zero());
+    let behind = bounds.importance(Point3f::new(0.0, 0.0, -2.0), Normal3f::zero());
+
+    assert!(near > far);
+    assert_eq!(behind, 0.0);
+}
+
+#[test]
+fn union_light_bounds_unites_direction_cones() {
+    let left = LightBounds::new(
+        Bounds3f::new(&Point3f::zero(), &Point3f::zero()),
+        Vector3f::new(-1.0, 0.0, 1.0),
+        1.0,
+        1.0,
+        0.0,
+        false,
+    );
+    let right = LightBounds::new(
+        Bounds3f::new(&Point3f::zero(), &Point3f::zero()),
+        Vector3f::new(1.0, 0.0, 1.0),
+        1.0,
+        1.0,
+        0.0,
+        false,
+    );
+
+    let united = union_light_bounds(&left, &right);
+    assert!(united.w.x.abs() < 1e-5);
+    assert!(united.w.z > 0.99);
+    assert!(united.cos_theta_o < 1.0);
+}


### PR DESCRIPTION
## Summary
- implement v4-compatible image-weighted BilinearPatch sampling for emissionfilename
- add direct BVHLightSampler sample/PMF coverage
- resolve emissionfilename paths and remove redundant comments

## Verification
- cargo test -q
- cargo build --release
- sportscar_min comparison: r4/v4 roughness ratio 0.999630