### PR TITLE
Fix arbitrary-axis rotation in Matrix4x4::rotate and add regression test

### DIFF
--- a/src/util/transform/matrix4x4.rs
+++ b/src/util/transform/matrix4x4.rs
@@ -98,12 +98,26 @@ impl Matrix4x4 {
         let a = Vector3f::new(x, y, z).normalize();
         let s = Float::sin(radians(theta));
         let c = Float::cos(radians(theta));
+        let one_minus_c = 1.0 - c;
 
-        let _m00 = a.x * a.x + (1.0 - a.x * a.x) * c;
-        let _m01 = a.x * a.y + (1.0 - a.x * a.x) * c;
         Matrix4x4 {
             m: [
-                c, -s, 0.0, 0.0, s, c, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+                a.x * a.x + (1.0 - a.x * a.x) * c,
+                a.x * a.y * one_minus_c - a.z * s,
+                a.x * a.z * one_minus_c + a.y * s,
+                0.0,
+                a.x * a.y * one_minus_c + a.z * s,
+                a.y * a.y + (1.0 - a.y * a.y) * c,
+                a.y * a.z * one_minus_c - a.x * s,
+                0.0,
+                a.x * a.z * one_minus_c - a.y * s,
+                a.y * a.z * one_minus_c + a.x * s,
+                a.z * a.z + (1.0 - a.z * a.z) * c,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
             ],
         }
     }

--- a/tests/matrix4x4.rs
+++ b/tests/matrix4x4.rs
@@ -68,3 +68,15 @@ fn test_009() {
 
     assert!(Vector3f::distance_squared(&v2, &Vector3f::new(0.0, 1.0, 1.0)) < 0.01);
 }
+
+#[test]
+fn arbitrary_axis_rotation_uses_the_supplied_axis() {
+    let rotation = Matrix4x4::rotate(120.0, 1.0, 1.0, 1.0);
+
+    let rotated = rotation.transform_vector(&Vector3f::new(1.0, 0.0, 0.0));
+    assert!(Vector3f::distance_squared(&rotated, &Vector3f::new(0.0, 1.0, 0.0)) < 1e-12);
+
+    // A rotation matrix is orthogonal, so its transpose must undo it.
+    let restored = rotation.transpose().transform_vector(&rotated);
+    assert!(Vector3f::distance_squared(&restored, &Vector3f::new(1.0, 0.0, 0.0)) < 1e-12);
+}


### PR DESCRIPTION
### Motivation
- `Matrix4x4::rotate` ignored the supplied arbitrary axis and produced an incorrect rotation matrix for non-cardinal axes, causing wrong transforms for arbitrary-axis rotations.
- Implement a correct rotation construction so rotations about arbitrary normalized axes match expected behavior (as in pbrt-v4 / Rodrigues formula).

### Description
- Replace the previous placeholder rotation with an explicit arbitrary-axis rotation matrix using the normalized axis and Rodrigues-style formula in `Matrix4x4::rotate` (compute `one_minus_c`, fill the 3x3 rotation block correctly). 
- Add a regression test `arbitrary_axis_rotation_uses_the_supplied_axis` to `tests/matrix4x4.rs` that rotates around `(1,1,1)` by `120.0` degrees, asserts the expected mapped vector, and verifies orthogonality by using the transpose to restore the original vector. 
- Minor formatting adjustment to keep the test assertion style consistent with `cargo fmt`.

### Testing
- Ran `cargo test --test matrix4x4` and all tests passed (`9 passed; 0 failed`).
- Ran `cargo fmt --check` which succeeded (no formatting violations remaining after the update). 
- Ran `git diff --check` and repository checks produced no blocking issues in the changed files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f767c0ff08326b20b95f197bcc1ac)