### PR TITLE
Fix missing mesh attributes in WebGPU path

### DIFF
--- a/src/gpu/ir/flat/flatten.rs
+++ b/src/gpu/ir/flat/flatten.rs
@@ -3,8 +3,8 @@ use super::{
     RenderSettings, Scene, Transform, Vertex, Viewport,
 };
 use crate::gpu::ir::node::{
-    Component, Integrator as NodeIntegrator, Light as NodeLight, Material as NodeMaterial, NodeRef,
-    Sampler as NodeSampler, Shape, TriangleMeshShape,
+    complete_triangle_attributes, Component, Integrator as NodeIntegrator, Light as NodeLight,
+    Material as NodeMaterial, NodeRef, Sampler as NodeSampler, Shape, TriangleMeshShape,
 };
 use crate::paramdict::ParameterDictionary;
 use crate::util::error::PbrtError;
@@ -165,6 +165,7 @@ fn flatten_node_ref(
                             )));
                         }
                     };
+                    let shape = complete_triangle_attributes(shape, &node.name)?;
                     let material = material.clone().ok_or_else(|| {
                         PbrtError::error(&format!(
                             "Shape node \"{}\" has no Material component.",

--- a/src/gpu/ir/node/shape.rs
+++ b/src/gpu/ir/node/shape.rs
@@ -1,7 +1,6 @@
 use super::types::Vec2f;
 use super::types::Vec3f;
 use crate::paramdict::ParameterDictionary;
-use crate::util::base::Float;
 use crate::util::error::PbrtError;
 use crate::util::mesh::TriQuadMesh;
 
@@ -69,10 +68,301 @@ pub fn triangle_mesh_from_params(
     Ok(Some(TriangleMeshShape {
         positions,
         indices,
-        normals: node_vec3_attribute(params.get_points("N"), vertex_count),
-        tangents: node_vec3_attribute(params.get_points("S"), vertex_count),
-        uvs: node_vec2_attribute(params.get_points("uv"), vertex_count),
+        normals: node_vec3_attribute(params, "N", vertex_count)?,
+        tangents: node_vec3_attribute(params, "S", vertex_count)?,
+        uvs: node_vec2_attribute(params, "uv", vertex_count)?,
     }))
+}
+
+/// Completes the attributes required by the flattened GPU mesh contract.
+///
+/// This intentionally runs before Flat IR construction.  In particular, a
+/// mesh without normals is expanded to triangle corners so that a shared
+/// vertex cannot accidentally turn flat shading into smooth shading.
+pub fn complete_triangle_attributes(
+    shape: TriangleMeshShape,
+    node_name: &str,
+) -> Result<TriangleMeshShape, PbrtError> {
+    let vertex_count = shape.positions.len();
+    if vertex_count == 0 || shape.indices.is_empty() || shape.indices.len() % 3 != 0 {
+        return Err(PbrtError::error(&format!(
+            "Shape node \"{}\" has no complete triangle mesh.",
+            node_name
+        )));
+    }
+    if !shape
+        .positions
+        .iter()
+        .all(|position| position.0.iter().all(|value| value.is_finite()))
+    {
+        return Err(PbrtError::error(&format!(
+            "Shape node \"{}\" contains a non-finite position.",
+            node_name
+        )));
+    }
+    for &index in &shape.indices {
+        if index as usize >= vertex_count {
+            return Err(PbrtError::error(&format!(
+                "Shape node \"{}\" contains an out-of-range vertex index.",
+                node_name
+            )));
+        }
+    }
+    validate_node_attribute_len(node_name, shape.normals.as_deref(), vertex_count, "normal")?;
+    validate_node_attribute_len(
+        node_name,
+        shape.tangents.as_deref(),
+        vertex_count,
+        "tangent",
+    )?;
+    validate_node_attribute_len(node_name, shape.uvs.as_deref(), vertex_count, "UV")?;
+
+    let uvs = shape
+        .uvs
+        .unwrap_or_else(|| generate_planar_uvs(&shape.positions));
+    if !uvs
+        .iter()
+        .all(|uv| uv.0.iter().all(|value| value.is_finite()))
+    {
+        return Err(PbrtError::error(&format!(
+            "Shape node \"{}\" contains a non-finite UV.",
+            node_name
+        )));
+    }
+
+    let source_tangents = shape.tangents;
+    if let Some(tangents) = source_tangents.as_deref() {
+        if !tangents.iter().all(|tangent| {
+            tangent.0.iter().all(|value| value.is_finite()) && length_squared(tangent.0) > 0.0
+        }) {
+            return Err(PbrtError::error(&format!(
+                "Shape node \"{}\" contains an invalid tangent.",
+                node_name
+            )));
+        }
+    }
+    if shape.normals.is_none() {
+        return expand_flat_mesh(
+            shape.positions,
+            shape.indices,
+            uvs,
+            source_tangents,
+            node_name,
+        );
+    }
+
+    let normals = shape.normals.unwrap();
+    if !normals.iter().all(|normal| {
+        normal.0.iter().all(|value| value.is_finite()) && length_squared(normal.0) > 0.0
+    }) {
+        return Err(PbrtError::error(&format!(
+            "Shape node \"{}\" contains an invalid normal.",
+            node_name
+        )));
+    }
+    let tangents = source_tangents
+        .unwrap_or_else(|| generate_tangents(&shape.positions, &shape.indices, &normals, &uvs));
+    if !tangents.iter().all(|tangent| {
+        tangent.0.iter().all(|value| value.is_finite()) && length_squared(tangent.0) > 0.0
+    }) {
+        return Err(PbrtError::error(&format!(
+            "Shape node \"{}\" contains an invalid tangent.",
+            node_name
+        )));
+    }
+    Ok(TriangleMeshShape {
+        positions: shape.positions,
+        indices: shape.indices,
+        normals: Some(normals),
+        tangents: Some(tangents),
+        uvs: Some(uvs),
+    })
+}
+
+fn generate_planar_uvs(positions: &[Vec3f]) -> Vec<Vec2f> {
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for position in positions {
+        for axis in 0..3 {
+            min[axis] = min[axis].min(position.0[axis]);
+            max[axis] = max[axis].max(position.0[axis]);
+        }
+    }
+    let extent = [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
+    let drop_axis = if extent[0] <= extent[1] && extent[0] <= extent[2] {
+        0
+    } else if extent[1] <= extent[2] {
+        1
+    } else {
+        2
+    };
+    let axes = match drop_axis {
+        0 => [1, 2],
+        1 => [0, 2],
+        _ => [0, 1],
+    };
+    positions
+        .iter()
+        .map(|position| {
+            let coordinate = |axis: usize| {
+                if extent[axis] > 0.0 {
+                    (position.0[axis] - min[axis]) / extent[axis]
+                } else {
+                    0.0
+                }
+            };
+            Vec2f([coordinate(axes[0]), coordinate(axes[1])])
+        })
+        .collect()
+}
+
+fn expand_flat_mesh(
+    positions: Vec<Vec3f>,
+    indices: Vec<u32>,
+    uvs: Vec<Vec2f>,
+    source_tangents: Option<Vec<Vec3f>>,
+    node_name: &str,
+) -> Result<TriangleMeshShape, PbrtError> {
+    let mut expanded_positions = Vec::with_capacity(indices.len());
+    let mut expanded_normals = Vec::with_capacity(indices.len());
+    let mut expanded_tangents = Vec::with_capacity(indices.len());
+    let mut expanded_uvs = Vec::with_capacity(indices.len());
+    let mut expanded_indices = Vec::with_capacity(indices.len());
+    for triangle in indices.chunks_exact(3) {
+        let p = [
+            positions[triangle[0] as usize],
+            positions[triangle[1] as usize],
+            positions[triangle[2] as usize],
+        ];
+        let uv = [
+            uvs[triangle[0] as usize],
+            uvs[triangle[1] as usize],
+            uvs[triangle[2] as usize],
+        ];
+        let normal = cross(sub(p[1].0, p[0].0), sub(p[2].0, p[0].0));
+        if !normal.iter().all(|value| value.is_finite()) || length_squared(normal) == 0.0 {
+            return Err(PbrtError::error(&format!(
+                "Shape node \"{}\" contains a zero-area triangle.",
+                node_name
+            )));
+        }
+        let normal = normalize(normal);
+        let generated_tangent = triangle_tangent(p, uv, normal);
+        for corner in 0..3 {
+            expanded_positions.push(p[corner]);
+            expanded_normals.push(Vec3f(normal));
+            expanded_tangents.push(
+                source_tangents
+                    .as_ref()
+                    .map(|tangents| tangents[triangle[corner] as usize])
+                    .unwrap_or(Vec3f(generated_tangent)),
+            );
+            expanded_uvs.push(uv[corner]);
+            expanded_indices.push((expanded_indices.len()) as u32);
+        }
+    }
+    Ok(TriangleMeshShape {
+        positions: expanded_positions,
+        indices: expanded_indices,
+        normals: Some(expanded_normals),
+        tangents: Some(expanded_tangents),
+        uvs: Some(expanded_uvs),
+    })
+}
+
+fn generate_tangents(
+    positions: &[Vec3f],
+    indices: &[u32],
+    normals: &[Vec3f],
+    uvs: &[Vec2f],
+) -> Vec<Vec3f> {
+    let mut tangents = vec![[0.0; 3]; positions.len()];
+    for triangle in indices.chunks_exact(3) {
+        let i = [
+            triangle[0] as usize,
+            triangle[1] as usize,
+            triangle[2] as usize,
+        ];
+        let tangent = triangle_tangent(
+            [positions[i[0]], positions[i[1]], positions[i[2]]],
+            [uvs[i[0]], uvs[i[1]], uvs[i[2]]],
+            normalize(normals[i[0]].0),
+        );
+        for index in i {
+            tangents[index] = add(tangents[index], tangent);
+        }
+    }
+    tangents
+        .into_iter()
+        .zip(normals)
+        .map(|(tangent, normal)| {
+            let tangent = sub(tangent, scale(normalize(normal.0), dot(tangent, normal.0)));
+            Vec3f(if length_squared(tangent) > 0.0 {
+                normalize(tangent)
+            } else {
+                coordinate_tangent(normalize(normal.0))
+            })
+        })
+        .collect()
+}
+
+fn triangle_tangent(p: [Vec3f; 3], uv: [Vec2f; 3], normal: [f32; 3]) -> [f32; 3] {
+    let e1 = sub(p[1].0, p[0].0);
+    let e2 = sub(p[2].0, p[0].0);
+    let du1 = uv[1].0[0] - uv[0].0[0];
+    let dv1 = uv[1].0[1] - uv[0].0[1];
+    let du2 = uv[2].0[0] - uv[0].0[0];
+    let dv2 = uv[2].0[1] - uv[0].0[1];
+    let determinant = du1 * dv2 - dv1 * du2;
+    if determinant.abs() > 1e-9 {
+        normalize(scale(
+            sub(scale(e1, dv2), scale(e2, dv1)),
+            1.0 / determinant,
+        ))
+    } else {
+        coordinate_tangent(normal)
+    }
+}
+
+fn coordinate_tangent(normal: [f32; 3]) -> [f32; 3] {
+    if normal[0].abs() > 0.1 {
+        normalize(cross([0.0, 1.0, 0.0], normal))
+    } else {
+        normalize(cross([1.0, 0.0, 0.0], normal))
+    }
+}
+
+fn add(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+}
+
+fn sub(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+fn scale(a: [f32; 3], s: f32) -> [f32; 3] {
+    [a[0] * s, a[1] * s, a[2] * s]
+}
+
+fn dot(a: [f32; 3], b: [f32; 3]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn length_squared(a: [f32; 3]) -> f32 {
+    dot(a, a)
+}
+
+fn normalize(a: [f32; 3]) -> [f32; 3] {
+    let length = length_squared(a).sqrt();
+    scale(a, 1.0 / length)
 }
 
 fn tri_quad_mesh_to_node_mesh(mesh: &TriQuadMesh) -> Option<TriangleMeshShape> {
@@ -113,26 +403,86 @@ fn tri_quad_mesh_to_node_mesh(mesh: &TriQuadMesh) -> Option<TriangleMeshShape> {
     })
 }
 
-fn node_vec3_attribute(values: Vec<Float>, vertex_count: usize) -> Option<Vec<Vec3f>> {
-    if values.is_empty() || values.len() != vertex_count * 3 {
-        return None;
+fn node_vec3_attribute(
+    params: &ParameterDictionary,
+    key: &str,
+    vertex_count: usize,
+) -> Result<Option<Vec<Vec3f>>, PbrtError> {
+    let values = params.get_points(key);
+    if values.is_empty() {
+        if params.has_parameter(key) {
+            return Err(PbrtError::error(&format!(
+                "Mesh attribute \"{}\" must contain {} values.",
+                key,
+                vertex_count * 3
+            )));
+        }
+        return Ok(None);
     }
-    Some(
+    if values.len() != vertex_count * 3 {
+        return Err(PbrtError::error(&format!(
+            "Mesh attribute \"{}\" must contain {} values, got {}.",
+            key,
+            vertex_count * 3,
+            values.len()
+        )));
+    }
+    Ok(Some(
         values
             .chunks_exact(3)
             .map(|value| Vec3f([value[0] as f32, value[1] as f32, value[2] as f32]))
             .collect(),
-    )
+    ))
 }
 
-fn node_vec2_attribute(values: Vec<Float>, vertex_count: usize) -> Option<Vec<Vec2f>> {
-    if values.is_empty() || values.len() != vertex_count * 2 {
-        return None;
+fn node_vec2_attribute(
+    params: &ParameterDictionary,
+    key: &str,
+    vertex_count: usize,
+) -> Result<Option<Vec<Vec2f>>, PbrtError> {
+    let values = params.get_points(key);
+    if values.is_empty() {
+        if params.has_parameter(key) {
+            return Err(PbrtError::error(&format!(
+                "Mesh attribute \"{}\" must contain {} values.",
+                key,
+                vertex_count * 2
+            )));
+        }
+        return Ok(None);
     }
-    Some(
+    if values.len() != vertex_count * 2 {
+        return Err(PbrtError::error(&format!(
+            "Mesh attribute \"{}\" must contain {} values, got {}.",
+            key,
+            vertex_count * 2,
+            values.len()
+        )));
+    }
+    Ok(Some(
         values
             .chunks_exact(2)
             .map(|value| Vec2f([value[0] as f32, value[1] as f32]))
             .collect(),
-    )
+    ))
+}
+
+fn validate_node_attribute_len<T>(
+    node_name: &str,
+    attribute: Option<&[T]>,
+    vertex_count: usize,
+    attribute_name: &str,
+) -> Result<(), PbrtError> {
+    if let Some(attribute) = attribute {
+        if attribute.len() != vertex_count {
+            return Err(PbrtError::error(&format!(
+                "Shape node \"{}\" has {} {} values for {} vertices.",
+                node_name,
+                attribute.len(),
+                attribute_name,
+                vertex_count
+            )));
+        }
+    }
+    Ok(())
 }

--- a/src/gpu/webgpu/abi.rs
+++ b/src/gpu/webgpu/abi.rs
@@ -32,6 +32,7 @@ pub struct ViewportUniform {
 pub struct Vertex {
     pub position: [f32; 4],
     pub normal: [f32; 4],
+    pub tangent: [f32; 4],
     pub uv: [f32; 2],
     pub padding: [u32; 2],
 }
@@ -52,6 +53,7 @@ pub struct Instance {
     pub material: u32,
     pub padding: [u32; 2],
     pub world_from_object: [[f32; 4]; 4],
+    pub normal_from_object: [[f32; 4]; 4],
 }
 
 #[repr(C)]
@@ -216,6 +218,39 @@ pub fn row_major_to_columns(matrix: [f32; 16]) -> [[f32; 4]; 4] {
         [matrix[2], matrix[6], matrix[10], matrix[14]],
         [matrix[3], matrix[7], matrix[11], matrix[15]],
     ]
+}
+
+pub fn inverse_transpose_linear(
+    matrix: [f32; 16],
+    label: &str,
+) -> Result<[[f32; 4]; 4], PbrtError> {
+    validate_affine(matrix, label)?;
+    let [a, b, c, _, d, e, f, _, g, h, i, _, _, _, _, _] = matrix;
+    let determinant = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+    if !determinant.is_finite() || determinant == 0.0 {
+        return Err(PbrtError::error(&format!(
+            "{label} transform has a singular linear part."
+        )));
+    }
+    let inverse_determinant = 1.0 / determinant;
+    Ok(row_major_to_columns([
+        (e * i - f * h) * inverse_determinant,
+        (f * g - d * i) * inverse_determinant,
+        (d * h - e * g) * inverse_determinant,
+        0.0,
+        (c * h - b * i) * inverse_determinant,
+        (a * i - c * g) * inverse_determinant,
+        (b * g - a * h) * inverse_determinant,
+        0.0,
+        (b * f - c * e) * inverse_determinant,
+        (c * d - a * f) * inverse_determinant,
+        (a * e - b * d) * inverse_determinant,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]))
 }
 
 pub fn validate_affine(matrix: [f32; 16], label: &str) -> Result<(), PbrtError> {

--- a/src/gpu/webgpu/scene.rs
+++ b/src/gpu/webgpu/scene.rs
@@ -5,8 +5,8 @@ use crate::gpu::ir::flat;
 use crate::util::error::PbrtError;
 
 use super::abi::{
-    camera_uniform, row_major_to_columns, validate_affine, viewport_uniform, Geometry, Instance,
-    PointLight, Vertex, ViewportUniform,
+    camera_uniform, inverse_transpose_linear, row_major_to_columns, viewport_uniform, Geometry,
+    Instance, PointLight, Vertex, ViewportUniform,
 };
 use super::acceleration::{self, Acceleration};
 use super::material::MaterialKind;
@@ -56,12 +56,13 @@ impl Scene {
                         "Flat instance {index} references an invalid material."
                     )));
                 }
-                validate_affine(instance.transform, &format!("Flat instance {index}"))?;
+                let label = format!("Flat instance {index}");
                 Ok(Instance {
                     geometry: instance.geometry,
                     material: instance.material,
                     padding: [0; 2],
                     world_from_object: row_major_to_columns(instance.transform),
+                    normal_from_object: inverse_transpose_linear(instance.transform, &label)?,
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -206,6 +207,13 @@ fn convert_geometry(
                     "Flat vertex UV contains a non-finite value.",
                 ));
             }
+            if !vertex.normal.iter().all(|value| value.is_finite())
+                || !vertex.tangent.iter().all(|value| value.is_finite())
+            {
+                return Err(PbrtError::error(
+                    "Flat vertex normal or tangent contains a non-finite value.",
+                ));
+            }
             Ok(Vertex {
                 position: [
                     vertex.position[0],
@@ -214,6 +222,7 @@ fn convert_geometry(
                     1.0,
                 ],
                 normal: [vertex.normal[0], vertex.normal[1], vertex.normal[2], 0.0],
+                tangent: [vertex.tangent[0], vertex.tangent[1], vertex.tangent[2], 0.0],
                 uv: vertex.uv,
                 padding: [0; 2],
             })

--- a/src/gpu/webgpu/shaders/common.wgsl
+++ b/src/gpu/webgpu/shaders/common.wgsl
@@ -26,6 +26,7 @@ struct ViewportUniform {
 struct Vertex {
     position: vec4<f32>,
     normal: vec4<f32>,
+    tangent: vec4<f32>,
     uv: vec2<f32>,
     _padding: vec2<u32>,
 };
@@ -42,6 +43,7 @@ struct Instance {
     material: u32,
     _padding: vec2<u32>,
     world_from_object: mat4x4<f32>,
+    normal_from_object: mat4x4<f32>,
 };
 
 struct RayWorkItem {

--- a/src/gpu/webgpu/shaders/shade_surface.wgsl
+++ b/src/gpu/webgpu/shaders/shade_surface.wgsl
@@ -31,7 +31,7 @@ fn shade_surface(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let object_normal = vertices[i0].normal.xyz * b0
         + vertices[i1].normal.xyz * b1
         + vertices[i2].normal.xyz * b2;
-    let transformed_normal = (instance.world_from_object * vec4<f32>(object_normal, 0.0)).xyz;
+    let transformed_normal = (instance.normal_from_object * vec4<f32>(object_normal, 0.0)).xyz;
     var normal = geometric_normal;
     if (dot(object_normal, object_normal) > 0.0) {
         normal = normalize(transformed_normal);

--- a/tests/gpu_flat_ir.rs
+++ b/tests/gpu_flat_ir.rs
@@ -2,9 +2,9 @@ use std::sync::{Arc, RwLock};
 
 use pbrt_r4::gpu::ir::flat::flatten_node;
 use pbrt_r4::gpu::ir::node::{
-    Camera, CameraComponent, Component, Film, FilmComponent, Instance as NodeInstance,
-    InstanceComponent, Integrator as NodeIntegrator, IntegratorComponent, Light as NodeLight,
-    LightComponent, Material, MaterialComponent, Node, Output, OutputComponent,
+    complete_triangle_attributes, Camera, CameraComponent, Component, Film, FilmComponent,
+    Instance as NodeInstance, InstanceComponent, Integrator as NodeIntegrator, IntegratorComponent,
+    Light as NodeLight, LightComponent, Material, MaterialComponent, Node, Output, OutputComponent,
     Sampler as NodeSampler, SamplerComponent, Shape, ShapeComponent, Transform, TriangleMeshShape,
 };
 use pbrt_r4::gpu::ir::node::{Vec2f, Vec3f};
@@ -301,4 +301,58 @@ fn flatten_node_ignores_explicit_diffuse_reflectance_for_now() {
     let scene = flatten_node(Arc::new(RwLock::new(root)))
         .expect("reflectance is currently ignored by the GPU material representation");
     assert_eq!(scene.materials[0].kind, "diffuse");
+}
+
+#[test]
+fn flatten_node_completes_missing_mesh_attributes() {
+    let shape = triangle_node("triangle", "diffuse", [0.0, 0.0, 0.0]);
+    {
+        let mut node = shape.write().unwrap();
+        let Component::Shape(shape) = &mut node.components[0] else {
+            panic!("expected shape component");
+        };
+        let Shape::TriangleMesh(mesh) = &mut shape.shape else {
+            panic!("expected triangle mesh");
+        };
+        mesh.normals = None;
+        mesh.tangents = None;
+        mesh.uvs = None;
+    }
+    let mut root = Node::new("root");
+    add_camera_and_film(&mut root, Default::default());
+    root.add_child(shape);
+
+    let scene = flatten_node(Arc::new(RwLock::new(root))).unwrap();
+    assert_eq!(scene.vertices.len(), 3);
+    assert_eq!(scene.vertices[0].normal, [0.0, 0.0, 1.0]);
+    assert_eq!(scene.vertices[0].uv, [0.0, 0.0]);
+    assert_eq!(scene.vertices[1].uv, [1.0, 0.0]);
+    assert_eq!(scene.vertices[2].uv, [0.0, 1.0]);
+    assert!(scene.vertices.iter().all(|vertex| {
+        vertex.tangent.iter().all(|value| value.is_finite()) && vertex.tangent[0].abs() > 0.9
+    }));
+}
+
+#[test]
+fn missing_normals_expand_shared_vertices_per_triangle() {
+    let mesh = TriangleMeshShape {
+        positions: vec![
+            Vec3f([0.0, 0.0, 0.0]),
+            Vec3f([1.0, 0.0, 0.0]),
+            Vec3f([1.0, 1.0, 0.0]),
+            Vec3f([0.0, 1.0, 1.0]),
+        ],
+        indices: vec![0, 1, 2, 0, 2, 3],
+        normals: None,
+        tangents: None,
+        uvs: None,
+    };
+
+    let completed = complete_triangle_attributes(mesh, "shared").unwrap();
+    assert_eq!(completed.positions.len(), 6);
+    assert_eq!(completed.indices, vec![0, 1, 2, 3, 4, 5]);
+    assert_ne!(
+        completed.normals.as_ref().unwrap()[0],
+        completed.normals.as_ref().unwrap()[3]
+    );
 }

--- a/tests/gpu_node_components.rs
+++ b/tests/gpu_node_components.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::sync::RwLock;
 
+use pbrt_r4::gpu::ir::node::triangle_mesh_from_params;
 use pbrt_r4::gpu::ir::node::{
     node_ref_to_json, tessellate_shapes, Camera, CameraComponent, Component, Material,
     MaterialComponent, Node, Shape, ShapeComponent, SphereShape,
@@ -230,6 +231,19 @@ end_header
             })
     });
     assert_eq!(shape_node, Some((3, 3, true, true)));
+}
+
+#[test]
+fn malformed_mesh_attribute_is_rejected_in_node_ir() {
+    let mut params = pbrt_r4::paramdict::ParameterDictionary::default();
+    params.add_point("P", &[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+    params.add_int("indices", 0);
+    params.add_int("indices", 1);
+    params.add_int("indices", 2);
+    params.add_point("N", &[0.0, 0.0, 1.0]);
+
+    let error = triangle_mesh_from_params("trianglemesh", &params).unwrap_err();
+    assert!(error.to_string().contains("attribute \"N\""));
 }
 
 #[test]

--- a/tests/gpu_webgpu_abi.rs
+++ b/tests/gpu_webgpu_abi.rs
@@ -1,6 +1,6 @@
 use pbrt_r4::gpu::webgpu::abi::{
-    row_major_to_columns, CameraUniform, Geometry, Instance, Material, PointLight, RayWorkItem,
-    SurfaceWorkItem, Vertex, ViewportUniform,
+    inverse_transpose_linear, row_major_to_columns, CameraUniform, Geometry, Instance, Material,
+    PointLight, RayWorkItem, SurfaceWorkItem, Vertex, ViewportUniform,
 };
 
 #[test]
@@ -18,11 +18,26 @@ fn webgpu_matrices_are_uploaded_as_column_major() {
 fn webgpu_storage_struct_sizes_match_shader_layout() {
     assert_eq!(std::mem::size_of::<CameraUniform>(), 128);
     assert_eq!(std::mem::size_of::<ViewportUniform>(), 32);
-    assert_eq!(std::mem::size_of::<Vertex>(), 48);
+    assert_eq!(std::mem::size_of::<Vertex>(), 64);
     assert_eq!(std::mem::size_of::<Geometry>(), 16);
-    assert_eq!(std::mem::size_of::<Instance>(), 80);
+    assert_eq!(std::mem::size_of::<Instance>(), 144);
     assert_eq!(std::mem::size_of::<Material>(), 16);
     assert_eq!(std::mem::size_of::<RayWorkItem>(), 64);
     assert_eq!(std::mem::size_of::<SurfaceWorkItem>(), 128);
     assert_eq!(std::mem::size_of::<PointLight>(), 32);
+}
+
+#[test]
+fn webgpu_normal_matrix_is_inverse_transpose_of_linear_transform() {
+    let normal = inverse_transpose_linear(
+        [
+            2.0, 0.0, 0.0, 0.0, 0.0, 4.0, 0.0, 0.0, 0.0, 0.0, 8.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        ],
+        "test",
+    )
+    .unwrap();
+    assert_eq!(normal[0][0], 0.5);
+    assert_eq!(normal[1][1], 0.25);
+    assert_eq!(normal[2][2], 0.125);
+    assert_eq!(normal[3], [0.0, 0.0, 0.0, 1.0]);
 }


### PR DESCRIPTION
## Summary
- complete missing mesh normals, tangents, and UVs before Flat IR lowering
- preserve flat shading by expanding shared vertices when normals are absent
- add inverse-transpose normal matrices and tangent data to the WebGPU ABI
- reject malformed and non-finite mesh attributes

## Validation
- `cargo fmt --all`
- `cargo test --test gpu_flat_ir --test gpu_node_components --test gpu_webgpu_abi`
