### PR TITLE
perf(media): cache validated NanoVDB tree metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ half = "=2.2.1"
 image = "=0.24.5"
 indicatif = "=0.17.3"
 log = "=0.4.20"
-nanovdb-rs = "=0.0.5"
+nanovdb-rs = { version = "=0.0.5", path = "../nanovdb-rs" }
 nom = "=7.1.1"
 ply-rs = "=0.1.3"
 qoi = "=0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ half = "=2.2.1"
 image = "=0.24.5"
 indicatif = "=0.17.3"
 log = "=0.4.20"
-nanovdb-rs = { version = "=0.0.5", path = "../nanovdb-rs" }
+nanovdb-rs = { version = "=0.0.5", git = "https://github.com/ototoi/nanovdb-rs.git", rev = "45f860b" }
 nom = "=7.1.1"
 ply-rs = "=0.1.3"
 qoi = "=0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ half = "=2.2.1"
 image = "=0.24.5"
 indicatif = "=0.17.3"
 log = "=0.4.20"
-nanovdb-rs = { version = "=0.0.5", git = "https://github.com/ototoi/nanovdb-rs.git", rev = "45f860b" }
+nanovdb-rs = "=0.0.7"
 nom = "=7.1.1"
 ply-rs = "=0.1.3"
 qoi = "=0.4.1"

--- a/src/media/nanovdb.rs
+++ b/src/media/nanovdb.rs
@@ -28,7 +28,9 @@ use crate::util::transform::*;
 use rayon::prelude::*;
 use std::sync::Arc;
 
-use nanovdb_rs::{create_sampler1, Grid, GridType, NvdbFile, ReadAccessor, TreeData};
+use nanovdb_rs::{
+    create_sampler1, Grid, GridType, NvdbFile, ReadAccessor, TreeData, ValidatedFloatTree,
+};
 
 /// Select a named `Float` grid from an already-open `.nvdb` file for
 /// `NanoVDBMedium`, keeping the sparse NanoVDB tree alive.
@@ -211,6 +213,7 @@ struct NanoVDBFloatGrid {
     world_to_index: Transform,
     tree_data: TreeData,
     background: f32,
+    validated_tree: Option<ValidatedFloatTree>,
 }
 
 impl NanoVDBFloatGrid {
@@ -221,18 +224,32 @@ impl NanoVDBFloatGrid {
             world_to_index,
             tree_data,
             background,
+            validated_tree: ValidatedFloatTree::new(grid.raw_bytes()),
         })
     }
 
     fn sample(&self, grid: &NanoVDBBuffer, p: &Point3f) -> Float {
         let mut accessor =
             ReadAccessor::with_tree_data(grid.raw_bytes(), self.tree_data, self.background);
-        self.sample_with_accessor(&mut accessor, p)
+        self.sample_with_accessor(&mut accessor, grid.raw_bytes(), p)
     }
 
-    fn sample_with_accessor(&self, accessor: &mut ReadAccessor<'_>, p: &Point3f) -> Float {
+    fn sample_with_accessor(
+        &self,
+        accessor: &mut ReadAccessor<'_>,
+        bytes: &[u8],
+        p: &Point3f,
+    ) -> Float {
         let p_index = self.world_to_index.transform_point(p);
         let p_index = [p_index.x, p_index.y, p_index.z];
+        if let Some(validated_tree) = self.validated_tree {
+            if let Some(value) = validated_tree.sample(
+                bytes,
+                [p_index[0] as f32, p_index[1] as f32, p_index[2] as f32],
+            ) {
+                return NanoVDBMedium::sanitize_density_value(value as Float);
+            }
+        }
         NanoVDBMedium::sanitize_density_value(create_sampler1(accessor).sample_f32([
             p_index[0] as f32,
             p_index[1] as f32,
@@ -485,7 +502,8 @@ impl NanoVDBMedium {
     }
 
     fn density_with_accessor(&self, accessor: &mut ReadAccessor<'_>, p: &Point3f) -> Float {
-        self.density_float_grid.sample_with_accessor(accessor, p)
+        self.density_float_grid
+            .sample_with_accessor(accessor, self.density_grid.raw_bytes(), p)
     }
 
     #[allow(dead_code)]

--- a/src/media/nanovdb.rs
+++ b/src/media/nanovdb.rs
@@ -29,7 +29,7 @@ use rayon::prelude::*;
 use std::sync::Arc;
 
 use nanovdb_rs::{
-    create_sampler1, Grid, GridType, NvdbFile, ReadAccessor, TreeData, ValidatedFloatTree,
+    create_sampler1, Grid, GridType, NvdbFile, ReadAccessor, TreeData, ValidatedFloatTreeCache,
 };
 
 /// Select a named `Float` grid from an already-open `.nvdb` file for
@@ -213,7 +213,7 @@ struct NanoVDBFloatGrid {
     world_to_index: Transform,
     tree_data: TreeData,
     background: f32,
-    validated_tree: Option<ValidatedFloatTree>,
+    validated_tree: Option<ValidatedFloatTreeCache>,
 }
 
 impl NanoVDBFloatGrid {
@@ -224,7 +224,7 @@ impl NanoVDBFloatGrid {
             world_to_index,
             tree_data,
             background,
-            validated_tree: ValidatedFloatTree::new(grid.raw_bytes()),
+            validated_tree: ValidatedFloatTreeCache::new(grid.raw_bytes()),
         })
     }
 


### PR DESCRIPTION
Summary:
- Update pbrt-r4 to nanovdb-rs 0.0.7 from crates.io.
- Cache validated NanoVDB float-tree metadata when loading the grid.
- Reuse the cache during sampling instead of repeating tree validation.

Validation:
- cargo fmt --all
- cargo check --locked
- cargo test --locked --test medium_create --test nanovdb2pbrt
- cargo build --release
- bunny-cloud_tiny release render completed successfully.

Benchmark note:
- Under the measured 1-thread/4-spp conditions, bunny-cloud_tiny was 2.76 s on r4 vs 1.64 s on pbrt-v4 (1.68x).
- This is an improvement over the earlier recorded 1.94x ratio, although the historical conditions were not identical.