### PR TITLE
perf(film): use atomic per-pixel splats

### DIFF
--- a/src/cpu/integrators/bdpt.rs
+++ b/src/cpu/integrators/bdpt.rs
@@ -1024,18 +1024,18 @@ fn mis_weight(
     if t_idx >= 0 {
         let new_pdf_rev = if s > 0 {
             // qs->PDF(integrator, qsMinus, *pt)
-            let qs = light_vertices[s_idx as usize].clone();
+            let qs = &light_vertices[s_idx as usize];
             let qs_minus = if s_minus >= 0 {
-                Some(light_vertices[s_minus as usize].clone())
+                Some(&light_vertices[s_minus as usize])
             } else {
                 None
             };
-            qs.pdf(base, qs_minus.as_ref(), &camera_vertices[t_idx as usize])
+            qs.pdf(base, qs_minus, &camera_vertices[t_idx as usize])
         } else {
             // pt->PDFLightOrigin(infiniteLights, *ptMinus, lightSampler)
-            let pt = camera_vertices[t_idx as usize].clone();
+            let pt = &camera_vertices[t_idx as usize];
             let pt_minus = if t_minus >= 0 {
-                camera_vertices[t_minus as usize].clone()
+                &camera_vertices[t_minus as usize]
             } else {
                 return restore_snapshot(
                     snap,
@@ -1048,7 +1048,7 @@ fn mis_weight(
                     1.0,
                 );
             };
-            pt.pdf_light_origin(&base.infinite_lights, &pt_minus, light_sampler)
+            pt.pdf_light_origin(&base.infinite_lights, pt_minus, light_sampler)
         };
         snap.pt_pdf_rev = Some(camera_vertices[t_idx as usize].pdf_rev);
         camera_vertices[t_idx as usize].pdf_rev = new_pdf_rev;
@@ -1057,15 +1057,15 @@ fn mis_weight(
     // Update pdf_rev of ptMinus
     if t_minus >= 0 {
         let new_pdf_rev = if s > 0 {
-            let pt = camera_vertices[t_idx as usize].clone();
+            let pt = &camera_vertices[t_idx as usize];
             let qs = if s_idx >= 0 {
-                Some(light_vertices[s_idx as usize].clone())
+                Some(&light_vertices[s_idx as usize])
             } else {
                 None
             };
-            pt.pdf(base, qs.as_ref(), &camera_vertices[t_minus as usize])
+            pt.pdf(base, qs, &camera_vertices[t_minus as usize])
         } else {
-            let pt = camera_vertices[t_idx as usize].clone();
+            let pt = &camera_vertices[t_idx as usize];
             pt.pdf_light(base, &camera_vertices[t_minus as usize])
         };
         snap.pt_minus_pdf_rev = Some(camera_vertices[t_minus as usize].pdf_rev);
@@ -1074,20 +1074,20 @@ fn mis_weight(
 
     // Update pdf_rev of qs and qsMinus
     if s_idx >= 0 {
-        let pt = camera_vertices[t_idx as usize].clone();
+        let pt = &camera_vertices[t_idx as usize];
         let pt_minus = if t_minus >= 0 {
-            Some(camera_vertices[t_minus as usize].clone())
+            Some(&camera_vertices[t_minus as usize])
         } else {
             None
         };
-        let new_pdf_rev = pt.pdf(base, pt_minus.as_ref(), &light_vertices[s_idx as usize]);
+        let new_pdf_rev = pt.pdf(base, pt_minus, &light_vertices[s_idx as usize]);
         snap.qs_pdf_rev = Some(light_vertices[s_idx as usize].pdf_rev);
         light_vertices[s_idx as usize].pdf_rev = new_pdf_rev;
     }
     if s_minus >= 0 {
-        let qs = light_vertices[s_idx as usize].clone();
-        let pt = camera_vertices[t_idx as usize].clone();
-        let new_pdf_rev = qs.pdf(base, Some(&pt), &light_vertices[s_minus as usize]);
+        let qs = &light_vertices[s_idx as usize];
+        let pt = &camera_vertices[t_idx as usize];
+        let new_pdf_rev = qs.pdf(base, Some(pt), &light_vertices[s_minus as usize]);
         snap.qs_minus_pdf_rev = Some(light_vertices[s_minus as usize].pdf_rev);
         light_vertices[s_minus as usize].pdf_rev = new_pdf_rev;
     }
@@ -1344,8 +1344,8 @@ pub fn connect_bdpt(
         }
     } else {
         // General case
-        let qs = light_vertices[(s - 1) as usize].clone();
-        let pt = camera_vertices[(t - 1) as usize].clone();
+        let qs = &light_vertices[(s - 1) as usize];
+        let pt = &camera_vertices[(t - 1) as usize];
         if qs.is_connectible() && pt.is_connectible() {
             let mut l = qs.beta
                 * qs.f(&pt, TransportMode::Importance)

--- a/src/cpu/integrators/bdpt.rs
+++ b/src/cpu/integrators/bdpt.rs
@@ -963,7 +963,7 @@ fn mis_weight(
     base: &IntegratorBase,
     light_vertices: &mut [Vertex],
     camera_vertices: &mut [Vertex],
-    sampled: Option<&Vertex>,
+    sampled: Option<Vertex>,
     s: i32,
     t: i32,
     light_sampler: &LightSampler,
@@ -1001,13 +1001,17 @@ fn mis_weight(
     // Apply sampled vertex for s==1 or t==1.
     if s == 1 {
         if let (Some(sampled), true) = (sampled, s_idx >= 0) {
-            snap.qs = Some(light_vertices[s_idx as usize].clone());
-            light_vertices[s_idx as usize] = sampled.clone();
+            snap.qs = Some(std::mem::replace(
+                &mut light_vertices[s_idx as usize],
+                sampled,
+            ));
         }
     } else if t == 1 {
         if let (Some(sampled), true) = (sampled, t_idx >= 0) {
-            snap.pt = Some(camera_vertices[t_idx as usize].clone());
-            camera_vertices[t_idx as usize] = sampled.clone();
+            snap.pt = Some(std::mem::replace(
+                &mut camera_vertices[t_idx as usize],
+                sampled,
+            ));
         }
     }
 
@@ -1349,7 +1353,7 @@ pub fn connect_bdpt(
         base,
         light_vertices,
         camera_vertices,
-        sampled_opt.as_ref(),
+        sampled_opt,
         s,
         t,
         light_sampler,

--- a/src/cpu/integrators/bdpt.rs
+++ b/src/cpu/integrators/bdpt.rs
@@ -2,6 +2,7 @@ use crate::base::bxdf::{
     is_non_specular, is_reflective, is_transmissive, TransportMode, BXDF_ALL, BXDF_REFL_TRANS_ALL,
 };
 use crate::base::camera::Camera;
+use crate::base::film::Film;
 use crate::base::light::{is_delta_light, Light, LightType};
 use crate::base::lightsampler::{LightSampleContext, LightSampler};
 use crate::base::medium::sample_t_maj_coefficients;
@@ -960,13 +961,13 @@ fn geometry_term(
 #[allow(clippy::too_many_arguments)]
 fn mis_weight(
     base: &IntegratorBase,
-    camera: &Arc<Camera>,
     light_vertices: &mut [Vertex],
     camera_vertices: &mut [Vertex],
     sampled: Option<&Vertex>,
     s: i32,
     t: i32,
     light_sampler: &LightSampler,
+    light_tracing_splat_scale: Float,
 ) -> Float {
     if s + t == 2 {
         return 1.0;
@@ -1098,27 +1099,17 @@ fn mis_weight(
     // light-tracing t=1 path is splatted onto the (crop-window) film, so the MIS
     // weight needs to compensate for the area ratio so that strategies remain
     // commensurable.
-    let film = camera.as_ref().get_film();
-    let splat_scale = {
-        let f = film.read().unwrap();
-        let fr = f.full_resolution();
-        let pb = f.pixel_bounds();
-        let full_area = fr.x as Float * fr.y as Float;
-        let pixel_area = ((pb.max.x - pb.min.x) * (pb.max.y - pb.min.y)) as Float;
-        if pixel_area > 0.0 {
-            full_area / pixel_area
-        } else {
-            1.0
-        }
-    };
-
     let mut sum_ri = 0.0;
     let mut ri: Float = 1.0;
     // Camera-subpath hypothetical strategies
     for i in (1..t).rev() {
         let ip = i as usize;
         ri *= remap0(camera_vertices[ip].pdf_rev) / remap0(camera_vertices[ip].pdf_fwd);
-        let r_use = if i == 1 { ri / splat_scale } else { ri };
+        let r_use = if i == 1 {
+            ri / light_tracing_splat_scale
+        } else {
+            ri
+        };
         if !camera_vertices[ip].delta && !camera_vertices[ip - 1].delta {
             sum_ri += r_use;
         }
@@ -1137,7 +1128,7 @@ fn mis_weight(
         }
     }
     if t == 1 {
-        sum_ri /= splat_scale;
+        sum_ri /= light_tracing_splat_scale;
     }
     let result = 1.0 / (1.0 + sum_ri);
 
@@ -1232,6 +1223,7 @@ pub fn connect_bdpt(
     t: i32,
     light_sampler: &LightSampler,
     sampler: &mut Sampler,
+    light_tracing_splat_scale: Float,
 ) -> (SampledSpectrum, Option<Point2f>) {
     let mut l_pkt = SampledSpectrum::zero();
     let mut p_raster: Option<Point2f> = None;
@@ -1277,15 +1269,7 @@ pub fn connect_bdpt(
                         // splatted contribution by FullRes^2 / PixelBounds.Area()
                         // so that crop-window renders remain commensurable with
                         // the other MIS strategies. See issue #347.
-                        let film = camera.as_ref().get_film();
-                        let f = film.read().unwrap();
-                        let fr = f.full_resolution();
-                        let pb = f.pixel_bounds();
-                        let full_area = fr.x as Float * fr.y as Float;
-                        let pixel_area = ((pb.max.x - pb.min.x) * (pb.max.y - pb.min.y)) as Float;
-                        if pixel_area > 0.0 {
-                            l *= full_area / pixel_area;
-                        }
+                        l *= light_tracing_splat_scale;
                         l_pkt = l;
                         sampled_opt = Some(sampled);
                     }
@@ -1363,13 +1347,13 @@ pub fn connect_bdpt(
     }
     let mis = mis_weight(
         base,
-        camera,
         light_vertices,
         camera_vertices,
         sampled_opt.as_ref(),
         s,
         t,
         light_sampler,
+        light_tracing_splat_scale,
     );
     (l_pkt * mis, p_raster)
 }
@@ -1386,6 +1370,7 @@ pub struct BDPTIntegrator {
     regularize: bool,
     light_sample_strategy: String,
     light_sampler: Option<LightSampler>,
+    light_tracing_splat_scale: Float,
 }
 
 impl BDPTIntegrator {
@@ -1399,6 +1384,7 @@ impl BDPTIntegrator {
         regularize: bool,
         pixel_bounds: &Bounds2i,
         light_sample_strategy: &str,
+        light_tracing_splat_scale: Float,
     ) -> Self {
         BDPTIntegrator {
             base: RayIntegratorBase::new(scene, camera, sampler, pixel_bounds),
@@ -1408,6 +1394,7 @@ impl BDPTIntegrator {
             regularize,
             light_sample_strategy: light_sample_strategy.to_string(),
             light_sampler: None,
+            light_tracing_splat_scale,
         }
     }
 }
@@ -1493,6 +1480,7 @@ impl RayIntegrator for BDPTIntegrator {
                     t,
                     light_sampler,
                     sampler,
+                    self.light_tracing_splat_scale,
                 );
                 if l_path.is_black() {
                     continue;
@@ -1543,7 +1531,14 @@ pub fn create_bdpt_integrator(
             strategy
         }
     };
-    let pixel_bounds = camera.get_film().read().unwrap().pixel_bounds();
+    let (pixel_bounds, light_tracing_splat_scale) = {
+        let film = camera.get_film();
+        let film = film.read().unwrap();
+        (
+            film.pixel_bounds(),
+            compute_light_tracing_splat_scale(&film),
+        )
+    };
     Ok(Arc::new(RwLock::new(BDPTIntegrator::new(
         scene,
         sampler,
@@ -1554,5 +1549,18 @@ pub fn create_bdpt_integrator(
         regularize,
         &pixel_bounds,
         &light_strategy,
+        light_tracing_splat_scale,
     ))))
+}
+
+pub fn compute_light_tracing_splat_scale(film: &Film) -> Float {
+    let full_resolution = film.full_resolution();
+    let pixel_bounds = film.pixel_bounds();
+    let full_area = full_resolution.x as Float * full_resolution.y as Float;
+    let pixel_area = pixel_bounds.area() as Float;
+    if pixel_area > 0.0 {
+        full_area / pixel_area
+    } else {
+        1.0
+    }
 }

--- a/src/cpu/integrators/bdpt.rs
+++ b/src/cpu/integrators/bdpt.rs
@@ -1501,7 +1501,7 @@ impl RayIntegrator for BDPTIntegrator {
                     l += l_path;
                 } else if let Some(p_film) = p_film_new {
                     let film = self.base.camera.get_film();
-                    film.write().unwrap().add_splat_packet(
+                    film.read().unwrap().add_splat_packet(
                         &Vector2f::new(p_film.x, p_film.y),
                         &l_path,
                         lambda,

--- a/src/cpu/integrators/mlt.rs
+++ b/src/cpu/integrators/mlt.rs
@@ -24,12 +24,30 @@ use crate::util::sampling::Distribution1D;
 use crate::util::spectrum::*;
 
 use rayon::prelude::*;
-use std::sync::{Arc, RwLock};
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
 
 const CAMERA_STREAM_INDEX: u64 = 0;
 const LIGHT_STREAM_INDEX: u64 = 1;
 const CONNECTION_STREAM_INDEX: u64 = 2;
 const N_SAMPLE_STREAMS: u64 = 3;
+const DEFAULT_DISPLAY_UPDATE_INTERVAL_MS: u64 = 250;
+const DISPLAY_TIME_CHECK_INTERVAL_MUTATIONS: i64 = 256;
+
+fn display_update_interval() -> Duration {
+    const ENV_NAME: &str = "PBRT_DISPLAY_UPDATE_INTERVAL_MS";
+    match std::env::var(ENV_NAME) {
+        Ok(value) => match value.parse::<u64>() {
+            Ok(milliseconds) if milliseconds > 0 => Duration::from_millis(milliseconds),
+            _ => {
+                log::warn!("Ignoring invalid {ENV_NAME}={value:?}; expected a positive integer");
+                Duration::from_millis(DEFAULT_DISPLAY_UPDATE_INTERVAL_MS)
+            }
+        },
+        Err(_) => Duration::from_millis(DEFAULT_DISPLAY_UPDATE_INTERVAL_MS),
+    }
+}
 
 pub struct MLTIntegrator {
     base: IntegratorBase,
@@ -280,119 +298,118 @@ impl Integrator for MLTIntegrator {
         let sample_bounds = film.read().unwrap().sample_bounds();
         let n_total_mutations = sample_bounds.area() as i64 * self.mutations_per_pixel as i64;
 
-        // ----- Markov chain pass (parallel over chains, broken into
-        //       rounds for live-display updates) -----
-        // pbrt-v4 (integrators.cpp:2647-2708) wraps the chain loop in
-        // `ParallelFor(0, nChains, ...)`. r4 splits that into
-        // `N_ROUNDS` sequential rounds; each round runs
-        // `n_chains / N_ROUNDS` chains in parallel, and the round
-        // boundary is where we flush `splat_tiles` into `splat_pixels`
-        // and ping the registered displays. Since
-        // `merge_splat_tiles` clears each tile after copying it to
-        // `splat_pixels` with the given scale, calling
-        // `merge_splats(b/mpp)` multiple times with the same scale
-        // yields exactly the same `splat_pixels` as a single
-        // end-of-render call.
+        // Follow all Markov chains in one parallel pass, as in pbrt-v4.
+        // Display updates are time-driven and opportunistically performed by
+        // one worker; they never divide the chain work into rounds or add a
+        // global barrier.
         let pixel_bounds = film.read().unwrap().pixel_bounds();
         let splat_scale = b / self.mutations_per_pixel as Float;
 
         let n_chains = self.n_chains;
-        const N_ROUNDS_TARGET: i32 = 10;
-        let n_rounds = N_ROUNDS_TARGET.min(n_chains.max(1));
-
         let max_depth = self.max_depth;
         let mpp = self.mutations_per_pixel;
         let sigma = self.sigma;
         let lsp = self.large_step_probability;
         let bootstrap_distrib = &bootstrap_distrib;
         let film = &film;
+        let display_enabled = !film.read().unwrap().base().display_is_empty();
+        let display_update_interval = display_update_interval();
+        let display_update_gate = Mutex::new(Instant::now());
+        let finished_chains = AtomicI32::new(0);
 
-        for round in 0..n_rounds {
-            let chain_lo = ((round as i64) * n_chains as i64 / n_rounds as i64) as i32;
-            let chain_hi = (((round + 1) as i64) * n_chains as i64 / n_rounds as i64) as i32;
-            (chain_lo..chain_hi).into_par_iter().for_each_init(
-                || MemoryArena::new(),
-                |chain_scratch, i| {
-                    let n_chain_mutations = ((i + 1) as i64 * n_total_mutations / n_chains as i64)
-                        .min(n_total_mutations)
-                        - (i as i64 * n_total_mutations / n_chains as i64);
+        (0..n_chains).into_par_iter().for_each_init(
+            || MemoryArena::new(),
+            |chain_scratch, i| {
+                let n_chain_mutations = ((i + 1) as i64 * n_total_mutations / n_chains as i64)
+                    .min(n_total_mutations)
+                    - (i as i64 * n_total_mutations / n_chains as i64);
 
-                    // pbrt-v4 (integrators.cpp:2655): `RNG rng(i)` →
-                    // `SetSequence(i, MixBits(i))`.
-                    let mut rng = RNG::new();
-                    rng.set_sequence(i as u64);
-                    let u_bootstrap = rng.uniform_float();
-                    let (bootstrap_index, _pdf, _) = bootstrap_distrib.sample_discrete(u_bootstrap);
-                    let depth = (bootstrap_index as i32) % (max_depth + 1);
+                // pbrt-v4 (integrators.cpp:2655): `RNG rng(i)` →
+                // `SetSequence(i, MixBits(i))`.
+                let mut rng = RNG::new();
+                rng.set_sequence(i as u64);
+                let u_bootstrap = rng.uniform_float();
+                let (bootstrap_index, _pdf, _) = bootstrap_distrib.sample_discrete(u_bootstrap);
+                let depth = (bootstrap_index as i32) % (max_depth + 1);
 
-                    let mlt = MLTSampler::new(
-                        mpp as u32,
-                        bootstrap_index as u64,
-                        sigma,
-                        lsp,
-                        N_SAMPLE_STREAMS,
-                    );
-                    let mut sampler_wrapper = Sampler::MLT(mlt);
-                    let (mut l_current, mut p_current, mut lambda_current) =
+                let mlt = MLTSampler::new(
+                    mpp as u32,
+                    bootstrap_index as u64,
+                    sigma,
+                    lsp,
+                    N_SAMPLE_STREAMS,
+                );
+                let mut sampler_wrapper = Sampler::MLT(mlt);
+                let (mut l_current, mut p_current, mut lambda_current) =
+                    self.l(&light_sampler, chain_scratch, &mut sampler_wrapper, depth);
+
+                // Hold one read lock for the whole chain; the splat path uses
+                // interior mutability per tile so concurrent chains can splat
+                // and one worker can merge pending splats for display.
+                let film_read = film.read().unwrap();
+                for mutation_index in 0..n_chain_mutations {
+                    sampler_wrapper.start_iteration();
+                    let (l_proposed, p_proposed, lambda_proposed) =
                         self.l(&light_sampler, chain_scratch, &mut sampler_wrapper, depth);
+                    let c_proposed = MLTIntegrator::c(&l_proposed, &lambda_proposed);
+                    let c_current = MLTIntegrator::c(&l_current, &lambda_current);
+                    // pbrt-v4 (integrators.cpp:2683):
+                    // `accept = std::min<Float>(1, cProposed / cCurrent)`.
+                    // `c_current == 0` yields `inf`, `min(1, inf) == 1`.
+                    let accept = Float::min(1.0, c_proposed / c_current);
 
-                    // Hold one read lock for the whole chain; the splat
-                    // path uses interior mutability per-tile so
-                    // concurrent chains can splat in parallel.
-                    let film_read = film.read().unwrap();
-                    for _ in 0..n_chain_mutations {
-                        sampler_wrapper.start_iteration();
-                        let (l_proposed, p_proposed, lambda_proposed) =
-                            self.l(&light_sampler, chain_scratch, &mut sampler_wrapper, depth);
-                        let c_proposed = MLTIntegrator::c(&l_proposed, &lambda_proposed);
-                        let c_current = MLTIntegrator::c(&l_current, &lambda_current);
-                        // pbrt-v4 (integrators.cpp:2683):
-                        // `accept = std::min<Float>(1, cProposed / cCurrent)`.
-                        // `c_current == 0` yields `inf`, `min(1, inf) == 1`.
-                        let accept = Float::min(1.0, c_proposed / c_current);
-
-                        // Splat both proposals (pbrt-v4 integrators.cpp:2685-2687).
-                        if accept > 0.0 {
-                            let scaled = l_proposed * (accept / c_proposed);
-                            film_read.add_splat_packet(
-                                &Vector2f::new(p_proposed.x, p_proposed.y),
-                                &scaled,
-                                &lambda_proposed,
-                            );
-                        }
-                        {
-                            let scaled = l_current * ((1.0 - accept) / c_current);
-                            film_read.add_splat_packet(
-                                &Vector2f::new(p_current.x, p_current.y),
-                                &scaled,
-                                &lambda_current,
-                            );
-                        }
-
-                        if rng.uniform_float() < accept {
-                            p_current = p_proposed;
-                            l_current = l_proposed;
-                            lambda_current = lambda_proposed;
-                            sampler_wrapper.accept();
-                        } else {
-                            sampler_wrapper.reject();
-                        }
-                        chain_scratch.reset();
+                    // Splat both proposals (pbrt-v4 integrators.cpp:2685-2687).
+                    if accept > 0.0 {
+                        let scaled = l_proposed * (accept / c_proposed);
+                        film_read.add_splat_packet(
+                            &Vector2f::new(p_proposed.x, p_proposed.y),
+                            &scaled,
+                            &lambda_proposed,
+                        );
                     }
-                    drop(film_read);
-                },
-            );
+                    {
+                        let scaled = l_current * ((1.0 - accept) / c_current);
+                        film_read.add_splat_packet(
+                            &Vector2f::new(p_current.x, p_current.y),
+                            &scaled,
+                            &lambda_current,
+                        );
+                    }
 
-            // All chains in this round have completed, so no read lock
-            // is held on `film`. Flush in-flight splats and push a
-            // preview to the displays.
-            let f = film.read().unwrap();
-            f.merge_splats(splat_scale);
-            f.update_display(&pixel_bounds);
-        }
+                    if rng.uniform_float() < accept {
+                        p_current = p_proposed;
+                        l_current = l_proposed;
+                        lambda_current = lambda_proposed;
+                        sampler_wrapper.accept();
+                    } else {
+                        sampler_wrapper.reject();
+                    }
+                    chain_scratch.reset();
+
+                    if display_enabled
+                        && mutation_index % DISPLAY_TIME_CHECK_INTERVAL_MUTATIONS == 0
+                    {
+                        if let Ok(mut last_update) = display_update_gate.try_lock() {
+                            if last_update.elapsed() >= display_update_interval {
+                                film_read.merge_splats(splat_scale);
+                                let finished = finished_chains.load(Ordering::Relaxed) as Float;
+                                let finished_pixel_mutations =
+                                    finished / n_chains as Float * mpp as Float;
+                                let preview_scale =
+                                    mpp as Float / Float::max(1.0, finished_pixel_mutations);
+                                film_read.update_display_scale(&pixel_bounds, preview_scale);
+                                *last_update = Instant::now();
+                            }
+                        }
+                    }
+                }
+                finished_chains.fetch_add(1, Ordering::Relaxed);
+            },
+        );
 
         let f = film.read().unwrap();
         f.merge_splats(splat_scale);
+        f.update_display(&pixel_bounds);
         f.render_end();
         f.write_image();
     }

--- a/src/cpu/integrators/mlt.rs
+++ b/src/cpu/integrators/mlt.rs
@@ -6,7 +6,8 @@ use crate::base::camera::{Camera, CameraSample};
 use crate::base::lightsampler::LightSampler;
 use crate::base::sampler::Sampler;
 use crate::cpu::integrators::bdpt::{
-    connect_bdpt, generate_camera_subpath, generate_light_subpath, Vertex,
+    compute_light_tracing_splat_scale, connect_bdpt, generate_camera_subpath,
+    generate_light_subpath, Vertex,
 };
 use crate::cpu::integrators::*;
 use crate::film::Film;
@@ -42,6 +43,7 @@ pub struct MLTIntegrator {
     regularize: bool,
     light_sample_strategy: String,
     light_sampler: Option<LightSampler>,
+    light_tracing_splat_scale: Float,
 }
 
 impl MLTIntegrator {
@@ -57,6 +59,7 @@ impl MLTIntegrator {
         large_step_probability: Float,
         regularize: bool,
         light_sample_strategy: &str,
+        light_tracing_splat_scale: Float,
     ) -> Self {
         Self {
             base: IntegratorBase::from_scene(scene),
@@ -70,6 +73,7 @@ impl MLTIntegrator {
             regularize,
             light_sample_strategy: light_sample_strategy.to_string(),
             light_sampler: None,
+            light_tracing_splat_scale,
         }
     }
 
@@ -200,6 +204,7 @@ impl MLTIntegrator {
             t,
             light_sampler,
             sampler_wrapper,
+            self.light_tracing_splat_scale,
         );
 
         let l_scaled = l_path * (n_strategies as Float);
@@ -420,6 +425,11 @@ pub fn create_mlt_integrator(
             strategy
         }
     };
+    let light_tracing_splat_scale = {
+        let film = camera.get_film();
+        let film = film.read().unwrap();
+        compute_light_tracing_splat_scale(&film)
+    };
     Ok(Arc::new(RwLock::new(MLTIntegrator::new(
         scene,
         camera.clone(),
@@ -431,5 +441,6 @@ pub fn create_mlt_integrator(
         large_step_probability,
         regularize,
         &light_strategy,
+        light_tracing_splat_scale,
     ))))
 }

--- a/src/film/film_base.rs
+++ b/src/film/film_base.rs
@@ -1,6 +1,6 @@
 use super::film_tile::*;
 use super::pixel_sensor::PixelSensor;
-use super::splat_tile::*;
+use super::splat_tile::{add_atomic_rgb, AtomicRgb};
 use crate::base::filter::Filter;
 use crate::displays::MultipleDisplay;
 use crate::displays::*;
@@ -229,40 +229,8 @@ impl FilmBase {
     }
 }
 
-/// Allocate splat tiles covering `pixel_bounds`. Each Film variant calls
-/// this from its constructor — pbrt-v4 stores `AtomicDouble rgbSplat[3]`
-/// directly on each Pixel, but r4 favors per-tile aggregation for
-/// portability (no stable AtomicF64 in Rust).
-pub fn make_splat_tiles(pixel_bounds: &Bounds2i) -> (Vec<Arc<RwLock<SplatTile>>>, Vector2i) {
-    let w = (pixel_bounds.max.x - pixel_bounds.min.x) as usize;
-    let h = (pixel_bounds.max.y - pixel_bounds.min.y) as usize;
-    let nx = (w + ST_W - 1) / ST_W;
-    let ny = (h + ST_W - 1) / ST_W;
-    let splat_size = Vector2i::new(nx as i32, ny as i32);
-
-    let mut splat_tiles = Vec::with_capacity(nx * ny);
-    for ty in 0..ny {
-        for tx in 0..nx {
-            let x0 = pixel_bounds.min.x as usize + tx * ST_W;
-            let x1 = usize::min(x0 + ST_W, pixel_bounds.max.x as usize);
-            let y0 = pixel_bounds.min.y as usize + ty * ST_W;
-            let y1 = usize::min(y0 + ST_W, pixel_bounds.max.y as usize);
-            let tile_bounds = Bounds2i::new(
-                &Vector2i::new(x0 as i32, y0 as i32),
-                &Vector2i::new(x1 as i32, y1 as i32),
-            );
-            splat_tiles.push(Arc::new(RwLock::new(SplatTile::new(&tile_bounds))));
-        }
-    }
-    (splat_tiles, splat_size)
-}
-
-/// Distribute a single splat sample into the appropriate `SplatTile` for
-/// the variant. Shared between Film variants because the splat-tile
-/// transport is identical regardless of pixel layout.
-pub fn add_splat_into_tiles(
-    splat_tiles: &[Arc<RwLock<SplatTile>>],
-    splat_size: Vector2i,
+pub fn add_splat_into_pixels(
+    splat_pixels: &[AtomicRgb],
     cropped_pixel_bounds: Bounds2i,
     pixel_sensor: &PixelSensor,
     p: &Vector2f,
@@ -278,32 +246,22 @@ pub fn add_splat_into_tiles(
         pi.x - cropped_pixel_bounds.min.x,
         pi.y - cropped_pixel_bounds.min.y,
     );
-    let tx = pi.x as usize / ST_W;
-    let ty = pi.y as usize / ST_W;
     let rgb = match lambda {
         Some(lambda) => pixel_sensor.to_output_rgb_with_wavelengths(v, lambda),
         None => pixel_sensor.to_output_rgb(v),
     };
 
-    let tindex = ty * splat_size.x as usize + tx;
-    debug_assert!(tindex < splat_tiles.len());
-    let mut splat_tile = splat_tiles[tindex].write().unwrap();
-    let x = pi.x as usize - tx * ST_W;
-    let y = pi.y as usize - ty * ST_W;
-
-    splat_tile.pixels[y * ST_W + x][0] += rgb[0];
-    splat_tile.pixels[y * ST_W + x][1] += rgb[1];
-    splat_tile.pixels[y * ST_W + x][2] += rgb[2];
-    splat_tile.dirty = true;
+    let index = pi.y as usize * (cropped_pixel_bounds.max.x - cropped_pixel_bounds.min.x) as usize
+        + pi.x as usize;
+    add_atomic_rgb(&splat_pixels[index], rgb);
 }
 
-/// Packet variant of `add_splat_into_tiles` -- takes a `SampledSpectrum`
+/// Packet variant of `add_splat_into_pixels` -- takes a `SampledSpectrum`
 /// directly. pbrt-v4 `Film::AddSplat(Point2f, SampledSpectrum, lambda)`
 /// pathway. Used by integrators that splat per-wavelength radiance
 /// (LightPathIntegrator, BDPT, etc.) without going through `Spectrum`.
-pub fn add_splat_packet_into_tiles(
-    splat_tiles: &[Arc<RwLock<SplatTile>>],
-    splat_size: Vector2i,
+pub fn add_splat_packet_into_pixels(
+    splat_pixels: &[AtomicRgb],
     cropped_pixel_bounds: Bounds2i,
     pixel_sensor: &PixelSensor,
     filter: &Filter,
@@ -338,14 +296,6 @@ pub fn add_splat_packet_into_tiles(
     );
     let splat_bounds = Bounds2i::new(&p0, &p1).intersect(&cropped_pixel_bounds);
 
-    struct SplatContribution {
-        tile_index: usize,
-        x: usize,
-        y: usize,
-        scale: Float,
-    }
-
-    let mut contributions = Vec::new();
     for pi in &splat_bounds {
         let d = Point2f::new(p.x - pi.x as Float - 0.5, p.y - pi.y as Float - 0.5);
         let wt = filter.evaluate(&d);
@@ -356,77 +306,13 @@ pub fn add_splat_packet_into_tiles(
             pi.x - cropped_pixel_bounds.min.x,
             pi.y - cropped_pixel_bounds.min.y,
         );
-        let tx = local.x as usize / ST_W;
-        let ty = local.y as usize / ST_W;
-        let tindex = ty * splat_size.x as usize + tx;
-        debug_assert!(tindex < splat_tiles.len());
-        contributions.push(SplatContribution {
-            tile_index: tindex,
-            x: local.x as usize - tx * ST_W,
-            y: local.y as usize - ty * ST_W,
-            scale: wt / filter_integral,
-        });
-    }
-    contributions.sort_by_key(|c| c.tile_index);
-
-    let mut i = 0;
-    while i < contributions.len() {
-        let tile_index = contributions[i].tile_index;
-        let mut splat_tile = splat_tiles[tile_index].write().unwrap();
-        while i < contributions.len() && contributions[i].tile_index == tile_index {
-            let c = &contributions[i];
-            let offset = c.y * ST_W + c.x;
-            splat_tile.pixels[offset][0] += c.scale * rgb[0];
-            splat_tile.pixels[offset][1] += c.scale * rgb[1];
-            splat_tile.pixels[offset][2] += c.scale * rgb[2];
-            i += 1;
-        }
-        splat_tile.dirty = true;
-    }
-}
-
-/// Flush any dirty splat tiles into the per-pixel splat buffer. Shared
-/// between Film variants.
-///
-/// `add_splat_packet_into_tiles` already applies the v4 filter footprint
-/// and `filterIntegral` normalization when queueing the per-tile splat.
-pub fn merge_splat_tiles(
-    splat_tiles: &[Arc<RwLock<SplatTile>>],
-    splat_pixels: &mut [[Float; 3]],
-    cropped_pixel_bounds: Bounds2i,
-    splat_scale: Float,
-) {
-    for tile in splat_tiles {
-        let mut tile = tile.write().unwrap();
-        if !tile.dirty {
-            continue;
-        }
-
-        let bounds = tile.pixel_bounds;
-        let x0 = bounds.min.x as usize;
-        let x1 = bounds.max.x as usize;
-        let y0 = bounds.min.y as usize;
-        let y1 = bounds.max.y as usize;
-        let cminx = cropped_pixel_bounds.min.x as usize;
-        let cminy = cropped_pixel_bounds.min.y as usize;
-        let cmaxx = cropped_pixel_bounds.max.x as usize;
-        let width = cmaxx - cminx;
-        for y in y0..y1 {
-            for x in x0..x1 {
-                let sx = x - x0;
-                let sy = y - y0;
-                let src_index = sy * ST_W + sx;
-                let dst_index = (x - cminx) + (y - cminy) * width;
-                for i in 0..3 {
-                    splat_pixels[dst_index][i] += splat_scale * tile.pixels[src_index][i];
-                }
-            }
-        }
-
-        for pixel in &mut tile.pixels {
-            *pixel = [0.0; 3];
-        }
-        tile.dirty = false;
+        let width = (cropped_pixel_bounds.max.x - cropped_pixel_bounds.min.x) as usize;
+        let index = local.y as usize * width + local.x as usize;
+        let scale = wt / filter_integral;
+        add_atomic_rgb(
+            &splat_pixels[index],
+            [scale * rgb[0], scale * rgb[1], scale * rgb[2]],
+        );
     }
 }
 

--- a/src/film/gbuffer_film.rs
+++ b/src/film/gbuffer_film.rs
@@ -1,6 +1,6 @@
 use super::film_base::{
-    add_splat_into_tiles, add_splat_packet_into_tiles, make_splat_tiles, merge_splat_tiles,
-    normalize_pixel, FilmBase, FilmBaseParameters,
+    add_splat_into_pixels, add_splat_packet_into_pixels, normalize_pixel, FilmBase,
+    FilmBaseParameters,
 };
 use super::film_tile::FilmTile;
 use super::splat_tile::*;
@@ -10,15 +10,16 @@ use crate::util::base::*;
 use crate::util::geometry::*;
 use crate::util::imageio::*;
 use crate::util::spectrum::*;
+use crate::util::AtomicDouble;
 
 use log::*;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::Mutex;
 
 /// Per-pixel storage for `GBufferFilm`. Mirrors pbrt-v4's
 /// `GBufferFilm::Pixel` (src/pbrt/film.h), where the RGB accumulator and
 /// the gbuffer fields share a single Pixel struct rather than being
 /// stored in two parallel buffers. The splat channel still lives in
-/// per-tile aggregation buffers for portability.
+/// per-pixel atomic splat accumulators matching pbrt-v4.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct GBufferPixel {
     pub rgb_sum: [Float; 3],
@@ -52,9 +53,8 @@ pub fn normalize_gbuffer_normal(sum: [Float; 3]) -> [Float; 3] {
 pub struct GBufferFilm {
     base: FilmBase,
     pixels: Mutex<Vec<GBufferPixel>>,
-    splat_pixels: Mutex<Vec<[Float; 3]>>,
-    splat_tiles: Vec<Arc<RwLock<SplatTile>>>,
-    splat_size: Vector2i,
+    splat_pixels: Vec<[AtomicDouble; 3]>,
+    splat_scale: AtomicDouble,
     scale: Float,
     max_sample_luminance: Float,
     gbuffer_coordinate_system: GBufferCoordinateSystem,
@@ -67,16 +67,14 @@ impl GBufferFilm {
         let max_sample_luminance = p.max_sample_luminance;
 
         let pixels = vec![GBufferPixel::zero(); pixel_bounds.area() as usize];
-        let splat_pixels = vec![[0.0; 3]; pixel_bounds.area() as usize];
-        let (splat_tiles, splat_size) = make_splat_tiles(&pixel_bounds);
+        let splat_pixels = new_atomic_rgb_buffer(pixel_bounds.area() as usize);
 
         let base = FilmBase::new(&p);
         Self {
             base,
             pixels: Mutex::new(pixels),
-            splat_pixels: Mutex::new(splat_pixels),
-            splat_tiles,
-            splat_size,
+            splat_pixels,
+            splat_scale: AtomicDouble::new(1.0),
             scale,
             max_sample_luminance,
             gbuffer_coordinate_system,
@@ -132,13 +130,8 @@ impl GBufferFilm {
     }
 
     pub fn merge_splats(&self, splat_scale: Float) {
-        let mut splat_pixels = self.splat_pixels.lock().unwrap();
-        merge_splat_tiles(
-            &self.splat_tiles,
-            &mut splat_pixels,
-            self.base.cropped_pixel_bounds(),
-            splat_scale,
-        );
+        self.splat_scale
+            .store(splat_scale as f64, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub fn add_splat(&mut self, p: &Vector2f, v: &Spectrum) {
@@ -168,9 +161,8 @@ impl GBufferFilm {
         v: &Spectrum,
         lambda: Option<&SampledWavelengths>,
     ) {
-        add_splat_into_tiles(
-            &self.splat_tiles,
-            self.splat_size,
+        add_splat_into_pixels(
+            &self.splat_pixels,
             self.base.cropped_pixel_bounds(),
             self.base.pixel_sensor_ref(),
             p,
@@ -180,12 +172,10 @@ impl GBufferFilm {
     }
 
     /// pbrt-v4 `Film::AddSplat(Point2f, SampledSpectrum, SampledWavelengths)`.
-    /// `&self` because all mutation flows through the per-tile RwLock
-    /// (see `RGBFilm::add_splat_packet`).
+    /// `&self` because the per-pixel splat accumulators are atomic.
     pub fn add_splat_packet(&self, p: &Vector2f, v: &SampledSpectrum, lambda: &SampledWavelengths) {
-        add_splat_packet_into_tiles(
-            &self.splat_tiles,
-            self.splat_size,
+        add_splat_packet_into_pixels(
+            &self.splat_pixels,
             self.base.cropped_pixel_bounds(),
             self.base.pixel_sensor_ref(),
             self.base.filter(),
@@ -214,10 +204,9 @@ impl GBufferFilm {
         for pixel in &mut *pixels {
             *pixel = GBufferPixel::zero();
         }
-        let mut splat_pixels = self.splat_pixels.lock().unwrap();
-        for pixel in &mut *splat_pixels {
-            *pixel = [0.0; 3];
-        }
+        clear_atomic_rgb_buffer(&self.splat_pixels);
+        self.splat_scale
+            .store(1.0, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub fn update_display(&self, bounds: &Bounds2i) {
@@ -244,7 +233,7 @@ impl GBufferFilm {
         let theight = ty1 - ty0;
         let mut buffer = vec![0.0; 3 * twidth * theight];
         let pixels = self.pixels.lock().unwrap();
-        let splat_pixels = self.splat_pixels.lock().unwrap();
+        let splat_scale = self.splat_scale.load(std::sync::atomic::Ordering::Relaxed) as Float;
         for y in ty0..ty1 {
             for x in tx0..tx1 {
                 let p = Vector2i::from((x as i32, y as i32));
@@ -252,8 +241,8 @@ impl GBufferFilm {
                 let c = normalize_pixel(
                     pixels[src_index].rgb_sum,
                     pixels[src_index].filter_weight_sum,
-                    &splat_pixels[src_index],
-                    scale,
+                    &load_atomic_rgb(&self.splat_pixels[src_index]),
+                    scale * splat_scale,
                 );
                 let by = y - ty0;
                 let bx = x - tx0;
@@ -284,7 +273,7 @@ impl GBufferFilm {
         let pixel_bounds = self.base.cropped_pixel_bounds();
         let area = pixel_bounds.area() as usize;
         let pixels = self.pixels.lock().unwrap();
-        let splat_pixels = self.splat_pixels.lock().unwrap();
+        let splat_scale = self.splat_scale.load(std::sync::atomic::Ordering::Relaxed) as Float;
 
         let mut r = vec![0.0f32; area];
         let mut g = vec![0.0f32; area];
@@ -311,8 +300,8 @@ impl GBufferFilm {
             let rgb = normalize_pixel(
                 pixels[i].rgb_sum,
                 pixels[i].filter_weight_sum,
-                &splat_pixels[i],
-                self.scale,
+                &load_atomic_rgb(&self.splat_pixels[i]),
+                self.scale * splat_scale,
             );
             r[i] = rgb[0] as f32;
             g[i] = rgb[1] as f32;
@@ -387,14 +376,14 @@ impl GBufferFilm {
         let pixel_bounds = self.base.cropped_pixel_bounds();
         let area = pixel_bounds.area() as usize;
         let pixels = self.pixels.lock().unwrap();
-        let splat_pixels = self.splat_pixels.lock().unwrap();
+        let splat_scale = self.splat_scale.load(std::sync::atomic::Ordering::Relaxed) as Float;
         let mut texels = Vec::with_capacity(area);
         for i in 0..area {
             let rgb = normalize_pixel(
                 pixels[i].rgb_sum,
                 pixels[i].filter_weight_sum,
-                &splat_pixels[i],
-                self.scale,
+                &load_atomic_rgb(&self.splat_pixels[i]),
+                self.scale * splat_scale,
             );
             texels.push(RGBSpectrum::new(rgb[0], rgb[1], rgb[2]));
         }

--- a/src/film/rgb_film.rs
+++ b/src/film/rgb_film.rs
@@ -1,6 +1,6 @@
 use super::film_base::{
-    add_splat_into_tiles, add_splat_packet_into_tiles, make_splat_tiles, merge_splat_tiles,
-    normalize_pixel, FilmBase, FilmBaseParameters,
+    add_splat_into_pixels, add_splat_packet_into_pixels, normalize_pixel, FilmBase,
+    FilmBaseParameters,
 };
 use super::film_tile::FilmTile;
 use super::splat_tile::*;
@@ -10,15 +10,15 @@ use crate::util::geometry::*;
 use crate::util::image::Image;
 use crate::util::imageio::*;
 use crate::util::spectrum::*;
+use crate::util::AtomicDouble;
 
 use log::*;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::Mutex;
 
 /// Per-pixel storage for `RGBFilm`. Mirrors pbrt-v4's
 /// `RGBFilm::Pixel { rgbSum[3], weightSum, rgbSplat[3] }` (see
-/// src/pbrt/film.h). The splat channel is held in a separate per-tile
-/// buffer (see [[feedback_atomic_float_tiling]]) instead of an
-/// `AtomicDouble` per-pixel, so it does not live inside this struct.
+/// src/pbrt/film.h). The splat channel is held in a separate per-pixel
+/// `AtomicDouble` buffer, matching pbrt-v4's `rgbSplat` storage.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct RGBPixel {
     pub rgb_sum: [Float; 3],
@@ -37,9 +37,8 @@ impl RGBPixel {
 pub struct RGBFilm {
     base: FilmBase,
     pixels: Mutex<Vec<RGBPixel>>,
-    splat_pixels: Mutex<Vec<[Float; 3]>>,
-    splat_tiles: Vec<Arc<RwLock<SplatTile>>>,
-    splat_size: Vector2i,
+    splat_pixels: Vec<[AtomicDouble; 3]>,
+    splat_scale: AtomicDouble,
     scale: Float,
     max_sample_luminance: Float,
 }
@@ -51,16 +50,14 @@ impl RGBFilm {
         let max_sample_luminance = p.max_sample_luminance;
 
         let pixels = vec![RGBPixel::zero(); pixel_bounds.area() as usize];
-        let splat_pixels = vec![[0.0; 3]; pixel_bounds.area() as usize];
-        let (splat_tiles, splat_size) = make_splat_tiles(&pixel_bounds);
+        let splat_pixels = new_atomic_rgb_buffer(pixel_bounds.area() as usize);
 
         let base = FilmBase::new(&p);
         Self {
             base,
             pixels: Mutex::new(pixels),
-            splat_pixels: Mutex::new(splat_pixels),
-            splat_tiles,
-            splat_size,
+            splat_pixels,
+            splat_scale: AtomicDouble::new(1.0),
             scale,
             max_sample_luminance,
         }
@@ -101,13 +98,8 @@ impl RGBFilm {
     }
 
     pub fn merge_splats(&self, splat_scale: Float) {
-        let mut splat_pixels = self.splat_pixels.lock().unwrap();
-        merge_splat_tiles(
-            &self.splat_tiles,
-            &mut splat_pixels,
-            self.base.cropped_pixel_bounds(),
-            splat_scale,
-        );
+        self.splat_scale
+            .store(splat_scale as f64, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub fn add_splat(&mut self, p: &Vector2f, v: &Spectrum) {
@@ -141,9 +133,8 @@ impl RGBFilm {
         v: &Spectrum,
         lambda: Option<&SampledWavelengths>,
     ) {
-        add_splat_into_tiles(
-            &self.splat_tiles,
-            self.splat_size,
+        add_splat_into_pixels(
+            &self.splat_pixels,
             self.base.cropped_pixel_bounds(),
             self.base.pixel_sensor_ref(),
             p,
@@ -154,9 +145,8 @@ impl RGBFilm {
 
     /// pbrt-v4 `Film::AddSplat(Point2f, SampledSpectrum, SampledWavelengths)`.
     pub fn add_splat_packet(&self, p: &Vector2f, v: &SampledSpectrum, lambda: &SampledWavelengths) {
-        add_splat_packet_into_tiles(
-            &self.splat_tiles,
-            self.splat_size,
+        add_splat_packet_into_pixels(
+            &self.splat_pixels,
             self.base.cropped_pixel_bounds(),
             self.base.pixel_sensor_ref(),
             self.base.filter(),
@@ -185,10 +175,9 @@ impl RGBFilm {
         for pixel in &mut *pixels {
             *pixel = RGBPixel::zero();
         }
-        let mut splat_pixels = self.splat_pixels.lock().unwrap();
-        for pixel in &mut *splat_pixels {
-            *pixel = [0.0; 3];
-        }
+        clear_atomic_rgb_buffer(&self.splat_pixels);
+        self.splat_scale
+            .store(1.0, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub fn update_display(&self, bounds: &Bounds2i) {
@@ -215,7 +204,7 @@ impl RGBFilm {
         let theight = ty1 - ty0;
         let mut buffer = vec![0.0; 3 * twidth * theight];
         let pixels = self.pixels.lock().unwrap();
-        let splat_pixels = self.splat_pixels.lock().unwrap();
+        let splat_scale = self.splat_scale.load(std::sync::atomic::Ordering::Relaxed) as Float;
         for y in ty0..ty1 {
             for x in tx0..tx1 {
                 let p = Vector2i::from((x as i32, y as i32));
@@ -223,8 +212,8 @@ impl RGBFilm {
                 let c = normalize_pixel(
                     pixels[src_index].rgb_sum,
                     pixels[src_index].filter_weight_sum,
-                    &splat_pixels[src_index],
-                    scale,
+                    &load_atomic_rgb(&self.splat_pixels[src_index]),
+                    scale * splat_scale,
                 );
                 let by = y - ty0;
                 let bx = x - tx0;
@@ -279,13 +268,13 @@ impl RGBFilm {
         let area = pixel_bounds.area() as usize;
         let mut rgb = vec![0.0; 3 * area];
         let pixels = self.pixels.lock().unwrap();
-        let splat_pixels = self.splat_pixels.lock().unwrap();
+        let splat_scale = self.splat_scale.load(std::sync::atomic::Ordering::Relaxed) as Float;
         for offset in 0..pixels.len() {
             let c = normalize_pixel(
                 pixels[offset].rgb_sum,
                 pixels[offset].filter_weight_sum,
-                &splat_pixels[offset],
-                self.scale,
+                &load_atomic_rgb(&self.splat_pixels[offset]),
+                self.scale * splat_scale,
             );
             rgb[3 * offset] = c[0];
             rgb[3 * offset + 1] = c[1];

--- a/src/film/spectral_film.rs
+++ b/src/film/spectral_film.rs
@@ -1,18 +1,18 @@
 use super::film_base::{
-    add_splat_into_tiles, make_splat_tiles, merge_splat_tiles, normalize_pixel, FilmBase,
+    add_splat_into_pixels, add_splat_packet_into_pixels, normalize_pixel, FilmBase,
     FilmBaseParameters,
 };
 use super::film_tile::{FilmTile, SpectralTileConfig};
 use super::splat_tile::*;
 use crate::displays::DisplayTile;
-use crate::film::film_base::add_splat_packet_into_tiles;
 use crate::util::base::*;
 use crate::util::geometry::*;
 use crate::util::imageio::*;
 use crate::util::spectrum::*;
+use crate::util::AtomicDouble;
 
 use log::*;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::Mutex;
 
 /// Default spectral range. Matches pbrt-v4 `SpectralFilm::Create` defaults
 /// (`src/pbrt/film.cpp`).
@@ -43,9 +43,8 @@ impl SpectralPixel {
 pub struct SpectralFilm {
     base: FilmBase,
     pixels: Mutex<Vec<SpectralPixel>>,
-    splat_pixels: Mutex<Vec<[Float; 3]>>,
-    splat_tiles: Vec<Arc<RwLock<SplatTile>>>,
-    splat_size: Vector2i,
+    splat_pixels: Vec<[AtomicDouble; 3]>,
+    splat_scale: AtomicDouble,
     scale: Float,
     max_sample_luminance: Float,
     lambda_min: Float,
@@ -77,16 +76,14 @@ impl SpectralFilm {
         let area = pixel_bounds.area() as usize;
         let pixels: Vec<SpectralPixel> =
             (0..area).map(|_| SpectralPixel::zero(n_buckets)).collect();
-        let splat_pixels = vec![[0.0; 3]; area];
-        let (splat_tiles, splat_size) = make_splat_tiles(&pixel_bounds);
+        let splat_pixels = new_atomic_rgb_buffer(area);
 
         let base = FilmBase::new(&p);
         Self {
             base,
             pixels: Mutex::new(pixels),
-            splat_pixels: Mutex::new(splat_pixels),
-            splat_tiles,
-            splat_size,
+            splat_pixels,
+            splat_scale: AtomicDouble::new(1.0),
             scale,
             max_sample_luminance,
             lambda_min,
@@ -182,13 +179,8 @@ impl SpectralFilm {
     }
 
     pub fn merge_splats(&self, splat_scale: Float) {
-        let mut splat_pixels = self.splat_pixels.lock().unwrap();
-        merge_splat_tiles(
-            &self.splat_tiles,
-            &mut splat_pixels,
-            self.base.cropped_pixel_bounds(),
-            splat_scale,
-        );
+        self.splat_scale
+            .store(splat_scale as f64, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub fn add_splat(&mut self, p: &Vector2f, v: &Spectrum) {
@@ -218,9 +210,8 @@ impl SpectralFilm {
         v: &Spectrum,
         lambda: Option<&SampledWavelengths>,
     ) {
-        add_splat_into_tiles(
-            &self.splat_tiles,
-            self.splat_size,
+        add_splat_into_pixels(
+            &self.splat_pixels,
             self.base.cropped_pixel_bounds(),
             self.base.pixel_sensor_ref(),
             p,
@@ -230,12 +221,10 @@ impl SpectralFilm {
     }
 
     /// pbrt-v4 `Film::AddSplat(Point2f, SampledSpectrum, SampledWavelengths)`.
-    /// `&self` because all mutation flows through the per-tile RwLock
-    /// (see `RGBFilm::add_splat_packet`).
+    /// `&self` because the per-pixel splat accumulators are atomic.
     pub fn add_splat_packet(&self, p: &Vector2f, v: &SampledSpectrum, lambda: &SampledWavelengths) {
-        add_splat_packet_into_tiles(
-            &self.splat_tiles,
-            self.splat_size,
+        add_splat_packet_into_pixels(
+            &self.splat_pixels,
             self.base.cropped_pixel_bounds(),
             self.base.pixel_sensor_ref(),
             self.base.filter(),
@@ -265,10 +254,9 @@ impl SpectralFilm {
         for pixel in &mut *pixels {
             *pixel = SpectralPixel::zero(n_buckets);
         }
-        let mut splat_pixels = self.splat_pixels.lock().unwrap();
-        for pixel in &mut *splat_pixels {
-            *pixel = [0.0; 3];
-        }
+        clear_atomic_rgb_buffer(&self.splat_pixels);
+        self.splat_scale
+            .store(1.0, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub fn update_display(&self, bounds: &Bounds2i) {
@@ -295,7 +283,7 @@ impl SpectralFilm {
         let theight = ty1 - ty0;
         let mut buffer = vec![0.0; 3 * twidth * theight];
         let pixels = self.pixels.lock().unwrap();
-        let splat_pixels = self.splat_pixels.lock().unwrap();
+        let splat_scale = self.splat_scale.load(std::sync::atomic::Ordering::Relaxed) as Float;
         for y in ty0..ty1 {
             for x in tx0..tx1 {
                 let p = Vector2i::from((x as i32, y as i32));
@@ -303,8 +291,8 @@ impl SpectralFilm {
                 let c = normalize_pixel(
                     pixels[src_index].rgb_sum,
                     pixels[src_index].filter_weight_sum,
-                    &splat_pixels[src_index],
-                    scale,
+                    &load_atomic_rgb(&self.splat_pixels[src_index]),
+                    scale * splat_scale,
                 );
                 let by = y - ty0;
                 let bx = x - tx0;
@@ -331,7 +319,7 @@ impl SpectralFilm {
         let area = pixel_bounds.area() as usize;
         let n_buckets = self.n_buckets;
         let pixels = self.pixels.lock().unwrap();
-        let splat_pixels = self.splat_pixels.lock().unwrap();
+        let splat_scale = self.splat_scale.load(std::sync::atomic::Ordering::Relaxed) as Float;
 
         let mut r = vec![0.0f32; area];
         let mut g = vec![0.0f32; area];
@@ -343,8 +331,8 @@ impl SpectralFilm {
             let c = normalize_pixel(
                 pixels[offset].rgb_sum,
                 pixels[offset].filter_weight_sum,
-                &splat_pixels[offset],
-                self.scale,
+                &load_atomic_rgb(&self.splat_pixels[offset]),
+                self.scale * splat_scale,
             );
             r[offset] = c[0] as f32;
             g[offset] = c[1] as f32;
@@ -405,14 +393,14 @@ impl SpectralFilm {
         let pixel_bounds = self.base.cropped_pixel_bounds();
         let area = pixel_bounds.area() as usize;
         let pixels = self.pixels.lock().unwrap();
-        let splat_pixels = self.splat_pixels.lock().unwrap();
+        let splat_scale = self.splat_scale.load(std::sync::atomic::Ordering::Relaxed) as Float;
         let mut texels = Vec::with_capacity(area);
         for i in 0..area {
             let rgb = normalize_pixel(
                 pixels[i].rgb_sum,
                 pixels[i].filter_weight_sum,
-                &splat_pixels[i],
-                self.scale,
+                &load_atomic_rgb(&self.splat_pixels[i]),
+                self.scale * splat_scale,
             );
             texels.push(RGBSpectrum::new(rgb[0], rgb[1], rgb[2]));
         }

--- a/src/film/splat_tile.rs
+++ b/src/film/splat_tile.rs
@@ -1,32 +1,31 @@
-use crate::util::base::*;
-use crate::util::geometry::*;
+use crate::util::atomic_double::AtomicDouble;
+use crate::util::base::Float;
+use std::sync::atomic::Ordering;
 
-pub const ST_W: usize = 16;
-pub const ST_SZ: usize = ST_W * ST_W;
+pub type AtomicRgb = [AtomicDouble; 3];
 
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub struct SplatTile {
-    pub dirty: bool,
-    pub pixel_bounds: Bounds2i,
-    pub pixels: [[Float; 3]; ST_SZ],
+pub fn new_atomic_rgb() -> AtomicRgb {
+    std::array::from_fn(|_| AtomicDouble::default())
 }
 
-impl SplatTile {
-    pub fn new(pixel_bounds: &Bounds2i) -> Self {
-        SplatTile {
-            dirty: true,
-            pixel_bounds: *pixel_bounds,
-            pixels: [[0.0; 3]; ST_SZ],
+pub fn new_atomic_rgb_buffer(pixel_count: usize) -> Vec<AtomicRgb> {
+    (0..pixel_count).map(|_| new_atomic_rgb()).collect()
+}
+
+pub fn clear_atomic_rgb_buffer(pixels: &[AtomicRgb]) {
+    for pixel in pixels {
+        for channel in pixel {
+            channel.store(0.0, Ordering::Relaxed);
         }
     }
 }
 
-impl Default for SplatTile {
-    fn default() -> Self {
-        SplatTile {
-            dirty: false,
-            pixel_bounds: Bounds2i::default(),
-            pixels: [[0.0; 3]; ST_SZ],
-        }
+pub fn load_atomic_rgb(pixel: &AtomicRgb) -> [Float; 3] {
+    std::array::from_fn(|channel| pixel[channel].load(Ordering::Relaxed) as Float)
+}
+
+pub fn add_atomic_rgb(pixel: &AtomicRgb, value: [Float; 3]) {
+    for channel in 0..3 {
+        pixel[channel].fetch_add(value[channel] as f64, Ordering::Relaxed);
     }
 }

--- a/src/util/atomic_double.rs
+++ b/src/util/atomic_double.rs
@@ -1,0 +1,68 @@
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// An atomically updated `f64` implemented with its IEEE-754 bit pattern.
+///
+/// Stable Rust does not provide `AtomicF64`, so the value is stored in an
+/// `AtomicU64` and updated with a compare-and-exchange loop.
+pub struct AtomicDouble {
+    bits: AtomicU64,
+}
+
+impl AtomicDouble {
+    pub fn new(value: f64) -> Self {
+        Self {
+            bits: AtomicU64::new(value.to_bits()),
+        }
+    }
+
+    pub fn load(&self, ordering: Ordering) -> f64 {
+        f64::from_bits(self.bits.load(ordering))
+    }
+
+    pub fn store(&self, value: f64, ordering: Ordering) {
+        self.bits.store(value.to_bits(), ordering);
+    }
+
+    /// Atomically adds `value` and returns the previous value.
+    pub fn fetch_add(&self, value: f64, ordering: Ordering) -> f64 {
+        let mut old_bits = self.bits.load(ordering);
+        loop {
+            let old_value = f64::from_bits(old_bits);
+            let new_bits = (old_value + value).to_bits();
+            match self.bits.compare_exchange_weak(
+                old_bits,
+                new_bits,
+                ordering,
+                compare_exchange_failure_ordering(ordering),
+            ) {
+                Ok(_) => return old_value,
+                Err(actual_bits) => old_bits = actual_bits,
+            }
+        }
+    }
+}
+
+impl Default for AtomicDouble {
+    fn default() -> Self {
+        Self::new(0.0)
+    }
+}
+
+impl fmt::Debug for AtomicDouble {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AtomicDouble")
+            .field("value", &self.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+fn compare_exchange_failure_ordering(ordering: Ordering) -> Ordering {
+    match ordering {
+        Ordering::Relaxed | Ordering::Release => Ordering::Relaxed,
+        Ordering::Acquire | Ordering::AcqRel => Ordering::Acquire,
+        Ordering::SeqCst => Ordering::SeqCst,
+        _ => unreachable!(),
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,6 +5,7 @@
 pub mod base;
 
 // Math and geometry
+pub mod atomic_double;
 pub mod efloat;
 pub mod geometry;
 pub mod interpolation;
@@ -38,6 +39,7 @@ pub mod misc;
 pub mod tensor;
 
 // Re-exports for convenience
+pub use atomic_double::*;
 pub use base::*;
 pub use distribution::*;
 pub use efloat::*;

--- a/tests/atomic_double.rs
+++ b/tests/atomic_double.rs
@@ -1,0 +1,36 @@
+use pbrt_r4::util::AtomicDouble;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::thread;
+
+#[test]
+fn atomic_double_preserves_value_bits() {
+    let value = AtomicDouble::new(-3.25);
+    assert_eq!(value.load(Ordering::Relaxed), -3.25);
+
+    value.store(1.5, Ordering::Relaxed);
+    assert_eq!(value.load(Ordering::Relaxed), 1.5);
+}
+
+#[test]
+fn atomic_double_fetch_add_is_thread_safe() {
+    const THREADS: usize = 8;
+    const INCREMENTS: usize = 10_000;
+    let value = Arc::new(AtomicDouble::default());
+    let mut workers = Vec::with_capacity(THREADS);
+
+    for _ in 0..THREADS {
+        let value = Arc::clone(&value);
+        workers.push(thread::spawn(move || {
+            for _ in 0..INCREMENTS {
+                value.fetch_add(1.0, Ordering::Relaxed);
+            }
+        }));
+    }
+
+    for worker in workers {
+        worker.join().unwrap();
+    }
+
+    assert_eq!(value.load(Ordering::Relaxed), (THREADS * INCREMENTS) as f64);
+}

--- a/tests/bdpt_splat_scale.rs
+++ b/tests/bdpt_splat_scale.rs
@@ -1,0 +1,33 @@
+use pbrt_r4::base::film::Film;
+use pbrt_r4::base::filter::Filter;
+use pbrt_r4::cpu::integrators::bdpt::compute_light_tracing_splat_scale;
+use pbrt_r4::paramdict::ParameterDictionary;
+
+fn create_film(params: &ParameterDictionary) -> std::sync::Arc<std::sync::RwLock<Film>> {
+    let filter =
+        Filter::create("box", &ParameterDictionary::new()).expect("box filter should create");
+    Film::create("rgb", params, &filter).expect("film should create")
+}
+
+#[test]
+fn light_tracing_splat_scale_is_one_without_crop() {
+    let mut params = ParameterDictionary::new();
+    params.add_int("xresolution", 400);
+    params.add_int("yresolution", 200);
+    let film = create_film(&params);
+    let film = film.read().unwrap();
+
+    assert_eq!(compute_light_tracing_splat_scale(&film), 1.0);
+}
+
+#[test]
+fn light_tracing_splat_scale_uses_full_to_cropped_area_ratio() {
+    let mut params = ParameterDictionary::new();
+    params.add_int("xresolution", 400);
+    params.add_int("yresolution", 200);
+    params.add_floats("cropwindow", &[0.25, 0.75, 0.25, 0.75]);
+    let film = create_film(&params);
+    let film = film.read().unwrap();
+
+    assert_eq!(compute_light_tracing_splat_scale(&film), 4.0);
+}

--- a/tests/film_base.rs
+++ b/tests/film_base.rs
@@ -1,8 +1,9 @@
 use pbrt_r4::base::filter::{Filter, GaussianFilter, TriangleFilter};
 use pbrt_r4::film::film_base::{
-    add_splat_packet_into_tiles, make_splat_tiles, normalize_pixel, FilmBase, FilmBaseParameters,
+    add_splat_packet_into_pixels, normalize_pixel, FilmBase, FilmBaseParameters,
 };
 use pbrt_r4::film::pixel_sensor::PixelSensor;
+use pbrt_r4::film::splat_tile::{load_atomic_rgb, new_atomic_rgb_buffer};
 use pbrt_r4::util::base::{Float, Point2i};
 use pbrt_r4::util::geometry::{Bounds2i, Vector2};
 use pbrt_r4::util::spectrum::{SampledSpectrum, SampledWavelengths};
@@ -49,7 +50,7 @@ fn normalize_pixel_preserves_negative_splats_after_scaling() {
 #[test]
 fn add_splat_packet_filters_footprint_and_clamps_sensor_rgb() {
     let bounds = Bounds2i::new(&Point2i::new(0, 0), &Point2i::new(4, 4));
-    let (splat_tiles, splat_size) = make_splat_tiles(&bounds);
+    let splat_pixels = new_atomic_rgb_buffer(bounds.area() as usize);
     let sensor = PixelSensor::create("cie1931", 100.0, 0.0).unwrap();
     let filter = Filter::Triangle(TriangleFilter::new(&Vector2f::new(1.0, 1.0)));
     let lambda = SampledWavelengths::sample_visible(0.37);
@@ -58,9 +59,8 @@ fn add_splat_packet_filters_footprint_and_clamps_sensor_rgb() {
     let max_component = sensor_rgb[0].max(sensor_rgb[1]).max(sensor_rgb[2]);
     let max_sample_luminance = max_component * 0.5;
 
-    add_splat_packet_into_tiles(
-        &splat_tiles,
-        splat_size,
+    add_splat_packet_into_pixels(
+        &splat_pixels,
         bounds,
         &sensor,
         &filter,
@@ -70,10 +70,8 @@ fn add_splat_packet_filters_footprint_and_clamps_sensor_rgb() {
         &lambda,
     );
 
-    let tile = splat_tiles[0].read().unwrap();
-    assert!(tile
-        .pixels
+    assert!(splat_pixels
         .iter()
-        .any(|pixel| pixel.iter().any(|value| *value != 0.0)));
-    assert_eq!(tile.pixels[2 * 4 + 2], [0.0, 0.0, 0.0]);
+        .any(|pixel| load_atomic_rgb(pixel).iter().any(|value| *value != 0.0)));
+    assert_eq!(load_atomic_rgb(&splat_pixels[2 * 4 + 2]), [0.0, 0.0, 0.0]);
 }


### PR DESCRIPTION
## Summary

- Reduce BDPT/MLT path-side allocation overhead and remove fixed MLT display rounds.
- Add stable-Rust `AtomicDouble` backed by `AtomicU64` and a compare-exchange loop.
- Replace per-tile splat locks, temporary contribution vectors, sorting, and flushes with per-pixel atomic RGB accumulators.
- Apply the change consistently to RGBFilm, GBufferFilm, and SpectralFilm.

## Performance

MLT Cornell caustic benchmark: 200x200, 10,000 bootstrap samples, 256 chains, 64 mutations/pixel, 16 threads.

- r4 before Film change: approximately 1.62s
- r4 with per-pixel AtomicDouble splats: approximately 1.32s
- pbrt-v4: approximately 1.14s

The r4 wall time improved by approximately 19%, and voluntary context switches decreased substantially.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test --test film_base --test atomic_double --test bdpt_splat_scale`
- `cargo build --release --bin pbrt-r4`