### PR TITLE
Fix degenerate DirectionCone boundary handling

### DIFF
--- a/src/util/geometry/direction_cone.rs
+++ b/src/util/geometry/direction_cone.rs
@@ -89,7 +89,10 @@ pub fn bound_subtended_directions(b: &Bounds3f, p: &Point3f) -> DirectionCone {
     let (center_v, radius) = b.bounding_sphere();
     let p_center = Point3f::new(center_v.x, center_v.y, center_v.z);
     let d2 = (p_center - *p).length_squared();
-    if d2 < radius * radius {
+    // A zero-distance reference point has no finite center direction, even
+    // for a zero-radius bounding sphere.  For non-degenerate bounds on the
+    // sphere, retain the v4 behavior and construct the cone below.
+    if d2 < radius * radius || d2 == 0.0 {
         return DirectionCone::entire_sphere();
     }
     let w = (p_center - *p).normalize();

--- a/tests/direction_cone.rs
+++ b/tests/direction_cone.rs
@@ -1,0 +1,32 @@
+use pbrt_r4::util::base::Point3f;
+use pbrt_r4::util::geometry::{bound_subtended_directions, Bounds3f, DirectionCone};
+
+#[test]
+fn degenerate_bounds_at_reference_point_cover_the_sphere() {
+    let p = Point3f::new(1.0, 2.0, 3.0);
+    let bounds = Bounds3f::from((p.x, p.y, p.z));
+
+    let cone = bound_subtended_directions(&bounds, &p);
+
+    assert_eq!(cone, DirectionCone::entire_sphere());
+    assert!(cone.w.x.is_finite() && cone.w.y.is_finite() && cone.w.z.is_finite());
+}
+
+#[test]
+fn reference_point_inside_bounding_sphere_covers_the_sphere() {
+    let bounds = Bounds3f::new(&Point3f::new(-1.0, 0.0, 0.0), &Point3f::new(1.0, 0.0, 0.0));
+
+    let cone = bound_subtended_directions(&bounds, &Point3f::new(0.0, 0.0, 0.0));
+
+    assert_eq!(cone, DirectionCone::entire_sphere());
+}
+
+#[test]
+fn reference_point_on_bounding_sphere_returns_a_hemisphere_cone() {
+    let bounds = Bounds3f::new(&Point3f::new(-1.0, 0.0, 0.0), &Point3f::new(1.0, 0.0, 0.0));
+
+    let cone = bound_subtended_directions(&bounds, &Point3f::new(1.0, 0.0, 0.0));
+
+    assert!((cone.cos_theta).abs() < 1e-6);
+    assert!(cone.w.x.is_finite() && cone.w.y.is_finite() && cone.w.z.is_finite());
+}


### PR DESCRIPTION
Handle zero-distance degenerate bounds without producing NaNs while preserving pbrt-v4 behavior for non-degenerate points on the bounding sphere. Add regression tests for degenerate, interior, and boundary cases.