### PR TITLE
Prepare v4.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbrt-r4"
-version = "4.2.0"
+version = "4.3.0"
 edition = "2021"
 build = "build/main.rs"
 default-run = "pbrt-r4"


### PR DESCRIPTION
Prepare the v4.3.0 release from the current develop branch.

- Bump the crate version from 4.2.0 to 4.3.0
- Verify the focused regression tests
- Verify cargo publish --dry-run