### PR TITLE
Skip invalid triangles in GPU meshes

### DIFF
--- a/src/gpu/ir/flat/flatten.rs
+++ b/src/gpu/ir/flat/flatten.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::film::PixelSensor;
 use crate::gpu::ir::node::{
-    complete_triangle_attributes, AreaLight as NodeAreaLight, Component,
+    complete_triangle_attributes, remove_invalid_triangles, AreaLight as NodeAreaLight, Component,
     Integrator as NodeIntegrator, Light as NodeLight, Material as NodeMaterial, NodeRef,
     Sampler as NodeSampler, Shape, TriangleMeshShape,
 };
@@ -463,6 +463,10 @@ fn flatten_node_ref(
                             )));
                         }
                     };
+                    let shape = remove_invalid_triangles(shape)?;
+                    if shape.indices.is_empty() {
+                        continue;
+                    }
                     let input_normals = shape.normals.clone();
                     let shape = complete_triangle_attributes(shape, &node.name)?;
                     let material = material.clone().ok_or_else(|| {

--- a/src/gpu/ir/node/shape.rs
+++ b/src/gpu/ir/node/shape.rs
@@ -248,6 +248,52 @@ pub fn complete_triangle_attributes(
     })
 }
 
+/// Removes triangles whose geometric normal is zero or non-finite.
+pub fn remove_invalid_triangles(
+    mut shape: TriangleMeshShape,
+) -> Result<TriangleMeshShape, PbrtError> {
+    if shape.indices.len() % 3 != 0 {
+        return Err(PbrtError::error(
+            "Triangle mesh index count must be divisible by three.",
+        ));
+    }
+    if shape
+        .indices
+        .iter()
+        .any(|&index| index as usize >= shape.positions.len())
+    {
+        return Err(PbrtError::error(
+            "Triangle mesh contains an out-of-range vertex index.",
+        ));
+    }
+    if shape
+        .positions
+        .iter()
+        .any(|position| !position.0.iter().all(|value| value.is_finite()))
+    {
+        return Err(PbrtError::error(
+            "Triangle mesh contains a non-finite position.",
+        ));
+    }
+
+    shape.indices = shape
+        .indices
+        .chunks_exact(3)
+        .filter(|triangle| {
+            let p = [
+                shape.positions[triangle[0] as usize].0,
+                shape.positions[triangle[1] as usize].0,
+                shape.positions[triangle[2] as usize].0,
+            ];
+            let normal = cross(sub(p[1], p[0]), sub(p[2], p[0]));
+            normal.iter().all(|value| value.is_finite()) && length_squared(normal) > 0.0
+        })
+        .flatten()
+        .copied()
+        .collect();
+    Ok(shape)
+}
+
 /// Flips per-vertex shading normals that disagree with the mesh winding.
 ///
 /// Subdivision limit normals (e.g. loopsubdiv's `Cross(S, T)` tangents) can

--- a/tests/gpu_node_components.rs
+++ b/tests/gpu_node_components.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 use std::sync::RwLock;
 
-use pbrt_r4::gpu::ir::node::triangle_mesh_from_params;
 use pbrt_r4::gpu::ir::node::{
-    node_ref_to_json, tessellate_shapes, Camera, CameraComponent, Component, DiskShape, Material,
-    MaterialComponent, Node, Shape, ShapeComponent, SphereShape,
+    node_ref_to_json, remove_invalid_triangles, tessellate_shapes, triangle_mesh_from_params,
+    Camera, CameraComponent, Component, DiskShape, Material, MaterialComponent, Node, Shape,
+    ShapeComponent, SphereShape, TriangleMeshShape, Vec3f,
 };
 use pbrt_r4::parser::scene_builder::{
     FileLoc, RenderFromObject, SceneBuilder, SceneEntity, ShapeSceneEntity,
@@ -252,6 +252,37 @@ fn sphere_tessellation_does_not_emit_degenerate_triangles() {
         ];
         cross.iter().map(|value| value * value).sum::<f32>() > 0.0
     }));
+}
+
+#[test]
+fn invalid_triangles_are_removed_before_attribute_completion() {
+    let shape = TriangleMeshShape {
+        positions: vec![
+            Vec3f([0.0, 0.0, 0.0]),
+            Vec3f([1.0, 0.0, 0.0]),
+            Vec3f([0.0, 1.0, 0.0]),
+        ],
+        indices: vec![0, 1, 2, 0, 1, 1],
+        normals: None,
+        tangents: None,
+        uvs: None,
+    };
+
+    let filtered = remove_invalid_triangles(shape).unwrap();
+    assert_eq!(filtered.indices, vec![0, 1, 2]);
+}
+
+#[test]
+fn an_entirely_invalid_triangle_mesh_is_removed() {
+    let shape = TriangleMeshShape {
+        positions: vec![Vec3f([0.0, 0.0, 0.0]), Vec3f([1.0, 0.0, 0.0])],
+        indices: vec![0, 1, 1],
+        normals: None,
+        tangents: None,
+        uvs: None,
+    };
+
+    assert!(remove_invalid_triangles(shape).unwrap().indices.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `remove_invalid_triangles()` before GPU triangle attribute completion.
- Remove triangles whose geometric normals are zero or non-finite.
- Report malformed index buffers, out-of-range indices, and non-finite positions as errors.
- Skip shapes when no valid triangles remain.

This keeps `complete_triangle_attributes()` focused on generating the attributes required by the Flat IR contract. It also allows the villa scene to pass `mesh_00073.ply`, which contains eight zero-area triangles. The scene now proceeds to the next unsupported feature, its infinite light.

## Verification

- `cargo fmt --all`
- `cargo check -q`
- `cargo test -q --test gpu_node_components --test gpu_flat_ir`
- Built `pbrt-r4` and verified that `villa-daylight.pbrt` passes the previous zero-area triangle failure

All 34 focused tests pass.
